### PR TITLE
Replace unsafePartial with fromMaybe when adequate

### DIFF
--- a/text/chapter5.md
+++ b/text/chapter5.md
@@ -250,15 +250,15 @@ Patterns do not only appear in top-level function declarations. It is possible t
 Here is an example. This function computes "longest zero suffix" of an array (the longest suffix which sums to zero):
 
 ```haskell
+import Data.Array (tail)
 import Data.Foldable (sum)
-import Data.Array.Partial (tail)
-import Partial.Unsafe (unsafePartial)
+import Data.Maybe (fromMaybe)
 
 lzs :: Array Int -> Array Int
 lzs [] = []
 lzs xs = case sum xs of
            0 -> xs
-           _ -> lzs (unsafePartial tail xs)
+           _ -> lzs (fromMaybe [] $ tail xs)
 ```
 
 For example:


### PR DESCRIPTION
As discussed in #14 this PR replaces `unsafePartial` with `fromMaybe`.

Since pattern matching is introduced later, the exercises and examples that would require the use of it, along with `fromMaybe`, have been replaced with simpler ones.