### PR TITLE
Remove `>X` from all exercise blocks

### DIFF
--- a/text/chapter10.md
+++ b/text/chapter10.md
@@ -251,18 +251,18 @@ We can call this function from JavaScript by passing an explicit type class dict
 shout(require('Prelude').showNumber)(42);
 ```
 
-X> ## Exercises
-X>
-X> 1. (Easy) What are the runtime representations of these types?
-X>
-X>     ```haskell
-X>     forall a. a
-X>     forall a. a -> a -> a
-X>     forall a. Ord a => Array a -> Boolean
-X>     ```
-X>
-X>     What can you say about the expressions which have these types?
-X> 1. (Medium) Try using the functions defined in the `purescript-arrays` package, calling them from JavaScript, by compiling the library using `pulp build` and importing modules using the `require` function in NodeJS. _Hint_: you may need to configure the output path so that the generated CommonJS modules are available on the NodeJS module path.
+ ## Exercises
+
+ 1. (Easy) What are the runtime representations of these types?
+
+     ```haskell
+     forall a. a
+     forall a. a -> a -> a
+     forall a. Ord a => Array a -> Boolean
+     ```
+
+     What can you say about the expressions which have these types?
+ 1. (Medium) Try using the functions defined in the `purescript-arrays` package, calling them from JavaScript, by compiling the library using `pulp build` and importing modules using the `require` function in NodeJS. _Hint_: you may need to configure the output path so that the generated CommonJS modules are available on the NodeJS module path.
 
 ## Using JavaScript Code From PureScript
 
@@ -545,10 +545,10 @@ The type of `getItem` is more interesting. It takes a key, and attempts to retri
 
 `Foreign` provides a way to work with _untyped data_, or more generally, data whose runtime representation is uncertain.
 
-X> ## Exercises
-X>
-X> 1. (Medium) Write a wrapper for the `confirm` method on the JavaScript `Window` object, and add your foreign function to the `Effect.Alert` module.
-X> 1. (Medium) Write a wrapper for the `removeItem` method on the `localStorage` object, and add your foreign function to the `Effect.Storage` module.
+ ## Exercises
+
+ 1. (Medium) Write a wrapper for the `confirm` method on the JavaScript `Window` object, and add your foreign function to the `Effect.Alert` module.
+ 1. (Medium) Write a wrapper for the `removeItem` method on the `localStorage` object, and add your foreign function to the `Effect.Storage` module.
 
 ## Working With Untyped Data
 
@@ -709,26 +709,26 @@ Try out the code, by running `pulp build -O --to dist/Main.js`, and then opening
 
 _Note_: You may need to serve the HTML and Javascript files from a HTTP server locally in order to avoid certain browser-specific issues.
 
-X> ## Exercises
-X>
-X> 1. (Easy) Use `decodeJSON` to parse a JSON document representing a two-dimensional JavaScript array of integers, such as `[[1, 2, 3], [4, 5], [6]]`. What if the elements are allowed to be null? What if the arrays themselves are allowed to be null?
-X> 1. (Medium) Convince yourself that the implementation of `savedData` should type-check, and write down the inferred types of each subexpression in the computation.
-X> 1. (Medium) The following data type represents a binary tree with values at the leaves:
-X>
-X>     ```haskell
-X>     data Tree a = Leaf a | Branch (Tree a) (Tree a)
-X>     ```
-X>
-X>     Derive `Encode` and `Decode` instances for this type using `purescript-foreign-generic`, and verify that encoded values can correctly be decoded in PSCi.
-X> 1. (Difficult) The following `data` type should be represented directly in JSON as either an integer or a string:
-X>
-X>     ```haskell
-X>     data IntOrString
-X>       = IntOrString_Int Int
-X>       | IntOrString_String String
-X>     ```
-X>
-X>     Write instances for `Encode` and `Decode` for the `IntOrString` data type which implement this behavior, and verify that encoded values can correctly be decoded in PSCi.
+ ## Exercises
+
+ 1. (Easy) Use `decodeJSON` to parse a JSON document representing a two-dimensional JavaScript array of integers, such as `[[1, 2, 3], [4, 5], [6]]`. What if the elements are allowed to be null? What if the arrays themselves are allowed to be null?
+ 1. (Medium) Convince yourself that the implementation of `savedData` should type-check, and write down the inferred types of each subexpression in the computation.
+ 1. (Medium) The following data type represents a binary tree with values at the leaves:
+
+     ```haskell
+     data Tree a = Leaf a | Branch (Tree a) (Tree a)
+     ```
+
+     Derive `Encode` and `Decode` instances for this type using `purescript-foreign-generic`, and verify that encoded values can correctly be decoded in PSCi.
+ 1. (Difficult) The following `data` type should be represented directly in JSON as either an integer or a string:
+
+     ```haskell
+     data IntOrString
+       = IntOrString_Int Int
+       | IntOrString_String String
+     ```
+
+     Write instances for `Encode` and `Decode` for the `IntOrString` data type which implement this behavior, and verify that encoded values can correctly be decoded in PSCi.
 
 ## Conclusion
 

--- a/text/chapter11.md
+++ b/text/chapter11.md
@@ -133,36 +133,36 @@ Given the `sumArray` function above, we could use `execState` in PSCi to sum the
 21
 ```
 
-X> ## Exercises
-X>
-X> 1. (Easy) What is the result of replacing `execState` with `runState` or `evalState` in our example above?
-X> 1. (Medium) A string of parentheses is _balanced_ if it is obtained by either concatenating zero-or-more shorter balanced
-X>     strings, or by wrapping a shorter balanced string in a pair of parentheses.
-X>     
-X>     Use the `State` monad and the `traverse_` function to write a function
-X>
-X>     ```haskell
-X>     testParens :: String -> Boolean
-X>     ```
-X>
-X>     which tests whether or not a `String` of parentheses is balanced, by keeping track of the number of opening parentheses
-X>     which have not been closed. Your function should work as follows:
-X>
-X>     ```text
-X>     > testParens ""
-X>     true
-X>     
-X>     > testParens "(()(())())"
-X>     true
-X>     
-X>     > testParens ")"
-X>     false
-X>     
-X>     > testParens "(()()"
-X>     false
-X>     ```
-X>
-X>     _Hint_: you may like to use the `toCharArray` function from the `Data.String` module to turn the input string into an array of characters.
+ ## Exercises
+
+ 1. (Easy) What is the result of replacing `execState` with `runState` or `evalState` in our example above?
+ 1. (Medium) A string of parentheses is _balanced_ if it is obtained by either concatenating zero-or-more shorter balanced
+     strings, or by wrapping a shorter balanced string in a pair of parentheses.
+     
+     Use the `State` monad and the `traverse_` function to write a function
+
+     ```haskell
+     testParens :: String -> Boolean
+     ```
+
+     which tests whether or not a `String` of parentheses is balanced, by keeping track of the number of opening parentheses
+     which have not been closed. Your function should work as follows:
+
+     ```text
+     > testParens ""
+     true
+     
+     > testParens "(()(())())"
+     true
+     
+     > testParens ")"
+     false
+     
+     > testParens "(()()"
+     false
+     ```
+
+     _Hint_: you may like to use the `toCharArray` function from the `Data.String` module to turn the input string into an array of characters.
 
 ## The Reader Monad
 
@@ -217,57 +217,57 @@ To run a computation in the `Reader` monad, the `runReader` function can be used
 runReader :: forall r a. Reader r a -> r -> a
 ```
 
-X> ## Exercises
-X>
-X> In these exercises, we will use the `Reader` monad to build a small library for rendering documents with indentation. The "global configuration" will be a number indicating the current indentation level:
-X>
-X>    ```haskell
-X>    type Level = Int
-X>    
-X>    type Doc = Reader Level String
-X>    ```
-X>
-X> 1. (Easy) Write a function `line` which renders a function at the current indentation level. Your function should have the following type:
-X>
-X>     ```haskell
-X>     line :: String -> Doc
-X>     ```
-X>
-X>     _Hint_: use the `ask` function to read the current indentation level.
-X> 1. (Easy) Use the `local` function to write a function
-X>
-X>     ```haskell
-X>     indent :: Doc -> Doc
-X>     ```
-X>
-X>     which increases the indentation level for a block of code.
-X> 1. (Medium) Use the `sequence` function defined in `Data.Traversable` to write a function
-X>
-X>     ```haskell
-X>     cat :: Array Doc -> Doc
-X>     ```
-X>
-X>     which concatenates a collection of documents, separating them with new lines.
-X> 1. (Medium) Use the `runReader` function to write a function
-X>
-X>     ```haskell
-X>     render :: Doc -> String
-X>     ```
-X>
-X>     which renders a document as a String.
-X>
-X> You should now be able to use your library to write simple documents, as follows:
-X>
-X> ```haskell
-X> render $ cat
-X>   [ line "Here is some indented text:"
-X>   , indent $ cat
-X>       [ line "I am indented"
-X>       , line "So am I"
-X>       , indent $ line "I am even more indented"
-X>       ]
-X>   ]
-X> ```
+ ## Exercises
+
+ In these exercises, we will use the `Reader` monad to build a small library for rendering documents with indentation. The "global configuration" will be a number indicating the current indentation level:
+
+    ```haskell
+    type Level = Int
+    
+    type Doc = Reader Level String
+    ```
+
+ 1. (Easy) Write a function `line` which renders a function at the current indentation level. Your function should have the following type:
+
+     ```haskell
+     line :: String -> Doc
+     ```
+
+     _Hint_: use the `ask` function to read the current indentation level.
+ 1. (Easy) Use the `local` function to write a function
+
+     ```haskell
+     indent :: Doc -> Doc
+     ```
+
+     which increases the indentation level for a block of code.
+ 1. (Medium) Use the `sequence` function defined in `Data.Traversable` to write a function
+
+     ```haskell
+     cat :: Array Doc -> Doc
+     ```
+
+     which concatenates a collection of documents, separating them with new lines.
+ 1. (Medium) Use the `runReader` function to write a function
+
+     ```haskell
+     render :: Doc -> String
+     ```
+
+     which renders a document as a String.
+
+ You should now be able to use your library to write simple documents, as follows:
+
+ ```haskell
+ render $ cat
+   [ line "Here is some indented text:"
+   , indent $ cat
+       [ line "I am indented"
+       , line "So am I"
+       , indent $ line "I am even more indented"
+       ]
+   ]
+ ```
 
 ## The Writer Monad
 
@@ -336,20 +336,20 @@ We can test our modified function in PSCi:
 Tuple 3 ["gcdLog 21 15","gcdLog 6 15","gcdLog 6 9","gcdLog 6 3","gcdLog 3 3"]
 ```
 
-X> ## Exercises
-X>
-X> 1. (Medium) Rewrite the `sumArray` function above using the `Writer` monad and the `Additive Int` monoid from the `purescript-monoid` package.
-X> 1. (Medium) The _Collatz_ function is defined on natural numbers `n` as `n / 2` when `n` is even, and `3 * n + 1` when `n` is odd. For example, the iterated Collatz sequence starting at `10` is as follows:
-X>
-X>     ```text
-X>     10, 5, 16, 8, 4, 2, 1, ...
-X>     ```
-X>
-X>     It is conjectured that the iterated Collatz sequence always reaches `1` after some finite number of applications of the Collatz function.
-X>
-X>     Write a function which uses recursion to calculate how many iterations of the Collatz function are required before the sequence reaches `1`.
-X>
-X>     Modify your function to use the `Writer` monad to log each application of the Collatz function.
+ ## Exercises
+
+ 1. (Medium) Rewrite the `sumArray` function above using the `Writer` monad and the `Additive Int` monoid from the `purescript-monoid` package.
+ 1. (Medium) The _Collatz_ function is defined on natural numbers `n` as `n / 2` when `n` is even, and `3 * n + 1` when `n` is odd. For example, the iterated Collatz sequence starting at `10` is as follows:
+
+     ```text
+     10, 5, 16, 8, 4, 2, 1, ...
+     ```
+
+     It is conjectured that the iterated Collatz sequence always reaches `1` after some finite number of applications of the Collatz function.
+
+     Write a function which uses recursion to calculate how many iterations of the Collatz function are required before the sequence reaches `1`.
+
+     Modify your function to use the `Writer` monad to log each application of the Collatz function.
 
 ## Monad Transformers
 
@@ -545,28 +545,28 @@ One problem with this code is that we have to use the `lift` function multiple t
 
 Fortunately, as we will see, we can use the automatic code generation provided by type class inference to do most of this "heavy lifting" for us.
 
-X> ## Exercises
-X>
-X> 1. (Easy) Use the `ExceptT` monad transformer over the `Identity` functor to write a function `safeDivide` which divides two numbers, throwing an error if the denominator is zero.
-X> 1. (Medium) Write a parser
-X>
-X>     ```haskell
-X>     string :: String -> Parser String
-X>     ```
-X>
-X>     which matches a string as a prefix of the current state, or fails with an error message.
-X>
-X>     Your parser should work as follows:
-X>
-X>     ```text
-X>     > runParser (string "abc") "abcdef"
-X>     (Right (Tuple (Tuple "abc" "def") ["The state is abcdef"]))
-X>     ```
-X>
-X>     _Hint_: you can use the implementation of `split` as a starting point. You might find the `stripPrefix` function useful.
-X> 1. (Difficult) Use the `ReaderT` and `WriterT` monad transformers to reimplement the document printing library which we wrote earlier using the `Reader` monad.
-X>
-X>     Instead of using `line` to emit strings and `cat` to concatenate strings, use the `Array String` monoid with the `WriterT` monad transformer, and `tell` to append a line to the result.
+ ## Exercises
+
+ 1. (Easy) Use the `ExceptT` monad transformer over the `Identity` functor to write a function `safeDivide` which divides two numbers, throwing an error if the denominator is zero.
+ 1. (Medium) Write a parser
+
+     ```haskell
+     string :: String -> Parser String
+     ```
+
+     which matches a string as a prefix of the current state, or fails with an error message.
+
+     Your parser should work as follows:
+
+     ```text
+     > runParser (string "abc") "abcdef"
+     (Right (Tuple (Tuple "abc" "def") ["The state is abcdef"]))
+     ```
+
+     _Hint_: you can use the implementation of `split` as a starting point. You might find the `stripPrefix` function useful.
+ 1. (Difficult) Use the `ReaderT` and `WriterT` monad transformers to reimplement the document printing library which we wrote earlier using the `Reader` monad.
+
+     Instead of using `line` to emit strings and `cat` to concatenate strings, use the `Array String` monoid with the `WriterT` monad transformer, and `tell` to append a line to the result.
 
 ## Type Classes to the Rescue!
 
@@ -731,18 +731,18 @@ We can even use `many` to fully split a string into its lower and upper case com
 
 Again, this illustrates the power of reusability that monad transformers bring - we were able to write a backtracking parser in a declarative style with only a few lines of code, by reusing standard abstractions!
 
-X> ## Exercises
-X>
-X> 1. (Easy) Remove the calls to the `lift` function from your implementation of the `string` parser. Verify that the new implementation type checks, and convince yourself that it should.
-X> 1. (Medium) Use your `string` parser with the `many` combinator to write a parser which recognizes strings consisting of several copies of the string `"a"` followed by several copies of the string `"b"`.
-X> 1. (Medium) Use the `<|>` operator to write a parser which recognizes strings of the letters `a` or `b` in any order.
-X> 1. (Difficult) The `Parser` monad might also be defined as follows:
-X>
-X>     ```haskell
-X>     type Parser = ExceptT Errors (StateT String (WriterT Log Identity))
-X>     ```
-X>
-X>     What effect does this change have on our parsing functions?
+ ## Exercises
+
+ 1. (Easy) Remove the calls to the `lift` function from your implementation of the `string` parser. Verify that the new implementation type checks, and convince yourself that it should.
+ 1. (Medium) Use your `string` parser with the `many` combinator to write a parser which recognizes strings consisting of several copies of the string `"a"` followed by several copies of the string `"b"`.
+ 1. (Medium) Use the `<|>` operator to write a parser which recognizes strings of the letters `a` or `b` in any order.
+ 1. (Difficult) The `Parser` monad might also be defined as follows:
+
+     ```haskell
+     type Parser = ExceptT Errors (StateT String (WriterT Log Identity))
+     ```
+
+     What effect does this change have on our parsing functions?
 
 ## The RWS Monad
 
@@ -978,12 +978,12 @@ The `runGame` function finally attaches the initial line handler to the console 
   prompt interface
 ```
 
-X> ## Exercises
-X>
-X> 1. (Medium) Implement a new command `cheat`, which moves all game items from the game grid into the user's inventory.
-X> 1. (Difficult) The `Writer` component of the `RWS` monad is currently used for two types of messages: error messages and informational messages. Because of this, several parts of the code use case statements to handle error cases.
-X>
-X>     Refactor the code to use the `ExceptT` monad transformer to handle the error messages, and `RWS` to handle informational messages.
+ ## Exercises
+
+ 1. (Medium) Implement a new command `cheat`, which moves all game items from the game grid into the user's inventory.
+ 1. (Difficult) The `Writer` component of the `RWS` monad is currently used for two types of messages: error messages and informational messages. Because of this, several parts of the code use case statements to handle error cases.
+
+     Refactor the code to use the `ExceptT` monad transformer to handle the error messages, and `RWS` to handle informational messages.
 
 ## Handling Command Line Options
 
@@ -1026,9 +1026,9 @@ This demonstrates two basic functions defined in the `Node.Yargs.Applicative` mo
 
 Notice how we were able to use the notation afforded by the applicative operators to give a compact, declarative specification of our command line interface. In addition, it is simple to add new command line arguments, simply by adding a new function argument to `runGame`, and then using `<*>` to lift `runGame` over an additional argument in the definition of `env`.
 
-X> ## Exercises
-X>
-X> 1. (Medium) Add a new Boolean-valued property `cheatMode` to the `GameEnvironment` record. Add a new command line flag `-c` to the `yargs` configuration which enables cheat mode. The `cheat` command from the previous exercise should be disallowed if cheat mode is not enabled.
+ ## Exercises
+
+ 1. (Medium) Add a new Boolean-valued property `cheatMode` to the `GameEnvironment` record. Add a new command line flag `-c` to the `yargs` configuration which enables cheat mode. The `cheat` command from the previous exercise should be disallowed if cheat mode is not enabled.
 
 ## Conclusion
 

--- a/text/chapter12.md
+++ b/text/chapter12.md
@@ -261,21 +261,21 @@ main =
     logShow
 ```
 
-X> ## Exercises
-X>
-X> 1. (Easy) Use `readFileCont` and `writeFileCont` to write a function which concatenates two text files.
-X> 1. (Medium) Use the FFI to give an appropriate type to the `setTimeout` function. Write a wrapper function which uses the `Async` monad:
-X>
-X>     ```haskell
-X>     type Milliseconds = Int
-X>
-X>     foreign import data TIMEOUT :: Effect
-X>
-X>     setTimeoutCont
-X>       :: forall eff
-X>        . Milliseconds
-X>       -> Async (timeout :: TIMEOUT | eff) Unit
-X>     ```
+ ## Exercises
+
+ 1. (Easy) Use `readFileCont` and `writeFileCont` to write a function which concatenates two text files.
+ 1. (Medium) Use the FFI to give an appropriate type to the `setTimeout` function. Write a wrapper function which uses the `Async` monad:
+
+     ```haskell
+     type Milliseconds = Int
+
+     foreign import data TIMEOUT :: Effect
+
+     setTimeoutCont
+       :: forall eff
+        . Milliseconds
+       -> Async (timeout :: TIMEOUT | eff) Unit
+     ```
 
 ## Putting ExceptT To Work
 
@@ -319,10 +319,10 @@ copyFileContEx src dest = do
   writeFileContEx dest content
 ```
 
-X> ## Exercises
-X>
-X> 1. (Medium) Modify your solution which concatenated two files, using `ExceptT` to handle any errors.
-X> 1. (Medium) Write a function `concatenateMany` to concatenate multiple text files, given an array of input file names. _Hint_: use `traverse`.
+ ## Exercises
+
+ 1. (Medium) Modify your solution which concatenated two files, using `ExceptT` to handle any errors.
+ 1. (Medium) Write a function `concatenateMany` to concatenate multiple text files, given an array of input file names. _Hint_: use `traverse`.
 
 ## A HTTP Client
 
@@ -381,11 +381,11 @@ get req = ContT \k ->
   runFn3 getImpl req (k <<< Right) (k <<< Left)
 ```
 
-X> ## Exercises
-X>
-X> 1. (Easy) Use `runContT` to test `get` in PSCi, printing the result to the console.
-X> 1. (Medium) Use `ExceptT` to write a function `getEx` which wraps `get`, as we did previously for `readFileCont` and `writeFileCont`.
-X> 1. (Difficult) Write a function which saves the response body of a request to a file on disk using `getEx` and `writeFileContEx`.
+ ## Exercises
+
+ 1. (Easy) Use `runContT` to test `get` in PSCi, printing the result to the console.
+ 1. (Medium) Use `ExceptT` to write a function `getEx` which wraps `get`, as we did previously for `readFileCont` and `writeFileCont`.
+ 1. (Difficult) Write a function which saves the response body of a request to a file on disk using `getEx` and `writeFileContEx`.
 
 ## Parallel Computations
 
@@ -430,35 +430,35 @@ Because applicative functors support lifting of functions of arbitrary arity, we
 
 We can also combine parallel computations with sequential portions of code, by using applicative combinators in a do notation block, or vice versa, using `parallel` and `sequential` to change type constructors where appropriate.
 
-X> ## Exercises
-X>
-X> 1. (Easy) Use `parallel` and `sequential` to make two HTTP requests and collect their response bodies in parallel. Your combining function should concatenate the two response bodies, and your continuation should use `print` to print the result to the console.
-X> 1. (Medium) The applicative functor which corresponds to `Async` is also an instance of `Alternative`. The `<|>` operator defined by this instance runs two computations in parallel, and returns the result from the computation which completes first.
-X>
-X>     Use this `Alternative` instance in conjunction with your `setTimeoutCont` function to define a function
-X>
-X>     ```haskell
-X>     timeout :: forall a eff
-X>              . Milliseconds
-X>             -> Async (timeout :: TIMEOUT | eff) a
-X>             -> Async (timeout :: TIMEOUT | eff) (Maybe a)
-X>     ```
-X>
-X>     which returns `Nothing` if the specified computation does not provide a result within the given number of milliseconds.
-X> 1. (Medium) `purescript-parallel` also provides instances of the `Parallel` class for several monad transformers, including `ExceptT`.
-X>
-X>     Rewrite the parallel file IO example to use `ExceptT` for error handling, instead of lifting `append` with `lift2`. Your solution should use the `ExceptT` transformer to transform the `Async` monad.
-X>
-X>     Use this approach to modify your `concatenateMany` function to read multiple input files in parallel.
-X> 1. (Difficult, Extended) Suppose we are given a collection of JSON documents on disk, such that each document contains an array of references to other files on disk:
-X>
-X>     ```javascript
-X>     { references: ['/tmp/1.json', '/tmp/2.json'] }
-X>     ```
-X>     
-X>     Write a utility which takes a single filename as input, and spiders the JSON files on disk referenced transitively by that file, collecting a list of all referenced files.
-X>
-X>     Your utility should use the `purescript-foreign` library to parse the JSON documents, and should fetch files referenced by a single file in parallel.
+ ## Exercises
+
+ 1. (Easy) Use `parallel` and `sequential` to make two HTTP requests and collect their response bodies in parallel. Your combining function should concatenate the two response bodies, and your continuation should use `print` to print the result to the console.
+ 1. (Medium) The applicative functor which corresponds to `Async` is also an instance of `Alternative`. The `<|>` operator defined by this instance runs two computations in parallel, and returns the result from the computation which completes first.
+
+     Use this `Alternative` instance in conjunction with your `setTimeoutCont` function to define a function
+
+     ```haskell
+     timeout :: forall a eff
+              . Milliseconds
+             -> Async (timeout :: TIMEOUT | eff) a
+             -> Async (timeout :: TIMEOUT | eff) (Maybe a)
+     ```
+
+     which returns `Nothing` if the specified computation does not provide a result within the given number of milliseconds.
+ 1. (Medium) `purescript-parallel` also provides instances of the `Parallel` class for several monad transformers, including `ExceptT`.
+
+     Rewrite the parallel file IO example to use `ExceptT` for error handling, instead of lifting `append` with `lift2`. Your solution should use the `ExceptT` transformer to transform the `Async` monad.
+
+     Use this approach to modify your `concatenateMany` function to read multiple input files in parallel.
+ 1. (Difficult, Extended) Suppose we are given a collection of JSON documents on disk, such that each document contains an array of references to other files on disk:
+
+     ```javascript
+     { references: ['/tmp/1.json', '/tmp/2.json'] }
+     ```
+     
+     Write a utility which takes a single filename as input, and spiders the JSON files on disk referenced transitively by that file, collecting a list of all referenced files.
+
+     Your utility should use the `purescript-foreign` library to parse the JSON documents, and should fetch files referenced by a single file in parallel.
 
 ## Conclusion
 

--- a/text/chapter13.md
+++ b/text/chapter13.md
@@ -94,10 +94,10 @@ Error: Test 6 failed:
 
 Notice how the input `xs` and `ys` were generated as a arrays of randomly-selected integers.
 
-X> ## Exercises
-X>
-X> 1. (Easy) Write a property which asserts that merging an array with the empty array does not modify the original array.
-X> 1. (Easy) Add an appropriate error message to the remaining property for `merge`.
+ ## Exercises
+
+ 1. (Easy) Write a property which asserts that merging an array with the empty array does not modify the original array.
+ 1. (Easy) Add an appropriate error message to the remaining property for `merge`.
 
 ## Testing Polymorphic Code
 
@@ -136,10 +136,10 @@ quickCheck \xs ys ->
 
 Here, `xs` and `ys` both have type `Array Int`, since the `ints` function has been used to disambiguate the unknown type.
 
-X> ## Exercises
-X>
-X> 1. (Easy) Write a function `bools` which forces the types of `xs` and `ys` to be `Array Boolean`, and add additional properties which test `mergePoly` at that type.
-X> 1. (Medium) Choose a pure function from the core libraries (for example, from the `purescript-arrays` package), and write a QuickCheck property for it, including an appropriate error message. Your property should use a helper function to fix any polymorphic type arguments to either `Int` or `Boolean`.
+ ## Exercises
+
+ 1. (Easy) Write a function `bools` which forces the types of `xs` and `ys` to be `Array Boolean`, and add additional properties which test `mergePoly` at that type.
+ 1. (Medium) Choose a pure function from the core libraries (for example, from the `purescript-arrays` package), and write a QuickCheck property for it, including an appropriate error message. Your property should use a helper function to fix any polymorphic type arguments to either `Int` or `Boolean`.
 
 ## Generating Arbitrary Data
 
@@ -243,10 +243,10 @@ quickCheck \t a ->
 
 Here, the argument `t` is a randomly-generated tree of type `Tree Int`, where the type argument disambiguated by the identity function `treeOfInt`.
 
-X> ## Exercises
-X>
-X> 1. (Medium) Create a newtype for `String` with an associated `Arbitrary` instance which generates collections of randomly-selected characters in the range `a-z`. _Hint_: use the `elements` and `arrayOf` functions from the `Test.QuickCheck.Gen` module.
-X> 1. (Difficult) Write a property which asserts that a value inserted into a tree is still a member of that tree after arbitrarily many more insertions.
+ ## Exercises
+
+ 1. (Medium) Create a newtype for `String` with an associated `Arbitrary` instance which generates collections of randomly-selected characters in the range `a-z`. _Hint_: use the `elements` and `arrayOf` functions from the `Test.QuickCheck.Gen` module.
+ 1. (Difficult) Write a property which asserts that a value inserted into a tree is still a member of that tree after arbitrarily many more insertions.
 
 ## Testing Higher-Order Functions
 
@@ -387,18 +387,18 @@ Success : Success : ...
 
 `quickCheckPure` might be useful in other situations, such as generating random input data for performance benchmarks, or generating sample form data for web applications.
 
-X> ## Exercises
-X>
-X> 1. (Easy) Write `Coarbitrary` instances for the `Byte` and `Sorted` type constructors.
-X> 1. (Medium) Write a (higher-order) property which asserts associativity of the `mergeWith f` function for any function `f`. Test your property in PSCi using `quickCheckPure`.
-X> 1. (Medium) Write `Arbitrary` and `Coarbitrary` instances for the following data type:
-X>
-X>     ```haskell
-X>     data OneTwoThree a = One a | Two a a | Three a a a
-X>     ```
-X>
-X>     _Hint_: Use the `oneOf` function defined in `Test.QuickCheck.Gen` to define your `Arbitrary` instance.
-X> 1. (Medium) Use the `all` function to simplify the result of the `quickCheckPure` function - your function should return `true` if every test passes, and `false` otherwise. Try using the `First` monoid, defined in `purescript-monoids` with the `foldMap` function to preserve the first error in case of failure.
+ ## Exercises
+
+ 1. (Easy) Write `Coarbitrary` instances for the `Byte` and `Sorted` type constructors.
+ 1. (Medium) Write a (higher-order) property which asserts associativity of the `mergeWith f` function for any function `f`. Test your property in PSCi using `quickCheckPure`.
+ 1. (Medium) Write `Arbitrary` and `Coarbitrary` instances for the following data type:
+
+     ```haskell
+     data OneTwoThree a = One a | Two a a | Three a a a
+     ```
+
+     _Hint_: Use the `oneOf` function defined in `Test.QuickCheck.Gen` to define your `Arbitrary` instance.
+ 1. (Medium) Use the `all` function to simplify the result of the `quickCheckPure` function - your function should return `true` if every test passes, and `false` otherwise. Try using the `First` monoid, defined in `purescript-monoids` with the `foldMap` function to preserve the first error in case of failure.
 
 ## Conclusion
 

--- a/text/chapter14.md
+++ b/text/chapter14.md
@@ -247,16 +247,16 @@ unit
 
 Note, however, that no changes had to be made to the `render` function, because the underlying data representation never changed. This is one of the benefits of the smart constructors approach - it allows us to separate the internal data representation for a module from the representation which is perceived by users of its external API.
 
-X> ## Exercises
-X>
-X> 1. (Easy) Use the `Data.DOM.Smart` module to experiment by creating new HTML documents using `render`.
-X> 1. (Medium) Some HTML attributes such as `checked` and `disabled` do not require values, and may be rendered as _empty attributes_:
-X>
-X>     ```html
-X>     <input disabled>
-X>     ```
-X>
-X>     Modify the representation of an `Attribute` to take empty attributes into account. Write a function which can be used in place of `attribute` or `:=` to add an empty attribute to an element.
+ ## Exercises
+
+ 1. (Easy) Use the `Data.DOM.Smart` module to experiment by creating new HTML documents using `render`.
+ 1. (Medium) Some HTML attributes such as `checked` and `disabled` do not require values, and may be rendered as _empty attributes_:
+
+     ```html
+     <input disabled>
+     ```
+
+     Modify the representation of an `Attribute` to take empty attributes into account. Write a function which can be used in place of `attribute` or `:=` to add an empty attribute to an element.
 
 ## Phantom Types
 
@@ -350,17 +350,17 @@ Now we find it is impossible to represent these invalid HTML documents, and we a
 unit
 ```
 
-X> ## Exercises
-X>
-X> 1. (Easy) Create a data type which represents either pixel or percentage lengths. Write an instance of `IsValue` for your type. Modify the `width` and `height` attributes to use your new type.
-X> 1. (Difficult) By defining type-level representatives for the Boolean values `true` and `false`, we can use a phantom type to encode whether an `AttributeKey` represents an _empty attribute_ such as `disabled` or `checked`.
-X>
-X>     ```haskell
-X>     data True
-X>     data False
-X>     ```
-X>
-X>     Modify your solution to the previous exercise to use a phantom type to prevent the user from using the `attribute` operator with an empty attribute.
+ ## Exercises
+
+ 1. (Easy) Create a data type which represents either pixel or percentage lengths. Write an instance of `IsValue` for your type. Modify the `width` and `height` attributes to use your new type.
+ 1. (Difficult) By defining type-level representatives for the Boolean values `true` and `false`, we can use a phantom type to encode whether an `AttributeKey` represents an _empty attribute_ such as `disabled` or `checked`.
+
+     ```haskell
+     data True
+     data False
+     ```
+
+     Modify your solution to the previous exercise to use a phantom type to prevent the user from using the `attribute` operator with an empty attribute.
 
 ## The Free Monad
 
@@ -567,9 +567,9 @@ That's it! We can test our new monadic API in PSCi, as follows:
 unit
 ```
 
-X> ## Exercises
-X>
-X> 1. (Medium) Add a new data constructor to the `ContentF` type to support a new action `comment`, which renders a comment in the generated HTML. Implement the new action using `liftF`. Update the interpretation `renderContentItem` to interpret your new constructor appropriately.
+ ## Exercises
+
+ 1. (Medium) Add a new data constructor to the `ContentF` type to support a new action `comment`, which renders a comment in the generated HTML. Implement the new action using `liftF`. Update the interpretation `renderContentItem` to interpret your new constructor appropriately.
 
 ## Extending the Language
 
@@ -702,23 +702,23 @@ unit
 
 You can verify that multiple calls to `newName` do in fact result in unique names.
 
-X> ## Exercises
-X>
-X> 1. (Medium) We can simplify the API further by hiding the `Element` type from its users. Make these changes in the following steps:
-X>     
-X>     - Combine functions like `p` and `img` (with return type `Element`) with the `elem` action to create new actions with return type `Content Unit`.
-X>     - Change the `render` function to accept an argument of type `Content Unit` instead of `Element`.
-X> 1. (Medium) Hide the implementation of the `Content` monad by using a `newtype` instead of a type synonym. You should not export the data
-X>     constructor for your `newtype`.
-X> 1. (Difficult) Modify the `ContentF` type to support a new action
-X>
-X>     ```haskell
-X>     isMobile :: Content Boolean
-X>     ```
-X>
-X>     which returns a boolean value indicating whether or not the document is being rendered for display on a mobile device.
-X>
-X>     _Hint_: use the `ask` action and the `ReaderT` monad transformer to interpret this action. Alternatively, you might prefer to use the `RWS` monad.
+ ## Exercises
+
+ 1. (Medium) We can simplify the API further by hiding the `Element` type from its users. Make these changes in the following steps:
+     
+     - Combine functions like `p` and `img` (with return type `Element`) with the `elem` action to create new actions with return type `Content Unit`.
+     - Change the `render` function to accept an argument of type `Content Unit` instead of `Element`.
+ 1. (Medium) Hide the implementation of the `Content` monad by using a `newtype` instead of a type synonym. You should not export the data
+     constructor for your `newtype`.
+ 1. (Difficult) Modify the `ContentF` type to support a new action
+
+     ```haskell
+     isMobile :: Content Boolean
+     ```
+
+     which returns a boolean value indicating whether or not the document is being rendered for display on a mobile device.
+
+     _Hint_: use the `ask` action and the `ReaderT` monad transformer to interpret this action. Alternatively, you might prefer to use the `RWS` monad.
 
 ## Conclusion
 

--- a/text/chapter2.md
+++ b/text/chapter2.md
@@ -307,10 +307,10 @@ Array Int
 
 Try out the interactive mode now. If you get stuck at any point, simply use the Reset command `:reset` to unload any modules which may be compiled in memory.
 
-X> ## Exercises
-X>
-X> 1. (Easy) Use the `pi` constant, which is defined in the `Math` module, to write a function `circleArea` which computes the area of a circle with a given radius. Test your function using PSCi (_Hint_: don't forget to import `pi` by modifying the `import Math` statement).
-X> 1. (Medium) Use `psc-package install` to install the `purescript-globals` package as a dependency. Test out its functions in PSCi (_Hint_: you can use the `:browse` command in PSCi to browse the contents of a module).
+ ## Exercises
+
+ 1. (Easy) Use the `pi` constant, which is defined in the `Math` module, to write a function `circleArea` which computes the area of a circle with a given radius. Test your function using PSCi (_Hint_: don't forget to import `pi` by modifying the `import Math` statement).
+ 1. (Medium) Use `psc-package install` to install the `purescript-globals` package as a dependency. Test out its functions in PSCi (_Hint_: you can use the `:browse` command in PSCi to browse the contents of a module).
 
 ## Conclusion
 

--- a/text/chapter3.md
+++ b/text/chapter3.md
@@ -609,12 +609,12 @@ Either way, this gives a clear definition of the `findEntry` function: "`findEnt
 
 I will let you make your own decision which definition is easier to understand, but it is often useful to think of functions as building blocks in this way - each function executing a single task, and solutions assembled using function composition.
 
-X> ## Exercises
-X>
-X> 1. (Easy) Test your understanding of the `findEntry` function by writing down the types of each of its major subexpressions. For example, the type of the `head` function as used is specialized to `AddressBook -> Maybe Entry`.
-X> 1. (Medium) Write a function which looks up an `Entry` given a street address, by reusing the existing code in `findEntry`. Test your function in PSCi.
-X> 1. (Medium) Write a function which tests whether a name appears in a `AddressBook`, returning a Boolean value. _Hint_: Use PSCi to find the type of the `Data.List.null` function, which test whether a list is empty or not.
-X> 1. (Difficult) Write a function `removeDuplicates` which removes duplicate address book entries with the same first and last names. _Hint_: Use PSCi to find the type of the `Data.List.nubBy` function, which removes duplicate elements from a list based on an equality predicate.
+ ## Exercises
+
+ 1. (Easy) Test your understanding of the `findEntry` function by writing down the types of each of its major subexpressions. For example, the type of the `head` function as used is specialized to `AddressBook -> Maybe Entry`.
+ 1. (Medium) Write a function which looks up an `Entry` given a street address, by reusing the existing code in `findEntry`. Test your function in PSCi.
+ 1. (Medium) Write a function which tests whether a name appears in a `AddressBook`, returning a Boolean value. _Hint_: Use PSCi to find the type of the `Data.List.null` function, which test whether a list is empty or not.
+ 1. (Difficult) Write a function `removeDuplicates` which removes duplicate address book entries with the same first and last names. _Hint_: Use PSCi to find the type of the `Data.List.nubBy` function, which removes duplicate elements from a list based on an equality predicate.
 
 ## Conclusion
 

--- a/text/chapter4.md
+++ b/text/chapter4.md
@@ -78,10 +78,10 @@ The `tail` function returns a `Maybe` wrapping the given array without its first
 
 This example is obviously a very impractical way to find the length of an array in JavaScript, but should provide enough help to allow you to complete the following exercises:
 
-X> ## Exercises
-X>
-X> 1. (Easy) Write a recursive function which returns `true` if and only if its input is an even integer.
-X> 2. (Medium) Write a recursive function which counts the number of even integers in an array. _Hint_: the function `head` (also available in `Data.Array`) can be used to find the first element in a non-empty array.
+ ## Exercises
+
+ 1. (Easy) Write a recursive function which returns `true` if and only if its input is an even integer.
+ 2. (Medium) Write a recursive function which counts the number of even integers in an array. _Hint_: the function `head` (also available in `Data.Array`) can be used to find the first element in a non-empty array.
 
 ## Maps
 
@@ -189,11 +189,11 @@ For example, suppose we wanted to compute an array of all numbers between 1 and 
 [2,4,6,8,10]
 ```
 
-X> ## Exercises
-X>
-X> 1. (Easy) Use the `map` or `<$>` function to write a function which calculates the squares of an array of numbers.
-X> 1. (Easy) Use the `filter` function to write a function which removes the negative numbers from an array of numbers.
-X> 1. (Medium) Define an infix synonym `<$?>` for `filter`. Rewrite your answer to the previous question to use your new operator. Experiment with the precedence level and associativity of your operator in PSCi.
+ ## Exercises
+
+ 1. (Easy) Use the `map` or `<$>` function to write a function which calculates the squares of an array of numbers.
+ 1. (Easy) Use the `filter` function to write a function which removes the negative numbers from an array of numbers.
+ 1. (Medium) Define an infix synonym `<$?>` for `filter`. Rewrite your answer to the previous question to use your new operator. Experiment with the precedence level and associativity of your operator in PSCi.
 
 ## Flattening Arrays
 
@@ -381,12 +381,12 @@ That is, if `guard` is passed an expression which evaluates to `true`, then it r
 
 This means that if the guard fails, then the current branch of the array comprehension will terminate early with no results. This means that a call to `guard` is equivalent to using `filter` on the intermediate array. Depending on the application, you might prefer to use `guard` instead of a `filter`. Try the two definitions of `factors` to verify that they give the same results.
 
-X> ## Exercises
-X>
-X> 1. (Easy) Use the `factors` function to define a function `isPrime` which tests if its integer argument is prime or not.
-X> 1. (Medium) Write a function which uses do notation to find the _cartesian product_ of two arrays, i.e. the set of all pairs of elements `a`, `b`, where `a` is an element of the first array, and `b` is an element of the second.
-X> 1. (Medium) A _Pythagorean triple_ is an array of numbers `[a, b, c]` such that `a² + b² = c²`. Use the `guard` function in an array comprehension to write a function `triples` which takes a number `n` and calculates all Pythagorean triples whose components are less than `n`. Your function should have type `Int -> Array (Array Int)`.
-X> 1. (Difficult) Write a function `factorizations` which produces all _factorizations_ of an integer `n`, i.e. arrays of integers whose product is `n`. _Hint_: for an integer greater than 1, break the problem down into two subproblems: finding the first factor, and finding the remaining factors.
+ ## Exercises
+
+ 1. (Easy) Use the `factors` function to define a function `isPrime` which tests if its integer argument is prime or not.
+ 1. (Medium) Write a function which uses do notation to find the _cartesian product_ of two arrays, i.e. the set of all pairs of elements `a`, `b`, where `a` is an element of the first array, and `b` is an element of the second.
+ 1. (Medium) A _Pythagorean triple_ is an array of numbers `[a, b, c]` such that `a² + b² = c²`. Use the `guard` function in an array comprehension to write a function `triples` which takes a number `n` and calculates all Pythagorean triples whose components are less than `n`. Your function should have type `Int -> Array (Array Int)`.
+ 1. (Difficult) Write a function `factorizations` which produces all _factorizations_ of an integer `n`, i.e. arrays of integers whose product is `n`. _Hint_: for an integer greater than 1, break the problem down into two subproblems: finding the first factor, and finding the remaining factors.
 
 ## Folds
 
@@ -544,12 +544,12 @@ For example, we can reverse an array using `foldr`:
 
 Writing `reverse` in terms of `foldl` will be left as an exercise for the reader.
 
-X> ## Exercises
-X>
-X> 1. (Easy) Use `foldl` to test whether an array of boolean values are all true.
-X> 2. (Medium) Characterize those arrays `xs` for which the function `foldl (==) false xs` returns true.
-X> 3. (Medium) Rewrite the `fib` function in tail recursive form using an accumulator parameter:
-X> 4. (Medium) Write `reverse` in terms of `foldl`.
+ ## Exercises
+
+ 1. (Easy) Use `foldl` to test whether an array of boolean values are all true.
+ 2. (Medium) Characterize those arrays `xs` for which the function `foldl (==) false xs` returns true.
+ 3. (Medium) Rewrite the `fib` function in tail recursive form using an accumulator parameter:
+ 4. (Medium) Write `reverse` in terms of `foldl`.
 
 ## A Virtual Filesystem
 
@@ -641,21 +641,21 @@ allFiles' file = file : do
 
 Try out the new version in PSCi - you should get the same result. I'll let you decide which version you find clearer.
 
-X> ## Exercises
-X>
-X> 1. (Easy) Write a function `onlyFiles` which returns all _files_ (not directories) in all subdirectories of a directory.
-X> 1. (Medium) Write a fold to determine the largest and smallest files in the filesystem.
-X> 1. (Difficult) Write a function `whereIs` to search for a file by name. The function should return a value of type `Maybe Path`, indicating the directory containing the file, if it exists. It should behave as follows:
-X>
-X>     ```text
-X>     > whereIs "/bin/ls"
-X>     Just (/bin/)
-X>     
-X>     > whereIs "/bin/cat"
-X>     Nothing
-X>     ```
-X>
-X>     _Hint_: Try to write this function as an array comprehension using do notation.
+ ## Exercises
+
+ 1. (Easy) Write a function `onlyFiles` which returns all _files_ (not directories) in all subdirectories of a directory.
+ 1. (Medium) Write a fold to determine the largest and smallest files in the filesystem.
+ 1. (Difficult) Write a function `whereIs` to search for a file by name. The function should return a value of type `Maybe Path`, indicating the directory containing the file, if it exists. It should behave as follows:
+
+     ```text
+     > whereIs "/bin/ls"
+     Just (/bin/)
+     
+     > whereIs "/bin/cat"
+     Nothing
+     ```
+
+     _Hint_: Try to write this function as an array comprehension using do notation.
 
 ## Conclusion
 

--- a/text/chapter5.md
+++ b/text/chapter5.md
@@ -110,10 +110,10 @@ In this case, the third line uses a guard to impose the extra condition that the
 
 As this example demonstrates, guards appear on the left of the equals symbol, separated from the list of patterns by a pipe character (`|`).
 
-X> ## Exercises
-X>
-X> 1. (Easy) Write the factorial function using pattern matching. _Hint_. Consider the two cases zero and non-zero inputs.
-X> 1. (Medium) Look up _Pascal's Rule_ for computing binomial coefficients. Use it to write a function which computes binomial coefficients using pattern matching.
+ ## Exercises
+
+ 1. (Easy) Write the factorial function using pattern matching. _Hint_. Consider the two cases zero and non-zero inputs.
+ 1. (Medium) Look up _Pascal's Rule_ for computing binomial coefficients. Use it to write a function which computes binomial coefficients using pattern matching.
 
 ## Array Patterns
 
@@ -237,11 +237,11 @@ sortPair arr = arr
 
 This way, we save ourselves from allocating a new array if the pair is already sorted.
 
-X> ## Exercises
-X>
-X> 1. (Easy) Write a function `sameCity` which uses record patterns to test whether two `Person` records belong to the same city.
-X> 1. (Medium) What is the most general type of the `sameCity` function, taking into account row polymorphism? What about the `livesInLA` function defined above?
-X> 1. (Medium) Write a function `fromSingleton` which uses an array literal pattern to extract the sole member of a singleton array. If the array is not a singleton, your function should return a provided default value. Your function should have type `forall a. a -> Array a -> a`
+ ## Exercises
+
+ 1. (Easy) Write a function `sameCity` which uses record patterns to test whether two `Person` records belong to the same city.
+ 1. (Medium) What is the most general type of the `sameCity` function, taking into account row polymorphism? What about the `livesInLA` function defined above?
+ 1. (Medium) Write a function `fromSingleton` which uses an array literal pattern to extract the sole member of a singleton array. If the array is not a singleton, your function should return a provided default value. Your function should have type `forall a. a -> Array a -> a`
 
 ## Case Expressions
 
@@ -465,11 +465,11 @@ origin = Point { x, y }
 
 This can be useful for improving readability of code in some circumstances.
 
-X> ## Exercises
-X>
-X> 1. (Easy) Construct a value of type `Shape` which represents a circle centered at the origin with radius `10.0`.
-X> 1. (Medium) Write a function from `Shape`s to `Shape`s, which scales its argument by a factor of `2.0`, center the origin.
-X> 1. (Medium) Write a function which extracts the text from a `Shape`. It should return `Maybe String`, and use the `Nothing` constructor if the input is not constructed using `Text`.
+ ## Exercises
+
+ 1. (Easy) Construct a value of type `Shape` which represents a circle centered at the origin with radius `10.0`.
+ 1. (Medium) Write a function from `Shape`s to `Shape`s, which scales its argument by a factor of `2.0`, center the origin.
+ 1. (Medium) Write a function which extracts the text from a `Shape`. It should return `Maybe String`, and use the `Nothing` constructor if the input is not constructed using `Text`.
 
 ## Newtypes
 
@@ -552,10 +552,10 @@ In the base case, we need to find the smallest bounding rectangle of an empty `P
 
 The accumulating function `combine` is defined in a `where` block. `combine` takes a bounding rectangle computed from `foldl`'s recursive call, and the next `Shape` in the array, and uses the `union` function to compute the union of the two bounding rectangles. The `shapeBounds` function computes the bounds of a single shape using pattern matching.
 
-X> ## Exercises
-X>
-X> 1. (Medium) Extend the vector graphics library with a new operation `area` which computes the area of a `Shape`. For the purposes of this exercise, the area of a piece of text is assumed to be zero.
-X> 1. (Difficult) Extend the `Shape` type with a new data constructor `Clipped`, which clips another `Picture` to a rectangle. Extend the `shapeBounds` function to compute the bounds of a clipped picture. Note that this makes `Shape` into a recursive data type.
+ ## Exercises
+
+ 1. (Medium) Extend the vector graphics library with a new operation `area` which computes the area of a `Shape`. For the purposes of this exercise, the area of a piece of text is assumed to be zero.
+ 1. (Difficult) Extend the `Shape` type with a new data constructor `Clipped`, which clips another `Picture` to a rectangle. Extend the `shapeBounds` function to compute the bounds of a clipped picture. Note that this makes `Shape` into a recursive data type.
 
 ## Conclusion
 

--- a/text/chapter6.md
+++ b/text/chapter6.md
@@ -109,9 +109,9 @@ No type class instance was found for
   Data.Show.Show (Int -> Int)
 ```
 
-X> ## Exercises
-X>
-X> 1. (Easy) Use the `showShape` function from the previous chapter to define a `Show` instance for the `Shape` type.
+ ## Exercises
+
+ 1. (Easy) Use the `showShape` function from the previous chapter to define a `Show` instance for the `Shape` type.
 
 ## Common Type Classes
 
@@ -289,18 +289,18 @@ Whatever "lifting" means in the general sense, it should be true that any reason
 
 Many standard type classes come with their own set of similar laws. The laws given to a type class give structure to the functions of that type class and allow us to study its instances in generality. The interested reader can research the laws ascribed to the standard type classes that we have seen already.
 
-X> ## Exercises
-X>
-X> 1. (Easy) The following newtype represents a complex number:
-X>
-X>     ```haskell
-X>     newtype Complex = Complex
-X>       { real :: Number
-X>       , imaginary :: Number
-X>       }
-X>     ```
-X>       
-X>     Define `Show` and `Eq` instances for `Complex`.
+ ## Exercises
+
+ 1. (Easy) The following newtype represents a complex number:
+
+     ```haskell
+     newtype Complex = Complex
+       { real :: Number
+       , imaginary :: Number
+       }
+     ```
+       
+     Define `Show` and `Eq` instances for `Complex`.
 
 ## Type Annotations
 
@@ -399,37 +399,37 @@ These two type class instances are provided in the `purescript-prelude` library.
 
 When the program is compiled, the correct type class instance for `Show` is chosen based on the inferred type of the argument to `show`. The selected instance might depend on many such instance relationships, but this complexity is not exposed to the developer.
 
-X> ## Exercises
-X>
-X> 1. (Easy) The following declaration defines a type of non-empty arrays of elements of type `a`:
-X>
-X>     ```haskell
-X>     data NonEmpty a = NonEmpty a (Array a)
-X>     ```
-X>      
-X>     Write an `Eq` instance for the type `NonEmpty a` which reuses the instances for `Eq a` and `Eq (Array a)`.
-X> 1. (Medium) Write a `Semigroup` instance for `NonEmpty a` by reusing the `Semigroup` instance for `Array`.
-X> 1. (Medium) Write a `Functor` instance for `NonEmpty`.
-X> 1. (Medium) Given any type `a` with an instance of `Ord`, we can add a new "infinite" value which is greater than any other value:
-X>
-X>     ```haskell
-X>     data Extended a = Finite a | Infinite
-X>     ```
-X>         
-X>     Write an `Ord` instance for `Extended a` which reuses the `Ord` instance for `a`.
-X> 1. (Difficult) Write a `Foldable` instance for `NonEmpty`. _Hint_: reuse the `Foldable` instance for arrays.
-X> 1. (Difficult) Given an type constructor `f` which defines an ordered container (and so has a `Foldable` instance), we can create a new container type which includes an extra element at the front:
-X>
-X>     ```haskell
-X>     data OneMore f a = OneMore a (f a)
-X>     ```
-X>         
-X>     The container `OneMore f` is also has an ordering, where the new element comes before any element of `f`. Write a `Foldable` instance for `OneMore f`:
-X>   
-X>     ```haskell
-X>     instance foldableOneMore :: Foldable f => Foldable (OneMore f) where
-X>       ...
-X>     ```
+ ## Exercises
+
+ 1. (Easy) The following declaration defines a type of non-empty arrays of elements of type `a`:
+
+     ```haskell
+     data NonEmpty a = NonEmpty a (Array a)
+     ```
+      
+     Write an `Eq` instance for the type `NonEmpty a` which reuses the instances for `Eq a` and `Eq (Array a)`.
+ 1. (Medium) Write a `Semigroup` instance for `NonEmpty a` by reusing the `Semigroup` instance for `Array`.
+ 1. (Medium) Write a `Functor` instance for `NonEmpty`.
+ 1. (Medium) Given any type `a` with an instance of `Ord`, we can add a new "infinite" value which is greater than any other value:
+
+     ```haskell
+     data Extended a = Finite a | Infinite
+     ```
+         
+     Write an `Ord` instance for `Extended a` which reuses the `Ord` instance for `a`.
+ 1. (Difficult) Write a `Foldable` instance for `NonEmpty`. _Hint_: reuse the `Foldable` instance for arrays.
+ 1. (Difficult) Given an type constructor `f` which defines an ordered container (and so has a `Foldable` instance), we can create a new container type which includes an extra element at the front:
+
+     ```haskell
+     data OneMore f a = OneMore a (f a)
+     ```
+         
+     The container `OneMore f` is also has an ordering, where the new element comes before any element of `f`. Write a `Foldable` instance for `OneMore f`:
+   
+     ```haskell
+     instance foldableOneMore :: Foldable f => Foldable (OneMore f) where
+       ...
+     ```
 
 ## Multi Parameter Type Classes
 
@@ -579,49 +579,49 @@ In general, it makes sense to define a superclass relationship when the laws for
 
 Another reason to define a superclass relationship is in the case where there is a clear "is-a" relationship between the two classes. That is, every member of the subclass _is a_ member of the superclass as well.
 
-X> ## Exercises
-X>
-X> 1. (Medium) Define a partial function which finds the maximum of a non-empty array of integers. Your function should have type `Partial => Array Int -> Int`. Test out your function in PSCi using `unsafePartial`. _Hint_: Use the `maximum` function from `Data.Foldable`.
-X> 1. (Medium) The `Action` class is a multi-parameter type class which defines an action of one type on another:
-X>
-X>     ```haskell
-X>     class Monoid m <= Action m a where
-X>       act :: m -> a -> a
-X>     ```
-X>           
-X>     An _action_ is a function which describes how monoidal values can be used to modify a value of another type. There are two laws for the `Action` type class:
-X>
-X>     - `act mempty a = a`
-X>     - `act (m1 <> m2) a = act m1 (act m2 a)`
-X>
-X>     That is, the action respects the operations defined by the `Monoid` class.
-X>        
-X>     For example, the natural numbers form a monoid under multiplication:
-X>
-X>     ```haskell
-X>     newtype Multiply = Multiply Int
-X>
-X>     instance semigroupMultiply :: Semigroup Multiply where
-X>       append (Multiply n) (Multiply m) = Multiply (n * m)
-X>
-X>     instance monoidMultiply :: Monoid Multiply where
-X>       mempty = Multiply 1
-X>     ```
-X>
-X>     This monoid acts on strings by repeating an input string some number of times. Write an instance which implements this action:
-X>
-X>     ```haskell
-X>     instance repeatAction :: Action Multiply String
-X>     ```
-X>
-X>     Does this instance satisfy the laws listed above?
-X> 1. (Medium) Write an instance `Action m a => Action m (Array a)`, where the action on arrays is defined by acting on each array element independently.
-X> 1. (Difficult) Given the following newtype, write an instance for `Action m (Self m)`, where the monoid `m` acts on itself using `append`:
-X>
-X>     ```haskell
-X>     newtype Self m = Self m
-X>     ```
-X> 1. (Difficult) Should the arguments of the multi-parameter type class `Action` be related by some functional dependency? Why or why not?
+ ## Exercises
+
+ 1. (Medium) Define a partial function which finds the maximum of a non-empty array of integers. Your function should have type `Partial => Array Int -> Int`. Test out your function in PSCi using `unsafePartial`. _Hint_: Use the `maximum` function from `Data.Foldable`.
+ 1. (Medium) The `Action` class is a multi-parameter type class which defines an action of one type on another:
+
+     ```haskell
+     class Monoid m <= Action m a where
+       act :: m -> a -> a
+     ```
+           
+     An _action_ is a function which describes how monoidal values can be used to modify a value of another type. There are two laws for the `Action` type class:
+
+     - `act mempty a = a`
+     - `act (m1 <> m2) a = act m1 (act m2 a)`
+
+     That is, the action respects the operations defined by the `Monoid` class.
+        
+     For example, the natural numbers form a monoid under multiplication:
+
+     ```haskell
+     newtype Multiply = Multiply Int
+
+     instance semigroupMultiply :: Semigroup Multiply where
+       append (Multiply n) (Multiply m) = Multiply (n * m)
+
+     instance monoidMultiply :: Monoid Multiply where
+       mempty = Multiply 1
+     ```
+
+     This monoid acts on strings by repeating an input string some number of times. Write an instance which implements this action:
+
+     ```haskell
+     instance repeatAction :: Action Multiply String
+     ```
+
+     Does this instance satisfy the laws listed above?
+ 1. (Medium) Write an instance `Action m a => Action m (Array a)`, where the action on arrays is defined by acting on each array element independently.
+ 1. (Difficult) Given the following newtype, write an instance for `Action m (Self m)`, where the monoid `m` acts on itself using `append`:
+
+     ```haskell
+     newtype Self m = Self m
+     ```
+ 1. (Difficult) Should the arguments of the multi-parameter type class `Action` be related by some functional dependency? Why or why not?
 
 ## A Type Class for Hashes
 
@@ -710,21 +710,21 @@ What about some more interesting types? To prove the type class law for the `Arr
 
 The source code for this chapter includes several other examples of `Hashable` instances, such as instances for the `Maybe` and `Tuple` type.
 
-X> ## Exercises
-X>
-X> 1. (Easy) Use PSCi to test the hash functions for each of the defined instances.
-X> 1. (Medium) Use the `hashEqual` function to write a function which tests if an array has any duplicate elements, using hash-equality as an approximation to value equality. Remember to check for value equality using `==` if a duplicate pair is found. _Hint_: the `nubBy` function in `Data.Array` should make this task much simpler.
-X> 1. (Medium) Write a `Hashable` instance for the following newtype which satisfies the type class law:
-X>
-X>     ```haskell
-X>     newtype Hour = Hour Int
-X>     
-X>     instance eqHour :: Eq Hour where
-X>       eq (Hour n) (Hour m) = mod n 12 == mod m 12
-X>     ```
-X>     
-X>     The newtype `Hour` and its `Eq` instance represent the type of integers modulo 12, so that 1 and 13 are identified as equal, for example. Prove that the type class law holds for your instance.
-X> 1. (Difficult) Prove the type class laws for the `Hashable` instances for `Maybe`, `Either` and `Tuple`.
+ ## Exercises
+
+ 1. (Easy) Use PSCi to test the hash functions for each of the defined instances.
+ 1. (Medium) Use the `hashEqual` function to write a function which tests if an array has any duplicate elements, using hash-equality as an approximation to value equality. Remember to check for value equality using `==` if a duplicate pair is found. _Hint_: the `nubBy` function in `Data.Array` should make this task much simpler.
+ 1. (Medium) Write a `Hashable` instance for the following newtype which satisfies the type class law:
+
+     ```haskell
+     newtype Hour = Hour Int
+     
+     instance eqHour :: Eq Hour where
+       eq (Hour n) (Hour m) = mod n 12 == mod m 12
+     ```
+     
+     The newtype `Hour` and its `Eq` instance represent the type of integers modulo 12, so that 1 and 13 are identified as equal, for example. Prove that the type class law holds for your instance.
+ 1. (Difficult) Prove the type class laws for the `Hashable` instances for `Maybe`, `Either` and `Tuple`.
 
 ## Conclusion
 

--- a/text/chapter7.md
+++ b/text/chapter7.md
@@ -376,11 +376,11 @@ But the `combineList` function works for any `Applicative`! We can use it to com
 
 We will see the `combineList` function again later, when we consider `Traversable` functors.
 
-X> ## Exercises
-X>
-X> 1. (Easy) Use `lift2` to write lifted versions of the numeric operators `+`, `-`, `*` and `/` which work with optional arguments.
-X> 1. (Medium) Convince yourself that the definition of `lift3` given above in terms of `<$>` and `<*>` does type check.
-X> 1. (Difficult) Write a function `combineMaybe` which has type `forall a f. Applicative f => Maybe (f a) -> f (Maybe a)`. This function takes an optional computation with side-effects, and returns a side-effecting computation which has an optional result.
+ ## Exercises
+
+ 1. (Easy) Use `lift2` to write lifted versions of the numeric operators `+`, `-`, `*` and `/` which work with optional arguments.
+ 1. (Medium) Convince yourself that the definition of `lift3` given above in terms of `<$>` and `<*>` does type check.
+ 1. (Difficult) Write a function `combineMaybe` which has type `forall a f. Applicative f => Maybe (f a) -> f (Maybe a)`. This function takes an optional computation with side-effects, and returns a side-effecting computation which has an optional result.
 
 ## Applicative Validation
 
@@ -580,10 +580,10 @@ Valid (PhoneNumber { type: HomePhone, number: "555-555-5555" })
 Invalid (["Field 'Number' did not match the required format"])
 ```
 
-X> ## Exercises
-X>
-X> 1. (Easy) Use a regular expression validator to ensure that the `state` field of the `Address` type contains two alphabetic characters. _Hint_: see the source code for `phoneNumberRegex`.
-X> 1. (Medium) Using the `matches` validator, write a validation function which checks that a string is not entirely whitespace. Use it to replace `nonEmpty` where appropriate.
+ ## Exercises
+
+ 1. (Easy) Use a regular expression validator to ensure that the `state` field of the `Address` type contains two alphabetic characters. _Hint_: see the source code for `phoneNumberRegex`.
+ 1. (Medium) Using the `matches` validator, write a validation function which checks that a string is not entirely whitespace. Use it to replace `nonEmpty` where appropriate.
 
 ## Traversable Functors
 
@@ -698,18 +698,18 @@ These examples show that traversing the `Nothing` value returns `Nothing` with n
 
 Other traversable functors include `Array`, and `Tuple a` and `Either a` for any type `a`. Generally, most "container" data type constructors have `Traversable` instances. As an example, the exercises will include writing a `Traversable` instance for a type of binary trees.
 
-X> ## Exercises
-X>
-X> 1. (Medium) Write a `Traversable` instance for the following binary tree data structure, which combines side-effects from left-to-right:
-X>
-X>     ```haskell
-X>     data Tree a = Leaf | Branch (Tree a) a (Tree a)
-X>     ```
-X>
-X>     This corresponds to an in-order traversal of the tree. What about a preorder traversal? What about reverse order?
-X>
-X> 1. (Medium) Modify the code to make the `address` field of the `Person` type optional using `Data.Maybe`. _Hint_: Use `traverse` to validate a field of type `Maybe a`.
-X> 1. (Difficult) Try to write `sequence` in terms of `traverse`. Can you write `traverse` in terms of `sequence`?
+ ## Exercises
+
+ 1. (Medium) Write a `Traversable` instance for the following binary tree data structure, which combines side-effects from left-to-right:
+
+     ```haskell
+     data Tree a = Leaf | Branch (Tree a) a (Tree a)
+     ```
+
+     This corresponds to an in-order traversal of the tree. What about a preorder traversal? What about reverse order?
+
+ 1. (Medium) Modify the code to make the `address` field of the `Person` type optional using `Data.Maybe`. _Hint_: Use `traverse` to validate a field of type `Maybe a`.
+ 1. (Difficult) Try to write `sequence` in terms of `traverse`. Can you write `traverse` in terms of `sequence`?
 
 ## Applicative Functors for Parallelism
 

--- a/text/chapter8.md
+++ b/text/chapter8.md
@@ -330,49 +330,49 @@ Try writing `userCity` using only `pure` and `apply`: you will see that it is im
 
 In the last chapter, we saw that the `Applicative` type class can be used to express parallelism. This was precisely because the function arguments being lifted were independent of one another. Since the `Monad` type class allows computations to depend on the results of previous computations, the same does not apply - a monad has to combine its side-effects in sequence.
 
-X> ## Exercises
-X>
-X> 1. (Easy) Look up the types of the `head` and `tail` functions from the `Data.Array` module in the `purescript-arrays` package. Use do notation with the `Maybe` monad to combine these functions into a function `third` which returns the third element of an array with three or more elements. Your function should return an appropriate `Maybe` type.
-X> 1. (Medium) Write a function `sums` which uses `foldM` to determine all possible totals that could be made using a set of coins. The coins will be specified as an array which contains the value of each coin. Your function should have the following result:
-X>
-X>     ```text
-X>     > sums []
-X>     [0]
-X>
-X>     > sums [1, 2, 10]
-X>     [0,1,2,3,10,11,12,13]
-X>     ```
-X>
-X>     _Hint_: This function can be written as a one-liner using `foldM`. You might want to use the `nub` and `sort` functions to remove duplicates and sort the result respectively.
-X> 1. (Medium) Confirm that the `ap` function and the `apply` operator agree for the `Maybe` monad.
-X> 1. (Medium) Verify that the monad laws hold for the `Monad` instance for the `Maybe` type, as defined in the `purescript-maybe` package.
-X> 1. (Medium) Write a function `filterM` which generalizes the `filter` function on lists. Your function should have the following type signature:
-X>
-X>     ```haskell
-X>     filterM :: forall m a. Monad m => (a -> m Boolean) -> List a -> m (List a)
-X>     ```
-X>
-X>     Test your function in PSCi using the `Maybe` and `Array` monads.
-X> 1. (Difficult) Every monad has a default `Functor` instance given by:
-X>
-X>     ```haskell
-X>     map f a = do
-X>       x <- a
-X>       pure (f x)
-X>     ```
-X>
-X>     Use the monad laws to prove that for any monad, the following holds:
-X>
-X>     ```haskell
-X>     lift2 f (pure a) (pure b) = pure (f a b)
-X>     ```
-X>     
-X>     where the `Applicative` instance uses the `ap` function defined above. Recall that `lift2` was defined as follows:
-X>    
-X>     ```haskell
-X>     lift2 :: forall f a b c. Applicative f => (a -> b -> c) -> f a -> f b -> f c
-X>     lift2 f a b = f <$> a <*> b
-X>     ```
+ ## Exercises
+
+ 1. (Easy) Look up the types of the `head` and `tail` functions from the `Data.Array` module in the `purescript-arrays` package. Use do notation with the `Maybe` monad to combine these functions into a function `third` which returns the third element of an array with three or more elements. Your function should return an appropriate `Maybe` type.
+ 1. (Medium) Write a function `sums` which uses `foldM` to determine all possible totals that could be made using a set of coins. The coins will be specified as an array which contains the value of each coin. Your function should have the following result:
+
+     ```text
+     > sums []
+     [0]
+
+     > sums [1, 2, 10]
+     [0,1,2,3,10,11,12,13]
+     ```
+
+     _Hint_: This function can be written as a one-liner using `foldM`. You might want to use the `nub` and `sort` functions to remove duplicates and sort the result respectively.
+ 1. (Medium) Confirm that the `ap` function and the `apply` operator agree for the `Maybe` monad.
+ 1. (Medium) Verify that the monad laws hold for the `Monad` instance for the `Maybe` type, as defined in the `purescript-maybe` package.
+ 1. (Medium) Write a function `filterM` which generalizes the `filter` function on lists. Your function should have the following type signature:
+
+     ```haskell
+     filterM :: forall m a. Monad m => (a -> m Boolean) -> List a -> m (List a)
+     ```
+
+     Test your function in PSCi using the `Maybe` and `Array` monads.
+ 1. (Difficult) Every monad has a default `Functor` instance given by:
+
+     ```haskell
+     map f a = do
+       x <- a
+       pure (f x)
+     ```
+
+     Use the monad laws to prove that for any monad, the following holds:
+
+     ```haskell
+     lift2 f (pure a) (pure b) = pure (f a b)
+     ```
+     
+     where the `Applicative` instance uses the `ap` function defined above. Recall that `lift2` was defined as follows:
+    
+     ```haskell
+     lift2 :: forall f a b c. Applicative f => (a -> b -> c) -> f a -> f b -> f c
+     lift2 f a b = f <$> a <*> b
+     ```
 
 ## Native Effects
 

--- a/text/chapter9.md
+++ b/text/chapter9.md
@@ -171,34 +171,34 @@ $ pulp build -O --main Example.Shapes --to dist/Main.js
 
 and open `html/index.html` again to see the result. You should see the three different types of shapes rendered to the canvas.
 
-X> ## Exercises
-X>
-X> 1. (Easy) Experiment with the `strokePath` and `setStrokeStyle` functions in each of the examples so far.
-X> 1. (Easy) The `fillPath` and `strokePath` functions can be used to render complex paths with a common style by using a do notation block inside the function argument. Try changing the `Rectangle` example to render two rectangles side-by-side using the same call to `fillPath`. Try rendering a sector of a circle by using a combination of a piecewise-linear path and an arc segment.
-X> 1. (Medium) Given the following record type:
-X>
-X>     ```haskell
-X>     type Point = { x :: Number, y :: Number }
-X>     ```
-X>
-X>     which represents a 2D point, write a function `renderPath` which strokes a closed path constructed from a number of points:
-X>
-X>     ```haskell
-X>     renderPath
-X>       :: Context2D
-X>       -> Array Point
-X>       -> Effect Unit
-X>     ```
-X>
-X>     Given a function
-X>
-X>     ```haskell
-X>     f :: Number -> Point
-X>     ```
-X>
-X>     which takes a `Number` between `0` and `1` as its argument and returns a `Point`, write an action which plots `f` by using your `renderPath` function. Your action should approximate the path by sampling `f` at a finite set of points.
-X>
-X>     Experiment by rendering different paths by varying the function `f`.
+ ## Exercises
+
+ 1. (Easy) Experiment with the `strokePath` and `setStrokeStyle` functions in each of the examples so far.
+ 1. (Easy) The `fillPath` and `strokePath` functions can be used to render complex paths with a common style by using a do notation block inside the function argument. Try changing the `Rectangle` example to render two rectangles side-by-side using the same call to `fillPath`. Try rendering a sector of a circle by using a combination of a piecewise-linear path and an arc segment.
+ 1. (Medium) Given the following record type:
+
+     ```haskell
+     type Point = { x :: Number, y :: Number }
+     ```
+
+     which represents a 2D point, write a function `renderPath` which strokes a closed path constructed from a number of points:
+
+     ```haskell
+     renderPath
+       :: Context2D
+       -> Array Point
+       -> Effect Unit
+     ```
+
+     Given a function
+
+     ```haskell
+     f :: Number -> Point
+     ```
+
+     which takes a `Number` between `0` and `1` as its argument and returns a `Point`, write an action which plots `f` by using your `renderPath` function. Your action should approximate the path by sampling `f` at a finite set of points.
+
+     Experiment by rendering different paths by varying the function `f`.
 
 ## Drawing Random Circles
 
@@ -404,11 +404,11 @@ $ pulp build -O --main Example.Refs --to dist/Main.js
 
 and open the `html/index.html` file. If you click the canvas repeatedly, you should see a green rectangle rotating around the center of the canvas.
 
-X> ## Exercises
-X>
-X> 1. (Easy) Write a higher-order function which strokes and fills a path simultaneously. Rewrite the `Random.purs` example using your function.
-X> 1. (Medium) Use `Random` and `Dom` to create an application which renders a circle with random position, color and radius to the canvas when the mouse is clicked.
-X> 1. (Medium) Write a function which transforms the scene by rotating it around a point with specified coordinates. _Hint_: use a translation to first translate the scene to the origin.
+ ## Exercises
+
+ 1. (Easy) Write a higher-order function which strokes and fills a path simultaneously. Rewrite the `Random.purs` example using your function.
+ 1. (Medium) Use `Random` and `Dom` to create an application which renders a circle with random position, color and radius to the canvas when the mouse is clicked.
+ 1. (Medium) Write a function which transforms the scene by rotating it around a point with specified coordinates. _Hint_: use a translation to first translate the scene to the origin.
 
 ## L-Systems
 
@@ -621,44 +621,44 @@ $ pulp build -O --main Example.LSystem --to dist/Main.js
 
 and open `html/index.html`. You should see the Koch curve rendered to the canvas.
 
-X> ## Exercises
-X>
-X> 1. (Easy) Modify the L-system example above to use `fillPath` instead of `strokePath`. _Hint_: you will need to include a call to `closePath`, and move the call to `moveTo` outside of the `interpret` function.
-X> 1. (Easy) Try changing the various numerical constants in the code, to understand their effect on the rendered system.
-X> 1. (Medium) Break the `lsystem` function into two smaller functions. The first should build the final sentence using repeated application of `concatMap`, and the second should use `foldM` to interpret the result.
-X> 1. (Medium) Add a drop shadow to the filled shape, by using the `setShadowOffsetX`, `setShadowOffsetY`, `setShadowBlur` and `setShadowColor` actions. _Hint_: use PSCi to find the types of these functions.
-X> 1. (Medium) The angle of the corners is currently a constant (`pi/3`). Instead, it can be moved into the `Alphabet` data type, which allows it to be changed by the production rules:
-X>
-X>     ```haskell
-X>     type Angle = Number
-X>     
-X>     data Alphabet = L Angle | R Angle | F
-X>     ```
-X>     
-X>     How can this new information be used in the production rules to create interesting shapes?
-X> 1. (Difficult) An L-system is given by an alphabet with four letters: `L` (turn left through 60 degrees), `R` (turn right through 60 degrees), `F` (move forward) and `M` (also move forward).
-X>
-X>     The initial sentence of the system is the single letter `M`.
-X>
-X>     The production rules are specified as follows:
-X>
-X>     ```text
-X>     L -> L
-X>     R -> R
-X>     F -> FLMLFRMRFRMRFLMLF
-X>     M -> MRFRMLFLMLFLMRFRM
-X>     ```
-X>
-X>     Render this L-system. _Note_: you will need to decrease the number of iterations of the production rules, since the size of the final sentence grows exponentially with the number of iterations.
-X>
-X>     Now, notice the symmetry between `L` and `M` in the production rules. The two "move forward" instructions can be differentiated using a `Boolean` value using the following alphabet type:
-X>
-X>     ```haskell
-X>     data Alphabet = L | R | F Boolean
-X>     ```
-X>
-X>     Implement this L-system again using this representation of the alphabet.
-X> 1. (Difficult) Use a different monad `m` in the interpretation function. You might try using `Effect.Console` to write the L-system onto the console, or using `Effect.Random` to apply random "mutations" to the state type.
+ ## Exercises
+
+ 1. (Easy) Modify the L-system example above to use `fillPath` instead of `strokePath`. _Hint_: you will need to include a call to `closePath`, and move the call to `moveTo` outside of the `interpret` function.
+ 1. (Easy) Try changing the various numerical constants in the code, to understand their effect on the rendered system.
+ 1. (Medium) Break the `lsystem` function into two smaller functions. The first should build the final sentence using repeated application of `concatMap`, and the second should use `foldM` to interpret the result.
+ 1. (Medium) Add a drop shadow to the filled shape, by using the `setShadowOffsetX`, `setShadowOffsetY`, `setShadowBlur` and `setShadowColor` actions. _Hint_: use PSCi to find the types of these functions.
+ 1. (Medium) The angle of the corners is currently a constant (`pi/3`). Instead, it can be moved into the `Alphabet` data type, which allows it to be changed by the production rules:
+
+     ```haskell
+     type Angle = Number
+     
+     data Alphabet = L Angle | R Angle | F
+     ```
+     
+     How can this new information be used in the production rules to create interesting shapes?
+ 1. (Difficult) An L-system is given by an alphabet with four letters: `L` (turn left through 60 degrees), `R` (turn right through 60 degrees), `F` (move forward) and `M` (also move forward).
+
+     The initial sentence of the system is the single letter `M`.
+
+     The production rules are specified as follows:
+
+     ```text
+     L -> L
+     R -> R
+     F -> FLMLFRMRFRMRFLMLF
+     M -> MRFRMLFLMLFLMRFRM
+     ```
+
+     Render this L-system. _Note_: you will need to decrease the number of iterations of the production rules, since the size of the final sentence grows exponentially with the number of iterations.
+
+     Now, notice the symmetry between `L` and `M` in the production rules. The two "move forward" instructions can be differentiated using a `Boolean` value using the following alphabet type:
+
+     ```haskell
+     data Alphabet = L | R | F Boolean
+     ```
+
+     Implement this L-system again using this representation of the alphabet.
+ 1. (Difficult) Use a different monad `m` in the interpretation function. You might try using `Effect.Console` to write the L-system onto the console, or using `Effect.Random` to apply random "mutations" to the state type.
 
 ## Conclusion
 


### PR DESCRIPTION
This is the result of running `sed -i "s/X>//g" *.md` on all the files in `text` to make the exercise sections more readable in GitHub's markdown viewer. I'm not sure what those `X>`'s were supposed to be doing so I might not understand the cost of removing them.