### PR TITLE
Update to reflect CodePoint/CodeUnit split

### DIFF
--- a/text/chapter6.md
+++ b/text/chapter6.md
@@ -442,7 +442,7 @@ module Stream where
 
 import Data.Array as Array
 import Data.Maybe (Maybe)
-import Data.String as String
+import Data.String.CodeUnits as String
 
 class Stream stream element where
   uncons :: stream -> Maybe { head :: element, tail :: stream }


### PR DESCRIPTION
`Data.String` now exports `uncons :: String -> Maybe { head :: CodePoint, tail :: String }` instead of `uncons :: String -> Maybe { head :: Char, tail :: String }`