### PR TITLE
Generate spago-next configs

### DIFF
--- a/exercises/chapter10/spago.lock
+++ b/exercises/chapter10/spago.lock
@@ -1,0 +1,4404 @@
+workspace:
+  packages:
+    my-project:
+      path: ./
+      dependencies:
+        - aff
+        - aff-promise
+        - argonaut
+        - argonaut-generic
+        - arrays
+        - bifunctors
+        - console
+        - control
+        - effect
+        - either
+        - exceptions
+        - foldable-traversable
+        - free
+        - functions
+        - maybe
+        - ordered-collections
+        - pairs
+        - prelude
+        - react-basic
+        - react-basic-dom
+        - react-basic-hooks
+        - strings
+        - test-unit
+        - tuples
+        - validation
+        - web-dom
+        - web-html
+      test_dependencies: []
+      build_plan:
+        - aff
+        - aff-promise
+        - argonaut
+        - argonaut-codecs
+        - argonaut-core
+        - argonaut-generic
+        - argonaut-traversals
+        - arrays
+        - avar
+        - bifunctors
+        - catenable-lists
+        - console
+        - const
+        - contravariant
+        - control
+        - datetime
+        - distributive
+        - effect
+        - either
+        - enums
+        - exceptions
+        - exists
+        - foldable-traversable
+        - foreign
+        - foreign-object
+        - free
+        - functions
+        - functors
+        - gen
+        - identity
+        - indexed-monad
+        - integers
+        - invariant
+        - js-date
+        - js-timers
+        - lazy
+        - lcg
+        - lists
+        - maybe
+        - media-types
+        - newtype
+        - nonempty
+        - now
+        - nullable
+        - numbers
+        - ordered-collections
+        - orders
+        - pairs
+        - parallel
+        - partial
+        - prelude
+        - profunctor
+        - profunctor-lenses
+        - quickcheck
+        - random
+        - react-basic
+        - react-basic-dom
+        - react-basic-hooks
+        - record
+        - refs
+        - safe-coerce
+        - st
+        - strings
+        - tailrec
+        - test-unit
+        - transformers
+        - tuples
+        - type-equality
+        - typelevel-prelude
+        - unfoldable
+        - unsafe-coerce
+        - unsafe-reference
+        - validation
+        - web-dom
+        - web-events
+        - web-file
+        - web-html
+        - web-storage
+  package_set:
+    address:
+      url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
+    compiler: ">=0.15.0 <0.16.0"
+    content:
+      ace:
+        repo: https://github.com/purescript-contrib/purescript-ace.git
+        version: v9.0.0
+        dependencies:
+          - arrays
+          - effect
+          - foreign
+          - nullable
+          - prelude
+          - web-html
+          - web-uievents
+      aff:
+        repo: https://github.com/purescript-contrib/purescript-aff.git
+        version: v7.0.0
+        dependencies:
+          - datetime
+          - effect
+          - exceptions
+          - functions
+          - parallel
+          - transformers
+          - unsafe-coerce
+      aff-bus:
+        repo: https://github.com/purescript-contrib/purescript-aff-bus.git
+        version: v6.0.0
+        dependencies:
+          - aff
+          - avar
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - lists
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+      aff-coroutines:
+        repo: https://github.com/purescript-contrib/purescript-aff-coroutines.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - avar
+          - coroutines
+          - effect
+      aff-promise:
+        repo: https://github.com/nwolverson/purescript-aff-promise.git
+        version: v4.0.0
+        dependencies:
+          - aff
+          - foreign
+      aff-retry:
+        repo: https://github.com/Unisay/purescript-aff-retry.git
+        version: v2.0.0
+        dependencies:
+          - aff
+          - arrays
+          - datetime
+          - effect
+          - either
+          - exceptions
+          - integers
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - random
+          - transformers
+      affjax:
+        repo: https://github.com/purescript-contrib/purescript-affjax.git
+        version: v13.0.0
+        dependencies:
+          - aff
+          - argonaut-core
+          - arraybuffer-types
+          - foreign
+          - form-urlencoded
+          - http-methods
+          - integers
+          - media-types
+          - nullable
+          - refs
+          - unsafe-coerce
+          - web-xhr
+      affjax-node:
+        repo: https://github.com/purescript-contrib/purescript-affjax-node.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - affjax
+          - either
+          - maybe
+          - prelude
+      affjax-web:
+        repo: https://github.com/purescript-contrib/purescript-affjax-web.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - affjax
+          - either
+          - maybe
+          - prelude
+      ansi:
+        repo: https://github.com/hdgarrood/purescript-ansi.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - lists
+          - strings
+      argonaut:
+        repo: https://github.com/purescript-contrib/purescript-argonaut.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - argonaut-traversals
+      argonaut-codecs:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-codecs.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-core
+          - arrays
+          - effect
+          - foreign-object
+          - identity
+          - integers
+          - maybe
+          - nonempty
+          - ordered-collections
+          - prelude
+          - record
+      argonaut-core:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-core.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - foreign-object
+          - functions
+          - gen
+          - maybe
+          - nonempty
+          - prelude
+          - strings
+          - tailrec
+      argonaut-generic:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-generic.git
+        version: v8.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - prelude
+          - record
+      argonaut-traversals:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-traversals.git
+        version: v10.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - profunctor-lenses
+      argparse-basic:
+        repo: https://github.com/natefaubion/purescript-argparse-basic.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - record
+          - strings
+          - tuples
+          - unfoldable
+      arraybuffer:
+        repo: https://github.com/purescript-contrib/purescript-arraybuffer.git
+        version: v13.0.0
+        dependencies:
+          - arraybuffer-types
+          - arrays
+          - effect
+          - float32
+          - functions
+          - gen
+          - maybe
+          - nullable
+          - prelude
+          - tailrec
+          - uint
+          - unfoldable
+      arraybuffer-builder:
+        repo: https://github.com/jamesdbrock/purescript-arraybuffer-builder.git
+        version: v3.0.1
+        dependencies:
+          - arraybuffer
+          - arraybuffer-types
+          - effect
+          - float32
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - transformers
+          - uint
+      arraybuffer-types:
+        repo: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
+        version: v3.0.2
+        dependencies: []
+      arrays:
+        repo: https://github.com/purescript/purescript-arrays.git
+        version: v7.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - foldable-traversable
+          - maybe
+          - nonempty
+          - partial
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - unfoldable
+          - unsafe-coerce
+      arrays-zipper:
+        repo: https://github.com/JordanMartinez/purescript-arrays-zipper.git
+        version: v2.0.1
+        dependencies:
+          - arrays
+          - control
+          - quickcheck
+      ask:
+        repo: https://github.com/Mateiadrielrafael/purescript-ask.git
+        version: v1.0.0
+        dependencies:
+          - unsafe-coerce
+      assert:
+        repo: https://github.com/purescript/purescript-assert.git
+        version: v6.0.0
+        dependencies:
+          - console
+          - effect
+          - prelude
+      avar:
+        repo: https://github.com/purescript-contrib/purescript-avar.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - exceptions
+          - functions
+          - maybe
+      b64:
+        repo: https://github.com/menelaos/purescript-b64.git
+        version: v0.0.8
+        dependencies:
+          - arraybuffer-types
+          - either
+          - encoding
+          - enums
+          - exceptions
+          - functions
+          - partial
+          - prelude
+          - strings
+      barlow-lens:
+        repo: https://github.com/sigma-andex/purescript-barlow-lens.git
+        version: v0.9.0
+        dependencies:
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - profunctor-lenses
+          - tuples
+          - typelevel-prelude
+      bifunctors:
+        repo: https://github.com/purescript/purescript-bifunctors.git
+        version: v6.0.0
+        dependencies:
+          - const
+          - either
+          - newtype
+          - prelude
+          - tuples
+      bigints:
+        repo: https://github.com/sharkdp/purescript-bigints.git
+        version: v7.0.1
+        dependencies:
+          - integers
+          - maybe
+          - strings
+      bower-json:
+        repo: https://github.com/klntsky/purescript-bower-json.git
+        version: v3.0.0
+        dependencies:
+          - argonaut-codecs
+          - arrays
+          - either
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - newtype
+          - prelude
+          - tuples
+      call-by-name:
+        repo: https://github.com/natefaubion/purescript-call-by-name.git
+        version: v4.0.1
+        dependencies:
+          - control
+          - either
+          - lazy
+          - maybe
+          - unsafe-coerce
+      canvas:
+        repo: https://github.com/purescript-web/purescript-canvas.git
+        version: v6.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - exceptions
+          - functions
+          - maybe
+      canvas-action:
+        repo: https://github.com/artemisSystem/purescript-canvas-action.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - arrays
+          - canvas
+          - colors
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - maybe
+          - numbers
+          - polymorphic-vectors
+          - prelude
+          - refs
+          - run
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-html
+      cartesian:
+        repo: https://github.com/Ebmtranceboy/purescript-cartesian.git
+        version: v1.0.6
+        dependencies:
+          - console
+          - effect
+          - integers
+          - psci-support
+      catenable-lists:
+        repo: https://github.com/purescript/purescript-catenable-lists.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - lists
+          - maybe
+          - prelude
+          - tuples
+          - unfoldable
+      channel:
+        repo: https://github.com/ConnorDillon/purescript-channel.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - assert
+          - avar
+          - console
+          - contravariant
+          - control
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - lazy
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      checked-exceptions:
+        repo: https://github.com/natefaubion/purescript-checked-exceptions.git
+        version: v3.1.1
+        dependencies:
+          - prelude
+          - transformers
+          - variant
+      codec:
+        repo: https://github.com/garyb/purescript-codec.git
+        version: v5.0.0
+        dependencies:
+          - profunctor
+          - transformers
+      codec-argonaut:
+        repo: https://github.com/garyb/purescript-codec-argonaut.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-core
+          - codec
+          - ordered-collections
+          - type-equality
+          - variant
+      colors:
+        repo: https://github.com/purescript-contrib/purescript-colors.git
+        version: v7.0.1
+        dependencies:
+          - arrays
+          - integers
+          - lists
+          - numbers
+          - partial
+          - strings
+      concurrent-queues:
+        repo: https://github.com/purescript-contrib/purescript-concurrent-queues.git
+        version: v3.0.0
+        dependencies:
+          - aff
+          - avar
+          - effect
+      console:
+        repo: https://github.com/purescript/purescript-console.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - prelude
+      const:
+        repo: https://github.com/purescript/purescript-const.git
+        version: v6.0.0
+        dependencies:
+          - invariant
+          - newtype
+          - prelude
+      contravariant:
+        repo: https://github.com/purescript/purescript-contravariant.git
+        version: v6.0.0
+        dependencies:
+          - const
+          - either
+          - newtype
+          - prelude
+          - tuples
+      control:
+        repo: https://github.com/purescript/purescript-control.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      convertable-options:
+        repo: https://github.com/natefaubion/purescript-convertable-options.git
+        version: v1.0.0
+        dependencies:
+          - console
+          - effect
+          - maybe
+          - record
+      coroutines:
+        repo: https://github.com/purescript-contrib/purescript-coroutines.git
+        version: v7.0.0
+        dependencies:
+          - freet
+          - parallel
+          - profunctor
+      css:
+        repo: https://github.com/purescript-contrib/purescript-css.git
+        version: v6.0.0
+        dependencies:
+          - colors
+          - console
+          - effect
+          - nonempty
+          - profunctor
+          - strings
+          - these
+          - transformers
+      datetime:
+        repo: https://github.com/purescript/purescript-datetime.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - either
+          - enums
+          - foldable-traversable
+          - functions
+          - gen
+          - integers
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - ordered-collections
+          - partial
+          - prelude
+          - tuples
+      datetime-parsing:
+        repo: https://github.com/flounders/purescript-datetime-parsing.git
+        version: v0.2.0
+        dependencies:
+          - arrays
+          - datetime
+          - either
+          - enums
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - numbers
+          - parsing
+          - prelude
+          - strings
+          - unicode
+      debug:
+        repo: https://github.com/garyb/purescript-debug.git
+        version: v6.0.0
+        dependencies:
+          - functions
+          - prelude
+      decimals:
+        repo: https://github.com/sharkdp/purescript-decimals.git
+        version: v7.0.0
+        dependencies:
+          - maybe
+      dissect:
+        repo: https://github.com/PureFunctor/purescript-dissect.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - foreign-object
+          - functors
+          - newtype
+          - partial
+          - prelude
+          - tailrec
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - variant
+      distributive:
+        repo: https://github.com/purescript/purescript-distributive.git
+        version: v6.0.0
+        dependencies:
+          - identity
+          - newtype
+          - prelude
+          - tuples
+          - type-equality
+      dodo-printer:
+        repo: https://github.com/natefaubion/purescript-dodo-printer.git
+        version: v2.2.0
+        dependencies:
+          - aff
+          - ansi
+          - avar
+          - console
+          - effect
+          - foldable-traversable
+          - lists
+          - maybe
+          - minibench
+          - node-child-process
+          - node-fs-aff
+          - node-process
+          - psci-support
+          - strings
+      dom-indexed:
+        repo: https://github.com/purescript-halogen/purescript-dom-indexed.git
+        version: v11.0.0
+        dependencies:
+          - media-types
+          - prelude
+          - web-clipboard
+          - web-pointerevents
+          - web-touchevents
+      droplet:
+        repo: https://github.com/easafe/purescript-droplet.git
+        version: v0.4.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - bigints
+          - datetime
+          - debug
+          - effect
+          - either
+          - enums
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - integers
+          - maybe
+          - newtype
+          - nullable
+          - ordered-collections
+          - partial
+          - prelude
+          - profunctor
+          - record
+          - spec
+          - strings
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+      dynamic-buffer:
+        repo: https://github.com/kritzcreek/purescript-dynamic-buffer.git
+        version: v3.0.1
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - refs
+      effect:
+        repo: https://github.com/purescript/purescript-effect.git
+        version: v4.0.0
+        dependencies:
+          - prelude
+      either:
+        repo: https://github.com/purescript/purescript-either.git
+        version: v6.1.0
+        dependencies:
+          - control
+          - invariant
+          - maybe
+          - prelude
+      elmish:
+        repo: https://github.com/collegevine/purescript-elmish.git
+        version: v0.8.1
+        dependencies:
+          - aff
+          - argonaut-core
+          - arrays
+          - bifunctors
+          - console
+          - debug
+          - effect
+          - either
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - functions
+          - integers
+          - js-date
+          - maybe
+          - nullable
+          - partial
+          - prelude
+          - refs
+          - typelevel-prelude
+          - undefined-is-not-a-problem
+          - unsafe-coerce
+          - web-dom
+          - web-html
+      elmish-enzyme:
+        repo: https://github.com/collegevine/purescript-elmish-enzyme.git
+        version: v0.1.1
+        dependencies:
+          - aff
+          - aff-promise
+          - arrays
+          - console
+          - debug
+          - effect
+          - elmish
+          - foldable-traversable
+          - foreign
+          - functions
+          - prelude
+          - transformers
+          - unsafe-coerce
+      elmish-hooks:
+        repo: https://github.com/collegevine/purescript-elmish-hooks.git
+        version: v0.8.2
+        dependencies:
+          - aff
+          - debug
+          - elmish
+          - maybe
+          - prelude
+          - tuples
+          - undefined-is-not-a-problem
+      elmish-html:
+        repo: https://github.com/collegevine/purescript-elmish-html.git
+        version: v0.7.1
+        dependencies:
+          - effect
+          - elmish
+          - foreign
+          - foreign-object
+          - prelude
+          - record
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-html
+      email-validate:
+        repo: https://github.com/cdepillabout/purescript-email-validate.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - string-parsers
+          - transformers
+      encoding:
+        repo: https://github.com/menelaos/purescript-encoding.git
+        version: v0.0.8
+        dependencies:
+          - arraybuffer-types
+          - either
+          - exceptions
+          - functions
+          - prelude
+      enums:
+        repo: https://github.com/purescript/purescript-enums.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - either
+          - gen
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tuples
+          - unfoldable
+      exceptions:
+        repo: https://github.com/purescript/purescript-exceptions.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - either
+          - maybe
+          - prelude
+      exists:
+        repo: https://github.com/purescript/purescript-exists.git
+        version: v6.0.0
+        dependencies:
+          - unsafe-coerce
+      exitcodes:
+        repo: https://github.com/Risto-Stevcev/purescript-exitcodes.git
+        version: v4.0.0
+        dependencies:
+          - enums
+      expect-inferred:
+        repo: https://github.com/justinwoo/purescript-expect-inferred.git
+        version: v3.0.0
+        dependencies:
+          - prelude
+          - typelevel-prelude
+      fast-vect:
+        repo: https://github.com/sigma-andex/purescript-fast-vect.git
+        version: v0.7.0
+        dependencies:
+          - arrays
+          - filterable
+          - foldable-traversable
+          - lists
+          - maybe
+          - ordered-collections
+          - prelude
+          - profunctor
+          - tuples
+          - unfoldable
+      filterable:
+        repo: https://github.com/purescript/purescript-filterable.git
+        version: v5.0.0
+        dependencies:
+          - arrays
+          - either
+          - foldable-traversable
+          - identity
+          - lists
+          - ordered-collections
+      fixed-points:
+        repo: https://github.com/purescript-contrib/purescript-fixed-points.git
+        version: v7.0.0
+        dependencies:
+          - exists
+          - newtype
+          - prelude
+          - transformers
+      fixed-precision:
+        repo: https://github.com/lumihq/purescript-fixed-precision.git
+        version: v5.0.0
+        dependencies:
+          - arrays
+          - bigints
+          - control
+          - integers
+          - maybe
+          - numbers
+          - partial
+          - prelude
+          - strings
+      flame:
+        repo: https://github.com/easafe/purescript-flame.git
+        version: v1.2.0
+        dependencies:
+          - aff
+          - argonaut-codecs
+          - argonaut-core
+          - argonaut-generic
+          - arrays
+          - bifunctors
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - maybe
+          - newtype
+          - nullable
+          - partial
+          - prelude
+          - random
+          - refs
+          - spec
+          - strings
+          - tuples
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-html
+          - web-uievents
+      float32:
+        repo: https://github.com/purescript-contrib/purescript-float32.git
+        version: v2.0.0
+        dependencies:
+          - gen
+          - maybe
+          - prelude
+      foldable-traversable:
+        repo: https://github.com/purescript/purescript-foldable-traversable.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - const
+          - control
+          - either
+          - functors
+          - identity
+          - maybe
+          - newtype
+          - orders
+          - prelude
+          - tuples
+      foreign:
+        repo: https://github.com/purescript/purescript-foreign.git
+        version: v7.0.0
+        dependencies:
+          - either
+          - functions
+          - identity
+          - integers
+          - lists
+          - maybe
+          - prelude
+          - strings
+          - transformers
+      foreign-object:
+        repo: https://github.com/purescript/purescript-foreign-object.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - functions
+          - gen
+          - lists
+          - maybe
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - typelevel-prelude
+          - unfoldable
+      foreign-readwrite:
+        repo: https://github.com/artemisSystem/purescript-foreign-readwrite.git
+        version: v3.0.0
+        dependencies:
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - record
+          - safe-coerce
+          - transformers
+          - unsafe-coerce
+      fork:
+        repo: https://github.com/purescript-contrib/purescript-fork.git
+        version: v6.0.0
+        dependencies:
+          - aff
+      form-urlencoded:
+        repo: https://github.com/purescript-contrib/purescript-form-urlencoded.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - js-uri
+          - maybe
+          - newtype
+          - prelude
+          - strings
+          - tuples
+      formatters:
+        repo: https://github.com/purescript-contrib/purescript-formatters.git
+        version: v7.0.0
+        dependencies:
+          - datetime
+          - fixed-points
+          - lists
+          - numbers
+          - parsing
+          - prelude
+          - transformers
+      free:
+        repo: https://github.com/purescript/purescript-free.git
+        version: v7.0.0
+        dependencies:
+          - catenable-lists
+          - control
+          - distributive
+          - either
+          - exists
+          - foldable-traversable
+          - invariant
+          - lazy
+          - maybe
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+      freeap:
+        repo: https://github.com/ethul/purescript-freeap.git
+        version: v7.0.0
+        dependencies:
+          - const
+          - exists
+          - gen
+          - lists
+      freet:
+        repo: https://github.com/purescript-contrib/purescript-freet.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - bifunctors
+          - effect
+          - either
+          - exists
+          - free
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      functions:
+        repo: https://github.com/purescript/purescript-functions.git
+        version: v6.0.0
+        dependencies:
+          - prelude
+      functors:
+        repo: https://github.com/purescript/purescript-functors.git
+        version: v5.0.0
+        dependencies:
+          - bifunctors
+          - const
+          - contravariant
+          - control
+          - distributive
+          - either
+          - invariant
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - tuples
+          - unsafe-coerce
+      fuzzy:
+        repo: https://github.com/citizennet/purescript-fuzzy.git
+        version: v0.4.0
+        dependencies:
+          - foldable-traversable
+          - foreign-object
+          - newtype
+          - ordered-collections
+          - prelude
+          - rationals
+          - strings
+          - tuples
+      gen:
+        repo: https://github.com/purescript/purescript-gen.git
+        version: v4.0.0
+        dependencies:
+          - either
+          - foldable-traversable
+          - identity
+          - maybe
+          - newtype
+          - nonempty
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      generate-values:
+        repo: https://github.com/jordanmartinez/purescript-generate-values.git
+        version: v1.0.1
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - enums
+          - foldable-traversable
+          - gen
+          - identity
+          - integers
+          - lcg
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - partial
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      geometry-plane:
+        repo: https://github.com/Ebmtranceboy/purescript-geometry-plane.git
+        version: v1.0.3
+        dependencies:
+          - console
+          - effect
+          - psci-support
+          - sparse-polynomials
+      github-actions-toolkit:
+        repo: https://github.com/purescript-contrib/purescript-github-actions-toolkit.git
+        version: v0.5.0
+        dependencies:
+          - aff
+          - aff-promise
+          - effect
+          - foreign-object
+          - node-buffer
+          - node-path
+          - node-streams
+          - nullable
+          - transformers
+      graphs:
+        repo: https://github.com/purescript/purescript-graphs.git
+        version: v8.0.0
+        dependencies:
+          - catenable-lists
+          - ordered-collections
+      group:
+        repo: https://github.com/morganthomas/purescript-group.git
+        version: v4.1.1
+        dependencies:
+          - lists
+      halogen:
+        repo: https://github.com/purescript-halogen/purescript-halogen.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - avar
+          - console
+          - const
+          - dom-indexed
+          - effect
+          - foreign
+          - fork
+          - free
+          - freeap
+          - halogen-subscriptions
+          - halogen-vdom
+          - media-types
+          - nullable
+          - ordered-collections
+          - parallel
+          - profunctor
+          - transformers
+          - unsafe-coerce
+          - unsafe-reference
+          - web-file
+          - web-uievents
+      halogen-css:
+        repo: https://github.com/purescript-halogen/purescript-halogen-css.git
+        version: v10.0.0
+        dependencies:
+          - css
+          - halogen
+      halogen-formless:
+        repo: https://github.com/thomashoneyman/purescript-halogen-formless.git
+        version: v4.0.0
+        dependencies:
+          - convertable-options
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - halogen
+          - heterogeneous
+          - maybe
+          - prelude
+          - record
+          - safe-coerce
+          - type-equality
+          - unsafe-coerce
+          - unsafe-reference
+          - variant
+          - web-events
+          - web-uievents
+      halogen-hooks:
+        repo: https://github.com/thomashoneyman/purescript-halogen-hooks.git
+        version: v0.6.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - effect
+          - exceptions
+          - foldable-traversable
+          - foreign-object
+          - free
+          - freeap
+          - halogen
+          - halogen-subscriptions
+          - maybe
+          - newtype
+          - ordered-collections
+          - parallel
+          - partial
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+          - unsafe-reference
+          - web-dom
+          - web-html
+      halogen-hooks-extra:
+        repo: https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git
+        version: v0.9.0
+        dependencies:
+          - halogen-hooks
+      halogen-store:
+        repo: https://github.com/thomashoneyman/purescript-halogen-store.git
+        version: v0.5.0
+        dependencies:
+          - aff
+          - distributive
+          - effect
+          - fork
+          - halogen
+          - halogen-hooks
+          - halogen-subscriptions
+          - maybe
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-reference
+      halogen-storybook:
+        repo: https://github.com/rnons/purescript-halogen-storybook.git
+        version: v2.0.0
+        dependencies:
+          - foreign-object
+          - halogen
+          - prelude
+          - routing
+      halogen-subscriptions:
+        repo: https://github.com/purescript-halogen/purescript-halogen-subscriptions.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - effect
+          - foldable-traversable
+          - functors
+          - refs
+          - safe-coerce
+          - unsafe-reference
+      halogen-svg-elems:
+        repo: https://github.com/JordanMartinez/purescript-halogen-svg-elems.git
+        version: v6.0.0
+        dependencies:
+          - halogen
+      halogen-vdom:
+        repo: https://github.com/purescript-halogen/purescript-halogen-vdom.git
+        version: v8.0.0
+        dependencies:
+          - bifunctors
+          - effect
+          - foreign
+          - foreign-object
+          - maybe
+          - prelude
+          - refs
+          - tuples
+          - unsafe-coerce
+          - web-html
+      halogen-vdom-string-renderer:
+        repo: https://github.com/purescript-halogen/purescript-halogen-vdom-string-renderer.git
+        version: v0.5.0
+        dependencies:
+          - foreign
+          - halogen-vdom
+          - ordered-collections
+          - prelude
+      heckin:
+        repo: https://github.com/maxdeviant/purescript-heckin.git
+        version: v2.0.1
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - maybe
+          - prelude
+          - strings
+          - transformers
+          - tuples
+          - unicode
+      heterogeneous:
+        repo: https://github.com/natefaubion/purescript-heterogeneous.git
+        version: v0.6.0
+        dependencies:
+          - either
+          - functors
+          - prelude
+          - record
+          - tuples
+          - variant
+      heterogeneous-extrablatt:
+        repo: https://github.com/sigma-andex/purescript-heterogeneous-extrablatt.git
+        version: v0.2.1
+        dependencies:
+          - heterogeneous
+          - prelude
+          - record
+      http-methods:
+        repo: https://github.com/purescript-contrib/purescript-http-methods.git
+        version: v6.0.0
+        dependencies:
+          - either
+          - prelude
+          - strings
+      httpure:
+        repo: https://github.com/citizennet/purescript-httpure.git
+        version: v0.15.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - js-uri
+          - maybe
+          - newtype
+          - node-buffer
+          - node-fs
+          - node-http
+          - node-streams
+          - options
+          - ordered-collections
+          - prelude
+          - refs
+          - strings
+          - tuples
+          - type-equality
+      httpurple:
+        repo: https://github.com/sigma-andex/purescript-httpurple.git
+        version: v1.3.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - js-uri
+          - justifill
+          - maybe
+          - newtype
+          - node-buffer
+          - node-fs
+          - node-http
+          - node-net
+          - node-process
+          - node-streams
+          - options
+          - ordered-collections
+          - posix-types
+          - prelude
+          - profunctor
+          - record
+          - refs
+          - routing-duplex
+          - strings
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+      httpurple-argonaut:
+        repo: https://github.com/sigma-andex/purescript-httpurple-argonaut.git
+        version: v1.0.1
+        dependencies:
+          - argonaut
+          - console
+          - effect
+          - either
+          - httpurple
+          - prelude
+      httpurple-yoga-json:
+        repo: https://github.com/sigma-andex/purescript-httpurple-yoga-json.git
+        version: v1.0.0
+        dependencies:
+          - console
+          - effect
+          - either
+          - foreign
+          - httpurple
+          - lists
+          - prelude
+          - yoga-json
+      identity:
+        repo: https://github.com/purescript/purescript-identity.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - invariant
+          - newtype
+          - prelude
+      indexed-monad:
+        repo: https://github.com/garyb/purescript-indexed-monad.git
+        version: v2.1.0
+        dependencies:
+          - control
+          - newtype
+      int64:
+        repo: https://github.com/purescript-contrib/purescript-int64.git
+        version: v2.0.0
+        dependencies:
+          - effect
+          - foreign
+          - functions
+          - integers
+          - maybe
+          - nullable
+          - prelude
+          - quickcheck
+      integers:
+        repo: https://github.com/purescript/purescript-integers.git
+        version: v6.0.0
+        dependencies:
+          - maybe
+          - numbers
+          - prelude
+      interpolate:
+        repo: https://github.com/jordanmartinez/purescript-interpolate.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+      invariant:
+        repo: https://github.com/purescript/purescript-invariant.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - prelude
+      js-date:
+        repo: https://github.com/purescript-contrib/purescript-js-date.git
+        version: v8.0.0
+        dependencies:
+          - datetime
+          - effect
+          - exceptions
+          - foreign
+          - integers
+          - now
+      js-fileio:
+        repo: https://github.com/newlandsvalley/purescript-js-fileio.git
+        version: v3.0.0
+        dependencies:
+          - aff
+          - effect
+          - prelude
+      js-timers:
+        repo: https://github.com/purescript-contrib/purescript-js-timers.git
+        version: v6.1.0
+        dependencies:
+          - effect
+      js-uri:
+        repo: https://github.com/purescript-contrib/purescript-js-uri.git
+        version: v3.0.0
+        dependencies:
+          - functions
+          - maybe
+      justifill:
+        repo: https://github.com/i-am-the-slime/purescript-justifill.git
+        version: v0.5.0
+        dependencies:
+          - maybe
+          - prelude
+          - record
+          - typelevel-prelude
+      jwt:
+        repo: https://github.com/menelaos/purescript-jwt.git
+        version: v0.0.9
+        dependencies:
+          - argonaut-core
+          - arrays
+          - b64
+          - either
+          - exceptions
+          - prelude
+          - profunctor-lenses
+          - strings
+      language-cst-parser:
+        repo: https://github.com/natefaubion/purescript-language-cst-parser.git
+        version: v0.12.0
+        dependencies:
+          - arrays
+          - const
+          - control
+          - either
+          - foldable-traversable
+          - free
+          - functions
+          - functors
+          - identity
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - ordered-collections
+          - partial
+          - prelude
+          - st
+          - strings
+          - transformers
+          - tuples
+          - typelevel-prelude
+          - unfoldable
+          - unsafe-coerce
+      lazy:
+        repo: https://github.com/purescript/purescript-lazy.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - invariant
+          - prelude
+      lcg:
+        repo: https://github.com/purescript/purescript-lcg.git
+        version: v4.0.0
+        dependencies:
+          - effect
+          - integers
+          - maybe
+          - partial
+          - prelude
+          - random
+      leibniz:
+        repo: https://github.com/paf31/purescript-leibniz.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+          - unsafe-coerce
+      linalg:
+        repo: https://github.com/gbagan/purescript-linalg.git
+        version: v5.1.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - functions
+          - maybe
+          - prelude
+          - tuples
+      lists:
+        repo: https://github.com/purescript/purescript-lists.git
+        version: v7.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - foldable-traversable
+          - lazy
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      logging:
+        repo: https://github.com/rightfold/purescript-logging.git
+        version: v3.0.0
+        dependencies:
+          - console
+          - contravariant
+          - effect
+          - either
+          - prelude
+          - transformers
+          - tuples
+      machines:
+        repo: https://github.com/purescript-contrib/purescript-machines.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - lists
+          - maybe
+          - prelude
+          - profunctor
+          - tuples
+          - unfoldable
+      matrices:
+        repo: https://github.com/kRITZCREEK/purescript-matrices.git
+        version: v5.0.1
+        dependencies:
+          - arrays
+          - strings
+      matryoshka:
+        repo: https://github.com/purescript-contrib/purescript-matryoshka.git
+        version: v1.0.0
+        dependencies:
+          - fixed-points
+          - free
+          - prelude
+          - profunctor
+          - transformers
+      maybe:
+        repo: https://github.com/purescript/purescript-maybe.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - invariant
+          - newtype
+          - prelude
+      media-types:
+        repo: https://github.com/purescript-contrib/purescript-media-types.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      metadata:
+        repo: https://github.com/purescript/purescript-metadata.git
+        version: v0.15.0
+        dependencies: []
+      midi:
+        repo: https://github.com/newlandsvalley/purescript-midi.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - ordered-collections
+          - prelude
+          - signal
+          - string-parsers
+          - strings
+          - tuples
+          - unfoldable
+      minibench:
+        repo: https://github.com/purescript/purescript-minibench.git
+        version: v4.0.0
+        dependencies:
+          - console
+          - effect
+          - integers
+          - numbers
+          - partial
+          - prelude
+          - refs
+      mmorph:
+        repo: https://github.com/Thimoteus/purescript-mmorph.git
+        version: v7.0.0
+        dependencies:
+          - free
+          - functors
+          - transformers
+      monad-control:
+        repo: https://github.com/athanclark/purescript-monad-control.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - freet
+          - identity
+          - lists
+      monad-logger:
+        repo: https://github.com/cprussin/purescript-monad-logger.git
+        version: v1.3.1
+        dependencies:
+          - aff
+          - ansi
+          - argonaut
+          - arrays
+          - console
+          - control
+          - effect
+          - foldable-traversable
+          - foreign-object
+          - integers
+          - js-date
+          - maybe
+          - newtype
+          - ordered-collections
+          - prelude
+          - strings
+          - transformers
+          - tuples
+      monad-loops:
+        repo: https://github.com/mlang/purescript-monad-loops.git
+        version: v0.5.0
+        dependencies:
+          - lists
+          - maybe
+          - prelude
+          - tailrec
+          - tuples
+      monad-unlift:
+        repo: https://github.com/athanclark/purescript-monad-unlift.git
+        version: v1.0.1
+        dependencies:
+          - monad-control
+      monoidal:
+        repo: https://github.com/mcneissue/purescript-monoidal.git
+        version: v0.16.0
+        dependencies:
+          - either
+          - profunctor
+          - these
+          - tuples
+      morello:
+        repo: https://github.com/sigma-andex/purescript-morello.git
+        version: v0.3.2
+        dependencies:
+          - arrays
+          - barlow-lens
+          - foldable-traversable
+          - heterogeneous
+          - heterogeneous-extrablatt
+          - newtype
+          - prelude
+          - profunctor
+          - profunctor-lenses
+          - record
+          - tuples
+          - typelevel-prelude
+          - validation
+      motsunabe:
+        repo: https://github.com/justinwoo/purescript-motsunabe.git
+        version: v2.0.0
+        dependencies:
+          - lists
+          - strings
+      nano-id:
+        repo: https://github.com/eikooc/nano-id.git
+        version: v1.1.0
+        dependencies:
+          - aff
+          - effect
+          - lists
+          - maybe
+          - prelude
+          - random
+          - spec
+          - strings
+          - stringutils
+      naturals:
+        repo: https://github.com/LiamGoodacre/purescript-naturals.git
+        version: v3.0.0
+        dependencies:
+          - enums
+          - maybe
+          - prelude
+      nested-functor:
+        repo: https://github.com/acple/purescript-nested-functor.git
+        version: v0.2.1
+        dependencies:
+          - prelude
+          - type-equality
+      newtype:
+        repo: https://github.com/purescript/purescript-newtype.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+          - safe-coerce
+      node-buffer:
+        repo: https://github.com/purescript-node/purescript-node-buffer.git
+        version: v8.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - maybe
+          - st
+          - unsafe-coerce
+      node-buffer-blob:
+        repo: https://github.com/purescript-node/purescript-node-buffer-blob.git
+        version: v1.0.0
+        dependencies:
+          - aff-promise
+          - arraybuffer-types
+          - arrays
+          - console
+          - effect
+          - maybe
+          - media-types
+          - newtype
+          - node-buffer
+          - nullable
+          - prelude
+          - web-streams
+      node-child-process:
+        repo: https://github.com/purescript-node/purescript-node-child-process.git
+        version: v9.0.0
+        dependencies:
+          - exceptions
+          - foreign
+          - foreign-object
+          - functions
+          - node-fs
+          - node-streams
+          - nullable
+          - posix-types
+          - unsafe-coerce
+      node-fs:
+        repo: https://github.com/purescript-node/purescript-node-fs.git
+        version: v8.0.0
+        dependencies:
+          - datetime
+          - effect
+          - either
+          - enums
+          - exceptions
+          - functions
+          - integers
+          - js-date
+          - maybe
+          - node-buffer
+          - node-path
+          - node-streams
+          - nullable
+          - partial
+          - prelude
+          - strings
+          - unsafe-coerce
+      node-fs-aff:
+        repo: https://github.com/purescript-node/purescript-node-fs-aff.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - either
+          - node-fs
+          - node-path
+      node-http:
+        repo: https://github.com/purescript-node/purescript-node-http.git
+        version: v8.0.0
+        dependencies:
+          - arraybuffer-types
+          - contravariant
+          - effect
+          - foreign
+          - foreign-object
+          - maybe
+          - node-buffer
+          - node-net
+          - node-streams
+          - node-url
+          - nullable
+          - options
+          - prelude
+          - unsafe-coerce
+      node-net:
+        repo: https://github.com/purescript-node/purescript-node-net.git
+        version: v4.0.0
+        dependencies:
+          - effect
+          - either
+          - exceptions
+          - foreign
+          - maybe
+          - node-buffer
+          - node-fs
+          - nullable
+          - options
+          - prelude
+          - transformers
+      node-path:
+        repo: https://github.com/purescript-node/purescript-node-path.git
+        version: v5.0.0
+        dependencies:
+          - effect
+      node-process:
+        repo: https://github.com/purescript-node/purescript-node-process.git
+        version: v10.0.0
+        dependencies:
+          - effect
+          - foreign-object
+          - maybe
+          - node-streams
+          - posix-types
+          - prelude
+          - unsafe-coerce
+      node-readline:
+        repo: https://github.com/purescript-node/purescript-node-readline.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - foreign
+          - node-process
+          - node-streams
+          - options
+          - prelude
+      node-streams:
+        repo: https://github.com/purescript-node/purescript-node-streams.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - either
+          - exceptions
+          - node-buffer
+          - nullable
+          - prelude
+      node-streams-aff:
+        repo: https://github.com/jamesdbrock/purescript-node-streams-aff.git
+        version: v2.0.0
+        dependencies:
+          - aff
+          - arrays
+          - effect
+          - either
+          - exceptions
+          - maybe
+          - node-buffer
+          - node-streams
+          - prelude
+          - st
+          - tuples
+      node-url:
+        repo: https://github.com/purescript-node/purescript-node-url.git
+        version: v6.0.0
+        dependencies:
+          - nullable
+      nonempty:
+        repo: https://github.com/purescript/purescript-nonempty.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - maybe
+          - prelude
+          - tuples
+          - unfoldable
+      now:
+        repo: https://github.com/purescript-contrib/purescript-now.git
+        version: v6.0.0
+        dependencies:
+          - datetime
+          - effect
+      npm-package-json:
+        repo: https://github.com/maxdeviant/purescript-npm-package-json.git
+        version: v2.0.0
+        dependencies:
+          - argonaut
+          - control
+          - either
+          - foreign-object
+          - maybe
+          - ordered-collections
+          - prelude
+      nullable:
+        repo: https://github.com/purescript-contrib/purescript-nullable.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - functions
+          - maybe
+      numbers:
+        repo: https://github.com/purescript/purescript-numbers.git
+        version: v9.0.0
+        dependencies:
+          - functions
+          - maybe
+      open-folds:
+        repo: https://github.com/purescript-open-community/purescript-open-folds.git
+        version: v6.3.0
+        dependencies:
+          - bifunctors
+          - console
+          - control
+          - distributive
+          - effect
+          - either
+          - foldable-traversable
+          - identity
+          - invariant
+          - maybe
+          - newtype
+          - ordered-collections
+          - prelude
+          - profunctor
+          - psci-support
+          - tuples
+      open-memoize:
+        repo: https://github.com/purescript-open-community/purescript-open-memoize.git
+        version: v6.1.0
+        dependencies:
+          - console
+          - effect
+          - either
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - psci-support
+          - strings
+          - tuples
+      open-pairing:
+        repo: https://github.com/purescript-open-community/purescript-open-pairing.git
+        version: v6.1.0
+        dependencies:
+          - console
+          - control
+          - effect
+          - either
+          - free
+          - functors
+          - identity
+          - newtype
+          - prelude
+          - psci-support
+          - transformers
+          - tuples
+      options:
+        repo: https://github.com/purescript-contrib/purescript-options.git
+        version: v7.0.0
+        dependencies:
+          - contravariant
+          - foreign
+          - foreign-object
+          - maybe
+          - tuples
+      optparse:
+        repo: https://github.com/f-o-a-m/purescript-optparse.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - control
+          - effect
+          - either
+          - enums
+          - exists
+          - exitcodes
+          - foldable-traversable
+          - free
+          - gen
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - newtype
+          - node-buffer
+          - node-process
+          - node-streams
+          - nonempty
+          - numbers
+          - open-memoize
+          - partial
+          - prelude
+          - quickcheck
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+      ordered-collections:
+        repo: https://github.com/purescript/purescript-ordered-collections.git
+        version: v3.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - gen
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - unfoldable
+      ordered-set:
+        repo: https://github.com/flip111/purescript-ordered-set.git
+        version: v0.4.0
+        dependencies:
+          - argonaut-codecs
+          - arrays
+          - partial
+          - prelude
+          - unfoldable
+      orders:
+        repo: https://github.com/purescript/purescript-orders.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      pairs:
+        repo: https://github.com/sharkdp/purescript-pairs.git
+        version: v9.0.0
+        dependencies:
+          - console
+          - distributive
+          - foldable-traversable
+          - quickcheck
+      parallel:
+        repo: https://github.com/purescript/purescript-parallel.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - functors
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - refs
+          - transformers
+      parsing:
+        repo: https://github.com/purescript-contrib/purescript-parsing.git
+        version: v9.1.0
+        dependencies:
+          - arrays
+          - either
+          - foldable-traversable
+          - identity
+          - integers
+          - lists
+          - maybe
+          - nullable
+          - prelude
+          - strings
+          - transformers
+          - unicode
+      parsing-dataview:
+        repo: https://github.com/jamesdbrock/purescript-parsing-dataview.git
+        version: v3.1.0
+        dependencies:
+          - arraybuffer
+          - arraybuffer-types
+          - effect
+          - float32
+          - maybe
+          - parsing
+          - prelude
+          - transformers
+          - tuples
+          - uint
+      partial:
+        repo: https://github.com/purescript/purescript-partial.git
+        version: v4.0.0
+        dependencies: []
+      pathy:
+        repo: https://github.com/purescript-contrib/purescript-pathy.git
+        version: v9.0.0
+        dependencies:
+          - console
+          - exceptions
+          - lists
+          - partial
+          - profunctor
+          - strings
+          - transformers
+          - typelevel-prelude
+          - unsafe-coerce
+      pha:
+        repo: https://github.com/gbagan/purescript-pha.git
+        version: v0.9.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - datetime
+          - effect
+          - foldable-traversable
+          - free
+          - integers
+          - maybe
+          - prelude
+          - profunctor-lenses
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+          - unsafe-reference
+          - web-dom
+          - web-events
+          - web-html
+          - web-pointerevents
+          - web-uievents
+      phaser:
+        repo: https://github.com/lfarroco/purescript-phaser.git
+        version: v0.6.0
+        dependencies:
+          - canvas
+          - console
+          - effect
+          - maybe
+          - nullable
+          - options
+          - prelude
+          - web-html
+      pipes:
+        repo: https://github.com/felixschl/purescript-pipes.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - lists
+          - mmorph
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      point-free:
+        repo: https://github.com/ursi/purescript-point-free.git
+        version: v1.0.0
+        dependencies:
+          - prelude
+      polymorphic-vectors:
+        repo: https://github.com/artemisSystem/purescript-polymorphic-vectors.git
+        version: v4.0.0
+        dependencies:
+          - distributive
+          - foldable-traversable
+          - numbers
+          - prelude
+          - record
+          - safe-coerce
+          - type-equality
+          - typelevel-prelude
+      posix-types:
+        repo: https://github.com/purescript-node/purescript-posix-types.git
+        version: v6.0.0
+        dependencies:
+          - maybe
+          - prelude
+      precise:
+        repo: https://github.com/purescript-contrib/purescript-precise.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - exceptions
+          - gen
+          - integers
+          - lists
+          - numbers
+          - prelude
+          - strings
+      precise-datetime:
+        repo: https://github.com/awakesecurity/purescript-precise-datetime.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - datetime
+          - decimals
+          - either
+          - enums
+          - foldable-traversable
+          - formatters
+          - integers
+          - js-date
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - strings
+          - tuples
+          - unicode
+      prelude:
+        repo: https://github.com/purescript/purescript-prelude.git
+        version: v6.0.0
+        dependencies: []
+      prettier-printer:
+        repo: https://github.com/paulyoung/purescript-prettier-printer.git
+        version: v3.0.0
+        dependencies:
+          - console
+          - lists
+          - prelude
+          - strings
+          - tuples
+      profunctor:
+        repo: https://github.com/purescript/purescript-profunctor.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - distributive
+          - either
+          - exists
+          - invariant
+          - newtype
+          - prelude
+          - tuples
+      profunctor-lenses:
+        repo: https://github.com/purescript-contrib/purescript-profunctor-lenses.git
+        version: v8.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - const
+          - control
+          - distributive
+          - either
+          - foldable-traversable
+          - foreign-object
+          - functors
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - ordered-collections
+          - partial
+          - prelude
+          - profunctor
+          - record
+          - transformers
+          - tuples
+      protobuf:
+        repo: https://github.com/xc-jp/purescript-protobuf.git
+        version: v4.0.0
+        dependencies:
+          - arraybuffer
+          - arraybuffer-builder
+          - arraybuffer-types
+          - arrays
+          - control
+          - effect
+          - either
+          - enums
+          - exceptions
+          - float32
+          - foldable-traversable
+          - functions
+          - int64
+          - maybe
+          - newtype
+          - parsing
+          - parsing-dataview
+          - prelude
+          - record
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+          - uint
+          - web-encoding
+      ps-cst:
+        repo: https://github.com/purescript-codegen/purescript-ps-cst.git
+        version: v1.2.0
+        dependencies:
+          - ansi
+          - console
+          - dodo-printer
+          - effect
+          - node-fs-aff
+          - node-path
+          - psci-support
+          - record
+          - strings
+      psa-utils:
+        repo: https://github.com/natefaubion/purescript-psa-utils.git
+        version: v8.0.0
+        dependencies:
+          - ansi
+          - argonaut-codecs
+          - argonaut-core
+          - arrays
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - maybe
+          - node-path
+          - ordered-collections
+          - prelude
+          - strings
+          - tuples
+          - unsafe-coerce
+      psc-ide:
+        repo: https://github.com/kRITZCREEK/purescript-psc-ide.git
+        version: v19.0.0
+        dependencies:
+          - aff
+          - argonaut
+          - arrays
+          - console
+          - maybe
+          - node-child-process
+          - node-fs
+          - parallel
+          - random
+      psci-support:
+        repo: https://github.com/purescript/purescript-psci-support.git
+        version: v6.0.0
+        dependencies:
+          - console
+          - effect
+          - prelude
+      qualified-do:
+        repo: https://github.com/artemisSystem/purescript-qualified-do.git
+        version: v2.2.0
+        dependencies:
+          - arrays
+          - control
+          - foldable-traversable
+          - parallel
+          - prelude
+          - unfoldable
+      quantities:
+        repo: https://github.com/sharkdp/purescript-quantities.git
+        version: v12.0.1
+        dependencies:
+          - decimals
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - newtype
+          - nonempty
+          - numbers
+          - pairs
+          - prelude
+          - tuples
+      quickcheck:
+        repo: https://github.com/purescript/purescript-quickcheck.git
+        version: v8.0.1
+        dependencies:
+          - arrays
+          - console
+          - control
+          - effect
+          - either
+          - enums
+          - exceptions
+          - foldable-traversable
+          - gen
+          - identity
+          - integers
+          - lazy
+          - lcg
+          - lists
+          - maybe
+          - newtype
+          - nonempty
+          - numbers
+          - partial
+          - prelude
+          - record
+          - st
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+          - unfoldable
+      quickcheck-combinators:
+        repo: https://github.com/athanclark/purescript-quickcheck-combinators.git
+        version: v0.1.3
+        dependencies:
+          - quickcheck
+          - typelevel
+      quickcheck-laws:
+        repo: https://github.com/purescript-contrib/purescript-quickcheck-laws.git
+        version: v7.0.0
+        dependencies:
+          - enums
+          - quickcheck
+      quickcheck-utf8:
+        repo: https://github.com/openchronology/purescript-quickcheck-utf8.git
+        version: v0.0.0
+        dependencies:
+          - quickcheck
+      quotient:
+        repo: https://github.com/rightfold/purescript-quotient.git
+        version: v3.0.0
+        dependencies:
+          - prelude
+          - quickcheck
+      random:
+        repo: https://github.com/purescript/purescript-random.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - integers
+      rationals:
+        repo: https://github.com/anttih/purescript-rationals.git
+        version: v5.0.0
+        dependencies:
+          - integers
+          - prelude
+      react:
+        repo: https://github.com/purescript-contrib/purescript-react.git
+        version: v10.0.1
+        dependencies:
+          - effect
+          - exceptions
+          - maybe
+          - nullable
+          - prelude
+          - typelevel-prelude
+          - unsafe-coerce
+      react-basic:
+        repo: https://github.com/lumihq/purescript-react-basic.git
+        version: v17.0.0
+        dependencies:
+          - effect
+          - prelude
+          - record
+      react-basic-dom:
+        repo: https://github.com/lumihq/purescript-react-basic-dom.git
+        version: v5.0.0
+        dependencies:
+          - effect
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - nullable
+          - prelude
+          - react-basic
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-file
+          - web-html
+      react-basic-hooks:
+        repo: https://github.com/megamaddu/purescript-react-basic-hooks.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - aff-promise
+          - bifunctors
+          - console
+          - control
+          - datetime
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - functions
+          - indexed-monad
+          - integers
+          - maybe
+          - newtype
+          - now
+          - nullable
+          - ordered-collections
+          - prelude
+          - react-basic
+          - refs
+          - tuples
+          - type-equality
+          - unsafe-coerce
+          - unsafe-reference
+          - web-html
+      react-dom:
+        repo: https://github.com/purescript-contrib/purescript-react-dom.git
+        version: v8.0.0
+        dependencies:
+          - effect
+          - react
+          - web-dom
+      read:
+        repo: https://github.com/truqu/purescript-read.git
+        version: v1.0.1
+        dependencies:
+          - maybe
+          - prelude
+          - strings
+      record:
+        repo: https://github.com/purescript/purescript-record.git
+        version: v4.0.0
+        dependencies:
+          - functions
+          - prelude
+          - unsafe-coerce
+      refined:
+        repo: https://github.com/danieljharvey/purescript-refined.git
+        version: v1.0.0
+        dependencies:
+          - argonaut
+          - effect
+          - prelude
+          - quickcheck
+          - typelevel
+      refs:
+        repo: https://github.com/purescript/purescript-refs.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - prelude
+      remotedata:
+        repo: https://github.com/krisajenkins/purescript-remotedata.git
+        version: v5.0.0
+        dependencies:
+          - bifunctors
+          - either
+          - profunctor-lenses
+      resource:
+        repo: https://github.com/joneshf/purescript-resource.git
+        version: v2.0.1
+        dependencies:
+          - aff
+          - console
+          - control
+          - effect
+          - newtype
+          - prelude
+          - psci-support
+          - refs
+      resourcet:
+        repo: https://github.com/robertdp/purescript-resourcet.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - effect
+          - foldable-traversable
+          - maybe
+          - ordered-collections
+          - parallel
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+      result:
+        repo: https://github.com/ad-si/purescript-result.git
+        version: v1.0.3
+        dependencies:
+          - either
+          - foldable-traversable
+          - prelude
+      return:
+        repo: https://github.com/ursi/purescript-return.git
+        version: v0.2.0
+        dependencies:
+          - foldable-traversable
+          - point-free
+          - prelude
+      ring-modules:
+        repo: https://github.com/f-o-a-m/purescript-ring-modules.git
+        version: v5.0.1
+        dependencies:
+          - prelude
+      routing:
+        repo: https://github.com/purescript-contrib/purescript-routing.git
+        version: v11.0.0
+        dependencies:
+          - aff
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - integers
+          - js-uri
+          - lists
+          - maybe
+          - numbers
+          - partial
+          - prelude
+          - semirings
+          - tuples
+          - validation
+          - web-html
+      routing-duplex:
+        repo: https://github.com/natefaubion/purescript-routing-duplex.git
+        version: v0.6.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - js-uri
+          - lazy
+          - numbers
+          - prelude
+          - profunctor
+          - record
+          - strings
+          - typelevel-prelude
+      run:
+        repo: https://github.com/natefaubion/purescript-run.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - free
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - tailrec
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - variant
+      safe-coerce:
+        repo: https://github.com/purescript/purescript-safe-coerce.git
+        version: v2.0.0
+        dependencies:
+          - unsafe-coerce
+      safely:
+        repo: https://github.com/paf31/purescript-safely.git
+        version: v4.0.1
+        dependencies:
+          - freet
+          - lists
+      selection-foldable:
+        repo: https://github.com/jamieyung/purescript-selection-foldable.git
+        version: v0.2.0
+        dependencies:
+          - filterable
+          - foldable-traversable
+          - maybe
+          - prelude
+      semirings:
+        repo: https://github.com/purescript/purescript-semirings.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - lists
+          - newtype
+          - prelude
+      signal:
+        repo: https://github.com/bodil/purescript-signal.git
+        version: v13.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - foldable-traversable
+          - maybe
+          - prelude
+      simple-emitter:
+        repo: https://github.com/oreshinya/purescript-simple-emitter.git
+        version: v2.0.0
+        dependencies:
+          - ordered-collections
+          - refs
+      sized-matrices:
+        repo: https://github.com/csicar/purescript-sized-matrices.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - distributive
+          - foldable-traversable
+          - maybe
+          - prelude
+          - sized-vectors
+          - strings
+          - typelevel
+          - unfoldable
+          - vectorfield
+      sized-vectors:
+        repo: https://github.com/bodil/purescript-sized-vectors.git
+        version: v5.0.2
+        dependencies:
+          - argonaut
+          - arrays
+          - distributive
+          - foldable-traversable
+          - maybe
+          - prelude
+          - quickcheck
+          - typelevel
+          - unfoldable
+      slug:
+        repo: https://github.com/thomashoneyman/purescript-slug.git
+        version: v3.0.1
+        dependencies:
+          - argonaut-codecs
+          - maybe
+          - prelude
+          - strings
+          - unicode
+      soundfonts:
+        repo: https://github.com/newlandsvalley/purescript-soundfonts.git
+        version: v4.1.0
+        dependencies:
+          - aff
+          - affjax
+          - affjax-web
+          - argonaut-core
+          - arraybuffer-types
+          - arrays
+          - b64
+          - bifunctors
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign-object
+          - http-methods
+          - integers
+          - lists
+          - maybe
+          - midi
+          - ordered-collections
+          - parallel
+          - partial
+          - prelude
+          - strings
+          - transformers
+          - tuples
+      sparse-matrices:
+        repo: https://github.com/Ebmtranceboy/purescript-sparse-matrices.git
+        version: v1.2.1
+        dependencies:
+          - console
+          - effect
+          - prelude
+          - sparse-polynomials
+      sparse-polynomials:
+        repo: https://github.com/Ebmtranceboy/purescript-sparse-polynomials.git
+        version: v1.0.5
+        dependencies:
+          - cartesian
+          - console
+          - effect
+          - ordered-collections
+          - prelude
+          - rationals
+          - tuples
+      spec:
+        repo: https://github.com/purescript-spec/purescript-spec.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - ansi
+          - avar
+          - console
+          - exceptions
+          - foldable-traversable
+          - fork
+          - now
+          - pipes
+          - prelude
+          - strings
+          - transformers
+      spec-discovery:
+        repo: https://github.com/purescript-spec/purescript-spec-discovery.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - aff-promise
+          - arrays
+          - console
+          - effect
+          - foldable-traversable
+          - node-fs
+          - prelude
+          - spec
+      spec-quickcheck:
+        repo: https://github.com/purescript-spec/purescript-spec-quickcheck.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - prelude
+          - quickcheck
+          - random
+          - spec
+      ssrs:
+        repo: https://github.com/PureFunctor/purescript-ssrs.git
+        version: v1.0.0
+        dependencies:
+          - dissect
+          - either
+          - fixed-points
+          - free
+          - lists
+          - prelude
+          - safe-coerce
+          - tailrec
+          - tuples
+          - variant
+      st:
+        repo: https://github.com/purescript/purescript-st.git
+        version: v6.0.0
+        dependencies:
+          - partial
+          - prelude
+          - tailrec
+          - unsafe-coerce
+      strictlypositiveint:
+        repo: https://github.com/jamieyung/purescript-strictlypositiveint.git
+        version: v1.0.1
+        dependencies:
+          - prelude
+      string-parsers:
+        repo: https://github.com/purescript-contrib/purescript-string-parsers.git
+        version: v8.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - prelude
+          - strings
+          - tailrec
+      strings:
+        repo: https://github.com/purescript/purescript-strings.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - enums
+          - foldable-traversable
+          - gen
+          - integers
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+          - unsafe-coerce
+      strings-extra:
+        repo: https://github.com/purescript-contrib/purescript-strings-extra.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - maybe
+          - prelude
+          - strings
+          - unicode
+      stringutils:
+        repo: https://github.com/menelaos/purescript-stringutils.git
+        version: v0.0.12
+        dependencies:
+          - arrays
+          - integers
+          - maybe
+          - partial
+          - prelude
+          - strings
+      substitute:
+        repo: https://github.com/ursi/purescript-substitute.git
+        version: v0.2.3
+        dependencies:
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - prelude
+          - return
+          - strings
+      supply:
+        repo: https://github.com/ajnsit/purescript-supply.git
+        version: v0.2.0
+        dependencies:
+          - console
+          - control
+          - effect
+          - lazy
+          - prelude
+          - refs
+          - tuples
+      tailrec:
+        repo: https://github.com/purescript/purescript-tailrec.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - effect
+          - either
+          - identity
+          - maybe
+          - partial
+          - prelude
+          - refs
+      test-unit:
+        repo: https://github.com/bodil/purescript-test-unit.git
+        version: v17.0.0
+        dependencies:
+          - aff
+          - avar
+          - effect
+          - either
+          - free
+          - js-timers
+          - lists
+          - prelude
+          - quickcheck
+          - strings
+      thermite:
+        repo: https://github.com/paf31/purescript-thermite.git
+        version: v6.3.1
+        dependencies:
+          - aff
+          - coroutines
+          - freet
+          - profunctor-lenses
+          - react
+      thermite-dom:
+        repo: https://github.com/athanclark/purescript-thermite-dom.git
+        version: v0.3.1
+        dependencies:
+          - react
+          - react-dom
+          - thermite
+          - web-html
+      these:
+        repo: https://github.com/purescript-contrib/purescript-these.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - gen
+          - lists
+          - quickcheck
+          - quickcheck-laws
+          - tuples
+      transformers:
+        repo: https://github.com/purescript/purescript-transformers.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - distributive
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - identity
+          - lazy
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      tree-rose:
+        repo: https://github.com/jordanmartinez/purescript-tree-rose.git
+        version: v4.0.2
+        dependencies:
+          - control
+          - foldable-traversable
+          - free
+          - lists
+          - maybe
+          - prelude
+          - tailrec
+      tuples:
+        repo: https://github.com/purescript/purescript-tuples.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - invariant
+          - prelude
+      two-or-more:
+        repo: https://github.com/i-am-the-slime/purescript-two-or-more.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - foldable-traversable
+          - maybe
+          - partial
+          - prelude
+          - psci-support
+          - tuples
+      type-equality:
+        repo: https://github.com/purescript/purescript-type-equality.git
+        version: v4.0.1
+        dependencies: []
+      typelevel:
+        repo: https://github.com/bodil/purescript-typelevel.git
+        version: v6.0.0
+        dependencies:
+          - partial
+          - prelude
+          - tuples
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-lists:
+        repo: https://github.com/PureFunctor/purescript-typelevel-lists.git
+        version: v2.1.0
+        dependencies:
+          - prelude
+          - tuples
+          - typelevel-peano
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-peano:
+        repo: https://github.com/csicar/purescript-typelevel-peano.git
+        version: v1.0.1
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - prelude
+          - psci-support
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-prelude:
+        repo: https://github.com/purescript/purescript-typelevel-prelude.git
+        version: v7.0.0
+        dependencies:
+          - prelude
+          - type-equality
+      typelevel-rows:
+        repo: https://github.com/jordanmartinez/purescript-typelevel-rows.git
+        version: v0.1.0
+        dependencies:
+          - prelude
+      uint:
+        repo: https://github.com/purescript-contrib/purescript-uint.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - enums
+          - gen
+          - maybe
+          - numbers
+          - prelude
+      uncurried-transformers:
+        repo: https://github.com/PureFunctor/purescript-uncurried-transformers.git
+        version: v1.1.0
+        dependencies:
+          - control
+          - effect
+          - either
+          - functions
+          - identity
+          - prelude
+          - safe-coerce
+          - tailrec
+          - transformers
+          - tuples
+      undefined-is-not-a-problem:
+        repo: https://github.com/paluh/purescript-undefined-is-not-a-problem.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - assert
+          - effect
+          - either
+          - foreign
+          - maybe
+          - newtype
+          - prelude
+          - random
+          - tuples
+          - type-equality
+          - unsafe-coerce
+      unfoldable:
+        repo: https://github.com/purescript/purescript-unfoldable.git
+        version: v6.0.0
+        dependencies:
+          - foldable-traversable
+          - maybe
+          - partial
+          - prelude
+          - tuples
+      unicode:
+        repo: https://github.com/purescript-contrib/purescript-unicode.git
+        version: v6.0.0
+        dependencies:
+          - foldable-traversable
+          - maybe
+          - strings
+      unlift:
+        repo: https://github.com/tweag/purescript-unlift.git
+        version: v1.0.1
+        dependencies:
+          - aff
+          - effect
+          - either
+          - freet
+          - identity
+          - lists
+          - maybe
+          - monad-control
+          - prelude
+          - st
+          - transformers
+          - tuples
+      unsafe-coerce:
+        repo: https://github.com/purescript/purescript-unsafe-coerce.git
+        version: v6.0.0
+        dependencies: []
+      unsafe-reference:
+        repo: https://github.com/purescript-contrib/purescript-unsafe-reference.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+      uri:
+        repo: https://github.com/purescript-contrib/purescript-uri.git
+        version: v9.0.0
+        dependencies:
+          - arrays
+          - integers
+          - js-uri
+          - numbers
+          - parsing
+          - prelude
+          - profunctor-lenses
+          - these
+          - transformers
+          - unfoldable
+      validation:
+        repo: https://github.com/purescript/purescript-validation.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - newtype
+          - prelude
+      variant:
+        repo: https://github.com/natefaubion/purescript-variant.git
+        version: v8.0.0
+        dependencies:
+          - enums
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - record
+          - tuples
+          - unsafe-coerce
+      vectorfield:
+        repo: https://github.com/csicar/purescript-vectorfield.git
+        version: v1.0.1
+        dependencies:
+          - console
+          - effect
+          - group
+          - prelude
+          - psci-support
+      versions:
+        repo: https://github.com/hdgarrood/purescript-versions.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - either
+          - foldable-traversable
+          - functions
+          - integers
+          - lists
+          - maybe
+          - orders
+          - parsing
+          - partial
+          - strings
+      web-clipboard:
+        repo: https://github.com/purescript-web/purescript-web-clipboard.git
+        version: v4.0.0
+        dependencies:
+          - web-html
+      web-cssom:
+        repo: https://github.com/purescript-web/purescript-web-cssom.git
+        version: v2.0.0
+        dependencies:
+          - web-dom
+          - web-html
+          - web-uievents
+      web-dom:
+        repo: https://github.com/purescript-web/purescript-web-dom.git
+        version: v6.0.0
+        dependencies:
+          - web-events
+      web-dom-parser:
+        repo: https://github.com/purescript-web/purescript-web-dom-parser.git
+        version: v8.0.0
+        dependencies:
+          - effect
+          - partial
+          - prelude
+          - web-dom
+      web-dom-xpath:
+        repo: https://github.com/purescript-web/purescript-web-dom-xpath.git
+        version: v3.0.0
+        dependencies:
+          - web-dom
+      web-encoding:
+        repo: https://github.com/purescript-web/purescript-web-encoding.git
+        version: v3.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - newtype
+          - prelude
+      web-events:
+        repo: https://github.com/purescript-web/purescript-web-events.git
+        version: v4.0.0
+        dependencies:
+          - datetime
+          - enums
+          - foreign
+          - nullable
+      web-fetch:
+        repo: https://github.com/purescript-web/purescript-web-fetch.git
+        version: v3.0.0
+        dependencies:
+          - effect
+          - foreign-object
+          - http-methods
+          - prelude
+          - record
+          - typelevel-prelude
+          - web-file
+          - web-promise
+          - web-streams
+      web-file:
+        repo: https://github.com/purescript-web/purescript-web-file.git
+        version: v4.0.0
+        dependencies:
+          - foreign
+          - media-types
+          - web-dom
+      web-html:
+        repo: https://github.com/purescript-web/purescript-web-html.git
+        version: v4.0.0
+        dependencies:
+          - js-date
+          - web-dom
+          - web-file
+          - web-storage
+      web-page-visibility:
+        repo: https://git.sr.ht/~toastal/purescript-web-page-visibility
+        version: v2.0.0
+        dependencies:
+          - effect
+          - enums
+          - exceptions
+          - maybe
+          - prelude
+          - strings
+          - web-events
+          - web-html
+      web-pointerevents:
+        repo: https://github.com/purescript-web/purescript-web-pointerevents.git
+        version: v1.0.0
+        dependencies:
+          - effect
+          - maybe
+          - prelude
+          - web-dom
+          - web-uievents
+      web-promise:
+        repo: https://github.com/purescript-web/purescript-web-promise.git
+        version: v3.0.0
+        dependencies:
+          - effect
+          - exceptions
+          - foldable-traversable
+          - functions
+          - maybe
+          - prelude
+      web-socket:
+        repo: https://github.com/purescript-web/purescript-web-socket.git
+        version: v4.0.0
+        dependencies:
+          - arraybuffer-types
+          - web-file
+      web-storage:
+        repo: https://github.com/purescript-web/purescript-web-storage.git
+        version: v5.0.0
+        dependencies:
+          - nullable
+          - web-events
+      web-streams:
+        repo: https://github.com/purescript-web/purescript-web-streams.git
+        version: v3.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - exceptions
+          - nullable
+          - prelude
+          - tuples
+          - web-promise
+      web-touchevents:
+        repo: https://github.com/purescript-web/purescript-web-touchevents.git
+        version: v4.0.0
+        dependencies:
+          - web-uievents
+      web-uievents:
+        repo: https://github.com/purescript-web/purescript-web-uievents.git
+        version: v4.0.0
+        dependencies:
+          - web-html
+      web-workers:
+        repo: https://github.com/gbagan/purescript-web-workers.git
+        version: v1.1.0
+        dependencies:
+          - effect
+          - foreign
+          - maybe
+          - prelude
+          - unsafe-coerce
+          - web-events
+      web-xhr:
+        repo: https://github.com/purescript-web/purescript-web-xhr.git
+        version: v5.0.0
+        dependencies:
+          - arraybuffer-types
+          - datetime
+          - http-methods
+          - web-dom
+          - web-file
+          - web-html
+      yoga-fetch:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-fetch.git
+        version: v1.0.1
+        dependencies:
+          - aff
+          - aff-promise
+          - arraybuffer-types
+          - effect
+          - foreign
+          - foreign-object
+          - newtype
+          - prelude
+          - typelevel-prelude
+          - unsafe-coerce
+      yoga-json:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-json.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - identity
+          - lists
+          - maybe
+          - nullable
+          - partial
+          - prelude
+          - record
+          - transformers
+          - typelevel-prelude
+          - variant
+      yoga-postgres:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-postgres.git
+        version: v6.0.0
+        dependencies:
+          - aff
+          - arrays
+          - datetime
+          - effect
+          - either
+          - enums
+          - foldable-traversable
+          - foreign
+          - integers
+          - maybe
+          - nullable
+          - prelude
+          - transformers
+          - unsafe-coerce
+  extra_packages: {}
+packages:
+  aff:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-aff.git
+    rev: 2d44d9f9d0d6a416a4103fba2fb39e5160f80e36
+    dependencies:
+      - datetime
+      - effect
+      - exceptions
+      - functions
+      - parallel
+      - transformers
+      - unsafe-coerce
+  aff-promise:
+    type: git
+    url: https://github.com/nwolverson/purescript-aff-promise.git
+    rev: 3aa74e68e3e4c3e38d821375703e0b2f49d831eb
+    dependencies:
+      - aff
+      - foreign
+  argonaut:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-argonaut.git
+    rev: 7505a47f2edb0c9cacaac4f11dcedf4723a3e9c8
+    dependencies:
+      - argonaut-codecs
+      - argonaut-core
+      - argonaut-traversals
+  argonaut-codecs:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-argonaut-codecs.git
+    rev: 176a5dddae28fda9a2ff31ed4bf1efcc148513a4
+    dependencies:
+      - argonaut-core
+      - arrays
+      - effect
+      - foreign-object
+      - identity
+      - integers
+      - maybe
+      - nonempty
+      - ordered-collections
+      - prelude
+      - record
+  argonaut-core:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-argonaut-core.git
+    rev: 68da81dd80ec36d3b013eff46dc067a972c22e5d
+    dependencies:
+      - arrays
+      - control
+      - either
+      - foreign-object
+      - functions
+      - gen
+      - maybe
+      - nonempty
+      - prelude
+      - strings
+      - tailrec
+  argonaut-generic:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-argonaut-generic.git
+    rev: 2df4080f036762df91a24b22842e389395ef0bdd
+    dependencies:
+      - argonaut-codecs
+      - argonaut-core
+      - prelude
+      - record
+  argonaut-traversals:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-argonaut-traversals.git
+    rev: 8d2403d8d57afb568933dbb36063d5670ce770a0
+    dependencies:
+      - argonaut-codecs
+      - argonaut-core
+      - profunctor-lenses
+  arrays:
+    type: git
+    url: https://github.com/purescript/purescript-arrays.git
+    rev: d20bae2f76db6cf29b7b75e26e82b8a54c32295e
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - maybe
+      - nonempty
+      - partial
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  avar:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-avar.git
+    rev: d00f5784d9cc8f079babd62740f5c52b87e5caa5
+    dependencies:
+      - aff
+      - effect
+      - either
+      - exceptions
+      - functions
+      - maybe
+  bifunctors:
+    type: git
+    url: https://github.com/purescript/purescript-bifunctors.git
+    rev: 16ba2fb6dd7f05528ebd9e2f9ca3a068b325e5b3
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  catenable-lists:
+    type: git
+    url: https://github.com/purescript/purescript-catenable-lists.git
+    rev: 09abe1f4888bc00841ad2b59e56a9e7ce7ebd4ab
+    dependencies:
+      - control
+      - foldable-traversable
+      - lists
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  console:
+    type: git
+    url: https://github.com/purescript/purescript-console.git
+    rev: 3b83d7b792d03872afeea5e62b4f686ab0f09842
+    dependencies:
+      - effect
+      - prelude
+  const:
+    type: git
+    url: https://github.com/purescript/purescript-const.git
+    rev: ab9570cf2b6e67f7e441178211db1231cfd75c37
+    dependencies:
+      - invariant
+      - newtype
+      - prelude
+  contravariant:
+    type: git
+    url: https://github.com/purescript/purescript-contravariant.git
+    rev: 9ad3e105b8855bcc25f4e0893c784789d05a58de
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  control:
+    type: git
+    url: https://github.com/purescript/purescript-control.git
+    rev: a6033808790879a17b2729e73747a9ed3fb2264e
+    dependencies:
+      - newtype
+      - prelude
+  datetime:
+    type: git
+    url: https://github.com/purescript/purescript-datetime.git
+    rev: a6a0cf1b0324964ad1854bc3377ed8766ba90e6f
+    dependencies:
+      - bifunctors
+      - control
+      - either
+      - enums
+      - foldable-traversable
+      - functions
+      - gen
+      - integers
+      - lists
+      - maybe
+      - newtype
+      - numbers
+      - ordered-collections
+      - partial
+      - prelude
+      - tuples
+  distributive:
+    type: git
+    url: https://github.com/purescript/purescript-distributive.git
+    rev: 6005e513642e855ebf6f884d24a35c2803ca252a
+    dependencies:
+      - identity
+      - newtype
+      - prelude
+      - tuples
+      - type-equality
+  effect:
+    type: git
+    url: https://github.com/purescript/purescript-effect.git
+    rev: a192ddb923027d426d6ea3d8deb030c9aa7c7dda
+    dependencies:
+      - prelude
+  either:
+    type: git
+    url: https://github.com/purescript/purescript-either.git
+    rev: af655a04ed2fd694b6688af39ee20d7907ad0763
+    dependencies:
+      - control
+      - invariant
+      - maybe
+      - prelude
+  enums:
+    type: git
+    url: https://github.com/purescript/purescript-enums.git
+    rev: bae47961d401f9acf88da38f32e87403e5f0cf2f
+    dependencies:
+      - control
+      - either
+      - gen
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tuples
+      - unfoldable
+  exceptions:
+    type: git
+    url: https://github.com/purescript/purescript-exceptions.git
+    rev: afab3c07c820bb49b6c5be50049db46a964a6161
+    dependencies:
+      - effect
+      - either
+      - maybe
+      - prelude
+  exists:
+    type: git
+    url: https://github.com/purescript/purescript-exists.git
+    rev: f765b4ace7869c27b9c05949e18c843881f9173b
+    dependencies:
+      - unsafe-coerce
+  foldable-traversable:
+    type: git
+    url: https://github.com/purescript/purescript-foldable-traversable.git
+    rev: b3926f870532d287ea59e2d5cd3873b81ef2a93a
+    dependencies:
+      - bifunctors
+      - const
+      - control
+      - either
+      - functors
+      - identity
+      - maybe
+      - newtype
+      - orders
+      - prelude
+      - tuples
+  foreign:
+    type: git
+    url: https://github.com/purescript/purescript-foreign.git
+    rev: 2dd222d1ec7363fa0a0a7adb0d8eaf81bb7006dd
+    dependencies:
+      - either
+      - functions
+      - identity
+      - integers
+      - lists
+      - maybe
+      - prelude
+      - strings
+      - transformers
+  foreign-object:
+    type: git
+    url: https://github.com/purescript/purescript-foreign-object.git
+    rev: 28a635827a9a6c251df73f68874070d51fe9f756
+    dependencies:
+      - arrays
+      - foldable-traversable
+      - functions
+      - gen
+      - lists
+      - maybe
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - typelevel-prelude
+      - unfoldable
+  free:
+    type: git
+    url: https://github.com/purescript/purescript-free.git
+    rev: e2d8fa8023a864363857834e11393483bced5e38
+    dependencies:
+      - catenable-lists
+      - control
+      - distributive
+      - either
+      - exists
+      - foldable-traversable
+      - invariant
+      - lazy
+      - maybe
+      - prelude
+      - tailrec
+      - transformers
+      - tuples
+      - unsafe-coerce
+  functions:
+    type: git
+    url: https://github.com/purescript/purescript-functions.git
+    rev: f626f20580483977c5b27a01aac6471e28aff367
+    dependencies:
+      - prelude
+  functors:
+    type: git
+    url: https://github.com/purescript/purescript-functors.git
+    rev: 022ffd7a2a7ec12080314f3d217b400674a247b4
+    dependencies:
+      - bifunctors
+      - const
+      - contravariant
+      - control
+      - distributive
+      - either
+      - invariant
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - tuples
+      - unsafe-coerce
+  gen:
+    type: git
+    url: https://github.com/purescript/purescript-gen.git
+    rev: 9fbcc2a1261c32e30d79c5418edef4d96fe76931
+    dependencies:
+      - either
+      - foldable-traversable
+      - identity
+      - maybe
+      - newtype
+      - nonempty
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  identity:
+    type: git
+    url: https://github.com/purescript/purescript-identity.git
+    rev: ef6768f8a52ab0bc943a85f5761ba07c257f639f
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  indexed-monad:
+    type: git
+    url: https://github.com/garyb/purescript-indexed-monad.git
+    rev: b95d33cea26bfbbdc17d8d80fb664df2ad79d28b
+    dependencies:
+      - control
+      - newtype
+  integers:
+    type: git
+    url: https://github.com/purescript/purescript-integers.git
+    rev: 54d712b25c594833083d15dc9ff2418eb9c52822
+    dependencies:
+      - maybe
+      - numbers
+      - prelude
+  invariant:
+    type: git
+    url: https://github.com/purescript/purescript-invariant.git
+    rev: 1d2a196d51e90623adb88496c2cfd759c6736894
+    dependencies:
+      - control
+      - prelude
+  js-date:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-js-date.git
+    rev: 1ea020316946cc4b87195bca9c54d0c16abaa490
+    dependencies:
+      - datetime
+      - effect
+      - exceptions
+      - foreign
+      - integers
+      - now
+  js-timers:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-js-timers.git
+    rev: 7cb728b3e6dc29f355143617e6e9ac770ecd9273
+    dependencies:
+      - effect
+  lazy:
+    type: git
+    url: https://github.com/purescript/purescript-lazy.git
+    rev: 48347841226b27af5205a1a8ec71e27a93ce86fd
+    dependencies:
+      - control
+      - foldable-traversable
+      - invariant
+      - prelude
+  lcg:
+    type: git
+    url: https://github.com/purescript/purescript-lcg.git
+    rev: 67c6c6483a563a59ae036d9dca0f1be2835326a5
+    dependencies:
+      - effect
+      - integers
+      - maybe
+      - partial
+      - prelude
+      - random
+  lists:
+    type: git
+    url: https://github.com/purescript/purescript-lists.git
+    rev: b113451e5b41cad87d669a3165f955c71cd863e2
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - lazy
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  maybe:
+    type: git
+    url: https://github.com/purescript/purescript-maybe.git
+    rev: c6f98ac1088766287106c5d9c8e30e7648d36786
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  media-types:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-media-types.git
+    rev: af853de226592f319a953637069a943dd261cba3
+    dependencies:
+      - newtype
+      - prelude
+  newtype:
+    type: git
+    url: https://github.com/purescript/purescript-newtype.git
+    rev: 29d8e6dd77aec2c975c948364ec3faf26e14ee7b
+    dependencies:
+      - prelude
+      - safe-coerce
+  nonempty:
+    type: git
+    url: https://github.com/purescript/purescript-nonempty.git
+    rev: 28150ecc7419238b187abd609a92a645273348bb
+    dependencies:
+      - control
+      - foldable-traversable
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  now:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-now.git
+    rev: b5ffed2381e5fefc063f484e607e8499e79eaf32
+    dependencies:
+      - datetime
+      - effect
+  nullable:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-nullable.git
+    rev: 3202744c6c65e8d1fbba7f4256a1c482078e7fb5
+    dependencies:
+      - effect
+      - functions
+      - maybe
+  numbers:
+    type: git
+    url: https://github.com/purescript/purescript-numbers.git
+    rev: 2a53528f18f9415334bae28e7bb3cf3be86342c2
+    dependencies:
+      - functions
+      - maybe
+  ordered-collections:
+    type: git
+    url: https://github.com/purescript/purescript-ordered-collections.git
+    rev: 9826b7632d0d0a691173bde308a634195f42a419
+    dependencies:
+      - arrays
+      - foldable-traversable
+      - gen
+      - lists
+      - maybe
+      - partial
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+  orders:
+    type: git
+    url: https://github.com/purescript/purescript-orders.git
+    rev: f86db621ec5eef1274145f8b1fd8ebbfe0ed4a2c
+    dependencies:
+      - newtype
+      - prelude
+  pairs:
+    type: git
+    url: https://github.com/sharkdp/purescript-pairs.git
+    rev: f16ba3acc6399dbca0c8632c811f53809d39002c
+    dependencies:
+      - console
+      - distributive
+      - foldable-traversable
+      - quickcheck
+  parallel:
+    type: git
+    url: https://github.com/purescript/purescript-parallel.git
+    rev: 85290dca837771ac4870071008c933d315ef678f
+    dependencies:
+      - control
+      - effect
+      - either
+      - foldable-traversable
+      - functors
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - refs
+      - transformers
+  partial:
+    type: git
+    url: https://github.com/purescript/purescript-partial.git
+    rev: 0fa0646f5ea1ec5f0c46dcbd770c705a6c9ad3ec
+    dependencies: []
+  prelude:
+    type: git
+    url: https://github.com/purescript/purescript-prelude.git
+    rev: 32787f4399c92459c41602131a5858559eb868c5
+    dependencies: []
+  profunctor:
+    type: git
+    url: https://github.com/purescript/purescript-profunctor.git
+    rev: 0a966a14e7b0c827d44657dc1710cdc712d2e034
+    dependencies:
+      - control
+      - distributive
+      - either
+      - exists
+      - invariant
+      - newtype
+      - prelude
+      - tuples
+  profunctor-lenses:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-profunctor-lenses.git
+    rev: 973d567afe458fd802cf4f0d9725b6dc35ad9297
+    dependencies:
+      - arrays
+      - bifunctors
+      - const
+      - control
+      - distributive
+      - either
+      - foldable-traversable
+      - foreign-object
+      - functors
+      - identity
+      - lists
+      - maybe
+      - newtype
+      - ordered-collections
+      - partial
+      - prelude
+      - profunctor
+      - record
+      - transformers
+      - tuples
+  quickcheck:
+    type: git
+    url: https://github.com/purescript/purescript-quickcheck.git
+    rev: bf5029f97e6c0d7552d3a08d2ab793a19e2c5e3d
+    dependencies:
+      - arrays
+      - console
+      - control
+      - effect
+      - either
+      - enums
+      - exceptions
+      - foldable-traversable
+      - gen
+      - identity
+      - integers
+      - lazy
+      - lcg
+      - lists
+      - maybe
+      - newtype
+      - nonempty
+      - numbers
+      - partial
+      - prelude
+      - record
+      - st
+      - strings
+      - tailrec
+      - transformers
+      - tuples
+      - unfoldable
+  random:
+    type: git
+    url: https://github.com/purescript/purescript-random.git
+    rev: 9540bc965a9596da02fefd9949418bb19c92533a
+    dependencies:
+      - effect
+      - integers
+  react-basic:
+    type: git
+    url: https://github.com/lumihq/purescript-react-basic.git
+    rev: 821ac4cb55b5919cc6248b45139164ad1a560e3f
+    dependencies:
+      - effect
+      - prelude
+      - record
+  react-basic-dom:
+    type: git
+    url: https://github.com/lumihq/purescript-react-basic-dom.git
+    rev: 4ee3cd2ec6086aae1476d08f2348f7f9bce8feac
+    dependencies:
+      - effect
+      - foldable-traversable
+      - foreign-object
+      - maybe
+      - nullable
+      - prelude
+      - react-basic
+      - unsafe-coerce
+      - web-dom
+      - web-events
+      - web-file
+      - web-html
+  react-basic-hooks:
+    type: git
+    url: https://github.com/megamaddu/purescript-react-basic-hooks.git
+    rev: 50575f50a68dc8b756b378674dea5c568b8c109d
+    dependencies:
+      - aff
+      - aff-promise
+      - bifunctors
+      - console
+      - control
+      - datetime
+      - effect
+      - either
+      - exceptions
+      - foldable-traversable
+      - functions
+      - indexed-monad
+      - integers
+      - maybe
+      - newtype
+      - now
+      - nullable
+      - ordered-collections
+      - prelude
+      - react-basic
+      - refs
+      - tuples
+      - type-equality
+      - unsafe-coerce
+      - unsafe-reference
+      - web-html
+  record:
+    type: git
+    url: https://github.com/purescript/purescript-record.git
+    rev: c89cd1ada6b636692571fc374196b1c39c4c9f70
+    dependencies:
+      - functions
+      - prelude
+      - unsafe-coerce
+  refs:
+    type: git
+    url: https://github.com/purescript/purescript-refs.git
+    rev: f8e6216da4cb9309fde1f20cd6f69ac3a3b7f9e8
+    dependencies:
+      - effect
+      - prelude
+  safe-coerce:
+    type: git
+    url: https://github.com/purescript/purescript-safe-coerce.git
+    rev: 7fa799ae80a38b8d948efcb52608e58e198b3da7
+    dependencies:
+      - unsafe-coerce
+  st:
+    type: git
+    url: https://github.com/purescript/purescript-st.git
+    rev: 2cc7ae1c3318a303378c4a9f3fa0f10ee7cc3589
+    dependencies:
+      - partial
+      - prelude
+      - tailrec
+      - unsafe-coerce
+  strings:
+    type: git
+    url: https://github.com/purescript/purescript-strings.git
+    rev: 4bc6954448d056f8aa7a659695a6ad60ad4fdf19
+    dependencies:
+      - arrays
+      - control
+      - either
+      - enums
+      - foldable-traversable
+      - gen
+      - integers
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  tailrec:
+    type: git
+    url: https://github.com/purescript/purescript-tailrec.git
+    rev: 5e2104aa734b31a17074cc805bf087d72b65afd1
+    dependencies:
+      - bifunctors
+      - effect
+      - either
+      - identity
+      - maybe
+      - partial
+      - prelude
+      - refs
+  test-unit:
+    type: git
+    url: https://github.com/bodil/purescript-test-unit.git
+    rev: 3112d7ebe06d467238058a6384dc75ffd960d335
+    dependencies:
+      - aff
+      - avar
+      - effect
+      - either
+      - free
+      - js-timers
+      - lists
+      - prelude
+      - quickcheck
+      - strings
+  transformers:
+    type: git
+    url: https://github.com/purescript/purescript-transformers.git
+    rev: be72ab52357d9a665cbf93d73ba1c07c4b0957ee
+    dependencies:
+      - control
+      - distributive
+      - effect
+      - either
+      - exceptions
+      - foldable-traversable
+      - identity
+      - lazy
+      - maybe
+      - newtype
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  tuples:
+    type: git
+    url: https://github.com/purescript/purescript-tuples.git
+    rev: 4f52da2729b448c8564369378f1232d8d2dc1d8b
+    dependencies:
+      - control
+      - invariant
+      - prelude
+  type-equality:
+    type: git
+    url: https://github.com/purescript/purescript-type-equality.git
+    rev: 0525b7d39e0fbd81b4209518139fb8ab02695774
+    dependencies: []
+  typelevel-prelude:
+    type: git
+    url: https://github.com/purescript/purescript-typelevel-prelude.git
+    rev: dca2fe3c8cfd5527d4fe70c4bedfda30148405bf
+    dependencies:
+      - prelude
+      - type-equality
+  unfoldable:
+    type: git
+    url: https://github.com/purescript/purescript-unfoldable.git
+    rev: 493dfe04ed590e20d8f69079df2f58486882748d
+    dependencies:
+      - foldable-traversable
+      - maybe
+      - partial
+      - prelude
+      - tuples
+  unsafe-coerce:
+    type: git
+    url: https://github.com/purescript/purescript-unsafe-coerce.git
+    rev: ab956f82e66e633f647fb3098e8ddd3ec58d689f
+    dependencies: []
+  unsafe-reference:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-unsafe-reference.git
+    rev: 058e23b8b9adcf776a910f9934ff515ddee73af5
+    dependencies:
+      - prelude
+  validation:
+    type: git
+    url: https://github.com/purescript/purescript-validation.git
+    rev: a3d9ec2176a7a808d70a01fa7e6f16d10e05429a
+    dependencies:
+      - bifunctors
+      - control
+      - either
+      - foldable-traversable
+      - newtype
+      - prelude
+  web-dom:
+    type: git
+    url: https://github.com/purescript-web/purescript-web-dom.git
+    rev: 568a1ee158b29e6e739e7a9aaed3e35ca4c4305a
+    dependencies:
+      - web-events
+  web-events:
+    type: git
+    url: https://github.com/purescript-web/purescript-web-events.git
+    rev: 2124356117be7b764a2f3948032255ac4dab7051
+    dependencies:
+      - datetime
+      - enums
+      - foreign
+      - nullable
+  web-file:
+    type: git
+    url: https://github.com/purescript-web/purescript-web-file.git
+    rev: 023786ae62bbb8bf58156dd7f02011fa38221ef1
+    dependencies:
+      - foreign
+      - media-types
+      - web-dom
+  web-html:
+    type: git
+    url: https://github.com/purescript-web/purescript-web-html.git
+    rev: be189cf91b9a19cf493637423522e2fe4a0088cc
+    dependencies:
+      - js-date
+      - web-dom
+      - web-file
+      - web-storage
+  web-storage:
+    type: git
+    url: https://github.com/purescript-web/purescript-web-storage.git
+    rev: 6b74461e136755db70c271dc898d51776363d7e2
+    dependencies:
+      - nullable
+      - web-events

--- a/exercises/chapter10/spago.lock
+++ b/exercises/chapter10/spago.lock
@@ -112,3467 +112,477 @@ workspace:
         - web-storage
   package_set:
     address:
-      url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
-    compiler: ">=0.15.0 <0.16.0"
+      registry: 10.0.0
+    compiler: ">=0.15.4 <0.16.0"
     content:
-      ace:
-        repo: https://github.com/purescript-contrib/purescript-ace.git
-        version: v9.0.0
-        dependencies:
-          - arrays
-          - effect
-          - foreign
-          - nullable
-          - prelude
-          - web-html
-          - web-uievents
-      aff:
-        repo: https://github.com/purescript-contrib/purescript-aff.git
-        version: v7.0.0
-        dependencies:
-          - datetime
-          - effect
-          - exceptions
-          - functions
-          - parallel
-          - transformers
-          - unsafe-coerce
-      aff-bus:
-        repo: https://github.com/purescript-contrib/purescript-aff-bus.git
-        version: v6.0.0
-        dependencies:
-          - aff
-          - avar
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - lists
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-      aff-coroutines:
-        repo: https://github.com/purescript-contrib/purescript-aff-coroutines.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - avar
-          - coroutines
-          - effect
-      aff-promise:
-        repo: https://github.com/nwolverson/purescript-aff-promise.git
-        version: v4.0.0
-        dependencies:
-          - aff
-          - foreign
-      aff-retry:
-        repo: https://github.com/Unisay/purescript-aff-retry.git
-        version: v2.0.0
-        dependencies:
-          - aff
-          - arrays
-          - datetime
-          - effect
-          - either
-          - exceptions
-          - integers
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - random
-          - transformers
-      affjax:
-        repo: https://github.com/purescript-contrib/purescript-affjax.git
-        version: v13.0.0
-        dependencies:
-          - aff
-          - argonaut-core
-          - arraybuffer-types
-          - foreign
-          - form-urlencoded
-          - http-methods
-          - integers
-          - media-types
-          - nullable
-          - refs
-          - unsafe-coerce
-          - web-xhr
-      affjax-node:
-        repo: https://github.com/purescript-contrib/purescript-affjax-node.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - affjax
-          - either
-          - maybe
-          - prelude
-      affjax-web:
-        repo: https://github.com/purescript-contrib/purescript-affjax-web.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - affjax
-          - either
-          - maybe
-          - prelude
-      ansi:
-        repo: https://github.com/hdgarrood/purescript-ansi.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - lists
-          - strings
-      argonaut:
-        repo: https://github.com/purescript-contrib/purescript-argonaut.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - argonaut-traversals
-      argonaut-codecs:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-codecs.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-core
-          - arrays
-          - effect
-          - foreign-object
-          - identity
-          - integers
-          - maybe
-          - nonempty
-          - ordered-collections
-          - prelude
-          - record
-      argonaut-core:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-core.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - foreign-object
-          - functions
-          - gen
-          - maybe
-          - nonempty
-          - prelude
-          - strings
-          - tailrec
-      argonaut-generic:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-generic.git
-        version: v8.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - prelude
-          - record
-      argonaut-traversals:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-traversals.git
-        version: v10.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - profunctor-lenses
-      argparse-basic:
-        repo: https://github.com/natefaubion/purescript-argparse-basic.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - record
-          - strings
-          - tuples
-          - unfoldable
-      arraybuffer:
-        repo: https://github.com/purescript-contrib/purescript-arraybuffer.git
-        version: v13.0.0
-        dependencies:
-          - arraybuffer-types
-          - arrays
-          - effect
-          - float32
-          - functions
-          - gen
-          - maybe
-          - nullable
-          - prelude
-          - tailrec
-          - uint
-          - unfoldable
-      arraybuffer-builder:
-        repo: https://github.com/jamesdbrock/purescript-arraybuffer-builder.git
-        version: v3.0.1
-        dependencies:
-          - arraybuffer
-          - arraybuffer-types
-          - effect
-          - float32
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - transformers
-          - uint
-      arraybuffer-types:
-        repo: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
-        version: v3.0.2
-        dependencies: []
-      arrays:
-        repo: https://github.com/purescript/purescript-arrays.git
-        version: v7.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - foldable-traversable
-          - maybe
-          - nonempty
-          - partial
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - unfoldable
-          - unsafe-coerce
-      arrays-zipper:
-        repo: https://github.com/JordanMartinez/purescript-arrays-zipper.git
-        version: v2.0.1
-        dependencies:
-          - arrays
-          - control
-          - quickcheck
-      ask:
-        repo: https://github.com/Mateiadrielrafael/purescript-ask.git
-        version: v1.0.0
-        dependencies:
-          - unsafe-coerce
-      assert:
-        repo: https://github.com/purescript/purescript-assert.git
-        version: v6.0.0
-        dependencies:
-          - console
-          - effect
-          - prelude
-      avar:
-        repo: https://github.com/purescript-contrib/purescript-avar.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - exceptions
-          - functions
-          - maybe
-      b64:
-        repo: https://github.com/menelaos/purescript-b64.git
-        version: v0.0.8
-        dependencies:
-          - arraybuffer-types
-          - either
-          - encoding
-          - enums
-          - exceptions
-          - functions
-          - partial
-          - prelude
-          - strings
-      barlow-lens:
-        repo: https://github.com/sigma-andex/purescript-barlow-lens.git
-        version: v0.9.0
-        dependencies:
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - profunctor-lenses
-          - tuples
-          - typelevel-prelude
-      bifunctors:
-        repo: https://github.com/purescript/purescript-bifunctors.git
-        version: v6.0.0
-        dependencies:
-          - const
-          - either
-          - newtype
-          - prelude
-          - tuples
-      bigints:
-        repo: https://github.com/sharkdp/purescript-bigints.git
-        version: v7.0.1
-        dependencies:
-          - integers
-          - maybe
-          - strings
-      bower-json:
-        repo: https://github.com/klntsky/purescript-bower-json.git
-        version: v3.0.0
-        dependencies:
-          - argonaut-codecs
-          - arrays
-          - either
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - newtype
-          - prelude
-          - tuples
-      call-by-name:
-        repo: https://github.com/natefaubion/purescript-call-by-name.git
-        version: v4.0.1
-        dependencies:
-          - control
-          - either
-          - lazy
-          - maybe
-          - unsafe-coerce
-      canvas:
-        repo: https://github.com/purescript-web/purescript-canvas.git
-        version: v6.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - exceptions
-          - functions
-          - maybe
-      canvas-action:
-        repo: https://github.com/artemisSystem/purescript-canvas-action.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - arrays
-          - canvas
-          - colors
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - maybe
-          - numbers
-          - polymorphic-vectors
-          - prelude
-          - refs
-          - run
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-html
-      cartesian:
-        repo: https://github.com/Ebmtranceboy/purescript-cartesian.git
-        version: v1.0.6
-        dependencies:
-          - console
-          - effect
-          - integers
-          - psci-support
-      catenable-lists:
-        repo: https://github.com/purescript/purescript-catenable-lists.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - lists
-          - maybe
-          - prelude
-          - tuples
-          - unfoldable
-      channel:
-        repo: https://github.com/ConnorDillon/purescript-channel.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - assert
-          - avar
-          - console
-          - contravariant
-          - control
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - lazy
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      checked-exceptions:
-        repo: https://github.com/natefaubion/purescript-checked-exceptions.git
-        version: v3.1.1
-        dependencies:
-          - prelude
-          - transformers
-          - variant
-      codec:
-        repo: https://github.com/garyb/purescript-codec.git
-        version: v5.0.0
-        dependencies:
-          - profunctor
-          - transformers
-      codec-argonaut:
-        repo: https://github.com/garyb/purescript-codec-argonaut.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-core
-          - codec
-          - ordered-collections
-          - type-equality
-          - variant
-      colors:
-        repo: https://github.com/purescript-contrib/purescript-colors.git
-        version: v7.0.1
-        dependencies:
-          - arrays
-          - integers
-          - lists
-          - numbers
-          - partial
-          - strings
-      concurrent-queues:
-        repo: https://github.com/purescript-contrib/purescript-concurrent-queues.git
-        version: v3.0.0
-        dependencies:
-          - aff
-          - avar
-          - effect
-      console:
-        repo: https://github.com/purescript/purescript-console.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - prelude
-      const:
-        repo: https://github.com/purescript/purescript-const.git
-        version: v6.0.0
-        dependencies:
-          - invariant
-          - newtype
-          - prelude
-      contravariant:
-        repo: https://github.com/purescript/purescript-contravariant.git
-        version: v6.0.0
-        dependencies:
-          - const
-          - either
-          - newtype
-          - prelude
-          - tuples
-      control:
-        repo: https://github.com/purescript/purescript-control.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      convertable-options:
-        repo: https://github.com/natefaubion/purescript-convertable-options.git
-        version: v1.0.0
-        dependencies:
-          - console
-          - effect
-          - maybe
-          - record
-      coroutines:
-        repo: https://github.com/purescript-contrib/purescript-coroutines.git
-        version: v7.0.0
-        dependencies:
-          - freet
-          - parallel
-          - profunctor
-      css:
-        repo: https://github.com/purescript-contrib/purescript-css.git
-        version: v6.0.0
-        dependencies:
-          - colors
-          - console
-          - effect
-          - nonempty
-          - profunctor
-          - strings
-          - these
-          - transformers
-      datetime:
-        repo: https://github.com/purescript/purescript-datetime.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - either
-          - enums
-          - foldable-traversable
-          - functions
-          - gen
-          - integers
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - ordered-collections
-          - partial
-          - prelude
-          - tuples
-      datetime-parsing:
-        repo: https://github.com/flounders/purescript-datetime-parsing.git
-        version: v0.2.0
-        dependencies:
-          - arrays
-          - datetime
-          - either
-          - enums
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - numbers
-          - parsing
-          - prelude
-          - strings
-          - unicode
-      debug:
-        repo: https://github.com/garyb/purescript-debug.git
-        version: v6.0.0
-        dependencies:
-          - functions
-          - prelude
-      decimals:
-        repo: https://github.com/sharkdp/purescript-decimals.git
-        version: v7.0.0
-        dependencies:
-          - maybe
-      dissect:
-        repo: https://github.com/PureFunctor/purescript-dissect.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - foreign-object
-          - functors
-          - newtype
-          - partial
-          - prelude
-          - tailrec
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - variant
-      distributive:
-        repo: https://github.com/purescript/purescript-distributive.git
-        version: v6.0.0
-        dependencies:
-          - identity
-          - newtype
-          - prelude
-          - tuples
-          - type-equality
-      dodo-printer:
-        repo: https://github.com/natefaubion/purescript-dodo-printer.git
-        version: v2.2.0
-        dependencies:
-          - aff
-          - ansi
-          - avar
-          - console
-          - effect
-          - foldable-traversable
-          - lists
-          - maybe
-          - minibench
-          - node-child-process
-          - node-fs-aff
-          - node-process
-          - psci-support
-          - strings
-      dom-indexed:
-        repo: https://github.com/purescript-halogen/purescript-dom-indexed.git
-        version: v11.0.0
-        dependencies:
-          - media-types
-          - prelude
-          - web-clipboard
-          - web-pointerevents
-          - web-touchevents
-      droplet:
-        repo: https://github.com/easafe/purescript-droplet.git
-        version: v0.4.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - bigints
-          - datetime
-          - debug
-          - effect
-          - either
-          - enums
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - integers
-          - maybe
-          - newtype
-          - nullable
-          - ordered-collections
-          - partial
-          - prelude
-          - profunctor
-          - record
-          - spec
-          - strings
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-      dynamic-buffer:
-        repo: https://github.com/kritzcreek/purescript-dynamic-buffer.git
-        version: v3.0.1
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - refs
-      effect:
-        repo: https://github.com/purescript/purescript-effect.git
-        version: v4.0.0
-        dependencies:
-          - prelude
-      either:
-        repo: https://github.com/purescript/purescript-either.git
-        version: v6.1.0
-        dependencies:
-          - control
-          - invariant
-          - maybe
-          - prelude
-      elmish:
-        repo: https://github.com/collegevine/purescript-elmish.git
-        version: v0.8.1
-        dependencies:
-          - aff
-          - argonaut-core
-          - arrays
-          - bifunctors
-          - console
-          - debug
-          - effect
-          - either
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - functions
-          - integers
-          - js-date
-          - maybe
-          - nullable
-          - partial
-          - prelude
-          - refs
-          - typelevel-prelude
-          - undefined-is-not-a-problem
-          - unsafe-coerce
-          - web-dom
-          - web-html
-      elmish-enzyme:
-        repo: https://github.com/collegevine/purescript-elmish-enzyme.git
-        version: v0.1.1
-        dependencies:
-          - aff
-          - aff-promise
-          - arrays
-          - console
-          - debug
-          - effect
-          - elmish
-          - foldable-traversable
-          - foreign
-          - functions
-          - prelude
-          - transformers
-          - unsafe-coerce
-      elmish-hooks:
-        repo: https://github.com/collegevine/purescript-elmish-hooks.git
-        version: v0.8.2
-        dependencies:
-          - aff
-          - debug
-          - elmish
-          - maybe
-          - prelude
-          - tuples
-          - undefined-is-not-a-problem
-      elmish-html:
-        repo: https://github.com/collegevine/purescript-elmish-html.git
-        version: v0.7.1
-        dependencies:
-          - effect
-          - elmish
-          - foreign
-          - foreign-object
-          - prelude
-          - record
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-html
-      email-validate:
-        repo: https://github.com/cdepillabout/purescript-email-validate.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - string-parsers
-          - transformers
-      encoding:
-        repo: https://github.com/menelaos/purescript-encoding.git
-        version: v0.0.8
-        dependencies:
-          - arraybuffer-types
-          - either
-          - exceptions
-          - functions
-          - prelude
-      enums:
-        repo: https://github.com/purescript/purescript-enums.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - either
-          - gen
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tuples
-          - unfoldable
-      exceptions:
-        repo: https://github.com/purescript/purescript-exceptions.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - either
-          - maybe
-          - prelude
-      exists:
-        repo: https://github.com/purescript/purescript-exists.git
-        version: v6.0.0
-        dependencies:
-          - unsafe-coerce
-      exitcodes:
-        repo: https://github.com/Risto-Stevcev/purescript-exitcodes.git
-        version: v4.0.0
-        dependencies:
-          - enums
-      expect-inferred:
-        repo: https://github.com/justinwoo/purescript-expect-inferred.git
-        version: v3.0.0
-        dependencies:
-          - prelude
-          - typelevel-prelude
-      fast-vect:
-        repo: https://github.com/sigma-andex/purescript-fast-vect.git
-        version: v0.7.0
-        dependencies:
-          - arrays
-          - filterable
-          - foldable-traversable
-          - lists
-          - maybe
-          - ordered-collections
-          - prelude
-          - profunctor
-          - tuples
-          - unfoldable
-      filterable:
-        repo: https://github.com/purescript/purescript-filterable.git
-        version: v5.0.0
-        dependencies:
-          - arrays
-          - either
-          - foldable-traversable
-          - identity
-          - lists
-          - ordered-collections
-      fixed-points:
-        repo: https://github.com/purescript-contrib/purescript-fixed-points.git
-        version: v7.0.0
-        dependencies:
-          - exists
-          - newtype
-          - prelude
-          - transformers
-      fixed-precision:
-        repo: https://github.com/lumihq/purescript-fixed-precision.git
-        version: v5.0.0
-        dependencies:
-          - arrays
-          - bigints
-          - control
-          - integers
-          - maybe
-          - numbers
-          - partial
-          - prelude
-          - strings
-      flame:
-        repo: https://github.com/easafe/purescript-flame.git
-        version: v1.2.0
-        dependencies:
-          - aff
-          - argonaut-codecs
-          - argonaut-core
-          - argonaut-generic
-          - arrays
-          - bifunctors
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - maybe
-          - newtype
-          - nullable
-          - partial
-          - prelude
-          - random
-          - refs
-          - spec
-          - strings
-          - tuples
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-html
-          - web-uievents
-      float32:
-        repo: https://github.com/purescript-contrib/purescript-float32.git
-        version: v2.0.0
-        dependencies:
-          - gen
-          - maybe
-          - prelude
-      foldable-traversable:
-        repo: https://github.com/purescript/purescript-foldable-traversable.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - const
-          - control
-          - either
-          - functors
-          - identity
-          - maybe
-          - newtype
-          - orders
-          - prelude
-          - tuples
-      foreign:
-        repo: https://github.com/purescript/purescript-foreign.git
-        version: v7.0.0
-        dependencies:
-          - either
-          - functions
-          - identity
-          - integers
-          - lists
-          - maybe
-          - prelude
-          - strings
-          - transformers
-      foreign-object:
-        repo: https://github.com/purescript/purescript-foreign-object.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - functions
-          - gen
-          - lists
-          - maybe
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - typelevel-prelude
-          - unfoldable
-      foreign-readwrite:
-        repo: https://github.com/artemisSystem/purescript-foreign-readwrite.git
-        version: v3.0.0
-        dependencies:
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - record
-          - safe-coerce
-          - transformers
-          - unsafe-coerce
-      fork:
-        repo: https://github.com/purescript-contrib/purescript-fork.git
-        version: v6.0.0
-        dependencies:
-          - aff
-      form-urlencoded:
-        repo: https://github.com/purescript-contrib/purescript-form-urlencoded.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - js-uri
-          - maybe
-          - newtype
-          - prelude
-          - strings
-          - tuples
-      formatters:
-        repo: https://github.com/purescript-contrib/purescript-formatters.git
-        version: v7.0.0
-        dependencies:
-          - datetime
-          - fixed-points
-          - lists
-          - numbers
-          - parsing
-          - prelude
-          - transformers
-      free:
-        repo: https://github.com/purescript/purescript-free.git
-        version: v7.0.0
-        dependencies:
-          - catenable-lists
-          - control
-          - distributive
-          - either
-          - exists
-          - foldable-traversable
-          - invariant
-          - lazy
-          - maybe
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-      freeap:
-        repo: https://github.com/ethul/purescript-freeap.git
-        version: v7.0.0
-        dependencies:
-          - const
-          - exists
-          - gen
-          - lists
-      freet:
-        repo: https://github.com/purescript-contrib/purescript-freet.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - bifunctors
-          - effect
-          - either
-          - exists
-          - free
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      functions:
-        repo: https://github.com/purescript/purescript-functions.git
-        version: v6.0.0
-        dependencies:
-          - prelude
-      functors:
-        repo: https://github.com/purescript/purescript-functors.git
-        version: v5.0.0
-        dependencies:
-          - bifunctors
-          - const
-          - contravariant
-          - control
-          - distributive
-          - either
-          - invariant
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - tuples
-          - unsafe-coerce
-      fuzzy:
-        repo: https://github.com/citizennet/purescript-fuzzy.git
-        version: v0.4.0
-        dependencies:
-          - foldable-traversable
-          - foreign-object
-          - newtype
-          - ordered-collections
-          - prelude
-          - rationals
-          - strings
-          - tuples
-      gen:
-        repo: https://github.com/purescript/purescript-gen.git
-        version: v4.0.0
-        dependencies:
-          - either
-          - foldable-traversable
-          - identity
-          - maybe
-          - newtype
-          - nonempty
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      generate-values:
-        repo: https://github.com/jordanmartinez/purescript-generate-values.git
-        version: v1.0.1
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - enums
-          - foldable-traversable
-          - gen
-          - identity
-          - integers
-          - lcg
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - partial
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      geometry-plane:
-        repo: https://github.com/Ebmtranceboy/purescript-geometry-plane.git
-        version: v1.0.3
-        dependencies:
-          - console
-          - effect
-          - psci-support
-          - sparse-polynomials
-      github-actions-toolkit:
-        repo: https://github.com/purescript-contrib/purescript-github-actions-toolkit.git
-        version: v0.5.0
-        dependencies:
-          - aff
-          - aff-promise
-          - effect
-          - foreign-object
-          - node-buffer
-          - node-path
-          - node-streams
-          - nullable
-          - transformers
-      graphs:
-        repo: https://github.com/purescript/purescript-graphs.git
-        version: v8.0.0
-        dependencies:
-          - catenable-lists
-          - ordered-collections
-      group:
-        repo: https://github.com/morganthomas/purescript-group.git
-        version: v4.1.1
-        dependencies:
-          - lists
-      halogen:
-        repo: https://github.com/purescript-halogen/purescript-halogen.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - avar
-          - console
-          - const
-          - dom-indexed
-          - effect
-          - foreign
-          - fork
-          - free
-          - freeap
-          - halogen-subscriptions
-          - halogen-vdom
-          - media-types
-          - nullable
-          - ordered-collections
-          - parallel
-          - profunctor
-          - transformers
-          - unsafe-coerce
-          - unsafe-reference
-          - web-file
-          - web-uievents
-      halogen-css:
-        repo: https://github.com/purescript-halogen/purescript-halogen-css.git
-        version: v10.0.0
-        dependencies:
-          - css
-          - halogen
-      halogen-formless:
-        repo: https://github.com/thomashoneyman/purescript-halogen-formless.git
-        version: v4.0.0
-        dependencies:
-          - convertable-options
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - halogen
-          - heterogeneous
-          - maybe
-          - prelude
-          - record
-          - safe-coerce
-          - type-equality
-          - unsafe-coerce
-          - unsafe-reference
-          - variant
-          - web-events
-          - web-uievents
-      halogen-hooks:
-        repo: https://github.com/thomashoneyman/purescript-halogen-hooks.git
-        version: v0.6.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - effect
-          - exceptions
-          - foldable-traversable
-          - foreign-object
-          - free
-          - freeap
-          - halogen
-          - halogen-subscriptions
-          - maybe
-          - newtype
-          - ordered-collections
-          - parallel
-          - partial
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-          - unsafe-reference
-          - web-dom
-          - web-html
-      halogen-hooks-extra:
-        repo: https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git
-        version: v0.9.0
-        dependencies:
-          - halogen-hooks
-      halogen-store:
-        repo: https://github.com/thomashoneyman/purescript-halogen-store.git
-        version: v0.5.0
-        dependencies:
-          - aff
-          - distributive
-          - effect
-          - fork
-          - halogen
-          - halogen-hooks
-          - halogen-subscriptions
-          - maybe
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-reference
-      halogen-storybook:
-        repo: https://github.com/rnons/purescript-halogen-storybook.git
-        version: v2.0.0
-        dependencies:
-          - foreign-object
-          - halogen
-          - prelude
-          - routing
-      halogen-subscriptions:
-        repo: https://github.com/purescript-halogen/purescript-halogen-subscriptions.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - effect
-          - foldable-traversable
-          - functors
-          - refs
-          - safe-coerce
-          - unsafe-reference
-      halogen-svg-elems:
-        repo: https://github.com/JordanMartinez/purescript-halogen-svg-elems.git
-        version: v6.0.0
-        dependencies:
-          - halogen
-      halogen-vdom:
-        repo: https://github.com/purescript-halogen/purescript-halogen-vdom.git
-        version: v8.0.0
-        dependencies:
-          - bifunctors
-          - effect
-          - foreign
-          - foreign-object
-          - maybe
-          - prelude
-          - refs
-          - tuples
-          - unsafe-coerce
-          - web-html
-      halogen-vdom-string-renderer:
-        repo: https://github.com/purescript-halogen/purescript-halogen-vdom-string-renderer.git
-        version: v0.5.0
-        dependencies:
-          - foreign
-          - halogen-vdom
-          - ordered-collections
-          - prelude
-      heckin:
-        repo: https://github.com/maxdeviant/purescript-heckin.git
-        version: v2.0.1
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - maybe
-          - prelude
-          - strings
-          - transformers
-          - tuples
-          - unicode
-      heterogeneous:
-        repo: https://github.com/natefaubion/purescript-heterogeneous.git
-        version: v0.6.0
-        dependencies:
-          - either
-          - functors
-          - prelude
-          - record
-          - tuples
-          - variant
-      heterogeneous-extrablatt:
-        repo: https://github.com/sigma-andex/purescript-heterogeneous-extrablatt.git
-        version: v0.2.1
-        dependencies:
-          - heterogeneous
-          - prelude
-          - record
-      http-methods:
-        repo: https://github.com/purescript-contrib/purescript-http-methods.git
-        version: v6.0.0
-        dependencies:
-          - either
-          - prelude
-          - strings
-      httpure:
-        repo: https://github.com/citizennet/purescript-httpure.git
-        version: v0.15.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - js-uri
-          - maybe
-          - newtype
-          - node-buffer
-          - node-fs
-          - node-http
-          - node-streams
-          - options
-          - ordered-collections
-          - prelude
-          - refs
-          - strings
-          - tuples
-          - type-equality
-      httpurple:
-        repo: https://github.com/sigma-andex/purescript-httpurple.git
-        version: v1.3.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - js-uri
-          - justifill
-          - maybe
-          - newtype
-          - node-buffer
-          - node-fs
-          - node-http
-          - node-net
-          - node-process
-          - node-streams
-          - options
-          - ordered-collections
-          - posix-types
-          - prelude
-          - profunctor
-          - record
-          - refs
-          - routing-duplex
-          - strings
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-      httpurple-argonaut:
-        repo: https://github.com/sigma-andex/purescript-httpurple-argonaut.git
-        version: v1.0.1
-        dependencies:
-          - argonaut
-          - console
-          - effect
-          - either
-          - httpurple
-          - prelude
-      httpurple-yoga-json:
-        repo: https://github.com/sigma-andex/purescript-httpurple-yoga-json.git
-        version: v1.0.0
-        dependencies:
-          - console
-          - effect
-          - either
-          - foreign
-          - httpurple
-          - lists
-          - prelude
-          - yoga-json
-      identity:
-        repo: https://github.com/purescript/purescript-identity.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - invariant
-          - newtype
-          - prelude
-      indexed-monad:
-        repo: https://github.com/garyb/purescript-indexed-monad.git
-        version: v2.1.0
-        dependencies:
-          - control
-          - newtype
-      int64:
-        repo: https://github.com/purescript-contrib/purescript-int64.git
-        version: v2.0.0
-        dependencies:
-          - effect
-          - foreign
-          - functions
-          - integers
-          - maybe
-          - nullable
-          - prelude
-          - quickcheck
-      integers:
-        repo: https://github.com/purescript/purescript-integers.git
-        version: v6.0.0
-        dependencies:
-          - maybe
-          - numbers
-          - prelude
-      interpolate:
-        repo: https://github.com/jordanmartinez/purescript-interpolate.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-      invariant:
-        repo: https://github.com/purescript/purescript-invariant.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - prelude
-      js-date:
-        repo: https://github.com/purescript-contrib/purescript-js-date.git
-        version: v8.0.0
-        dependencies:
-          - datetime
-          - effect
-          - exceptions
-          - foreign
-          - integers
-          - now
-      js-fileio:
-        repo: https://github.com/newlandsvalley/purescript-js-fileio.git
-        version: v3.0.0
-        dependencies:
-          - aff
-          - effect
-          - prelude
-      js-timers:
-        repo: https://github.com/purescript-contrib/purescript-js-timers.git
-        version: v6.1.0
-        dependencies:
-          - effect
-      js-uri:
-        repo: https://github.com/purescript-contrib/purescript-js-uri.git
-        version: v3.0.0
-        dependencies:
-          - functions
-          - maybe
-      justifill:
-        repo: https://github.com/i-am-the-slime/purescript-justifill.git
-        version: v0.5.0
-        dependencies:
-          - maybe
-          - prelude
-          - record
-          - typelevel-prelude
-      jwt:
-        repo: https://github.com/menelaos/purescript-jwt.git
-        version: v0.0.9
-        dependencies:
-          - argonaut-core
-          - arrays
-          - b64
-          - either
-          - exceptions
-          - prelude
-          - profunctor-lenses
-          - strings
-      language-cst-parser:
-        repo: https://github.com/natefaubion/purescript-language-cst-parser.git
-        version: v0.12.0
-        dependencies:
-          - arrays
-          - const
-          - control
-          - either
-          - foldable-traversable
-          - free
-          - functions
-          - functors
-          - identity
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - ordered-collections
-          - partial
-          - prelude
-          - st
-          - strings
-          - transformers
-          - tuples
-          - typelevel-prelude
-          - unfoldable
-          - unsafe-coerce
-      lazy:
-        repo: https://github.com/purescript/purescript-lazy.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - invariant
-          - prelude
-      lcg:
-        repo: https://github.com/purescript/purescript-lcg.git
-        version: v4.0.0
-        dependencies:
-          - effect
-          - integers
-          - maybe
-          - partial
-          - prelude
-          - random
-      leibniz:
-        repo: https://github.com/paf31/purescript-leibniz.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-          - unsafe-coerce
-      linalg:
-        repo: https://github.com/gbagan/purescript-linalg.git
-        version: v5.1.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - functions
-          - maybe
-          - prelude
-          - tuples
-      lists:
-        repo: https://github.com/purescript/purescript-lists.git
-        version: v7.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - foldable-traversable
-          - lazy
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      logging:
-        repo: https://github.com/rightfold/purescript-logging.git
-        version: v3.0.0
-        dependencies:
-          - console
-          - contravariant
-          - effect
-          - either
-          - prelude
-          - transformers
-          - tuples
-      machines:
-        repo: https://github.com/purescript-contrib/purescript-machines.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - lists
-          - maybe
-          - prelude
-          - profunctor
-          - tuples
-          - unfoldable
-      matrices:
-        repo: https://github.com/kRITZCREEK/purescript-matrices.git
-        version: v5.0.1
-        dependencies:
-          - arrays
-          - strings
-      matryoshka:
-        repo: https://github.com/purescript-contrib/purescript-matryoshka.git
-        version: v1.0.0
-        dependencies:
-          - fixed-points
-          - free
-          - prelude
-          - profunctor
-          - transformers
-      maybe:
-        repo: https://github.com/purescript/purescript-maybe.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - invariant
-          - newtype
-          - prelude
-      media-types:
-        repo: https://github.com/purescript-contrib/purescript-media-types.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      metadata:
-        repo: https://github.com/purescript/purescript-metadata.git
-        version: v0.15.0
-        dependencies: []
-      midi:
-        repo: https://github.com/newlandsvalley/purescript-midi.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - ordered-collections
-          - prelude
-          - signal
-          - string-parsers
-          - strings
-          - tuples
-          - unfoldable
-      minibench:
-        repo: https://github.com/purescript/purescript-minibench.git
-        version: v4.0.0
-        dependencies:
-          - console
-          - effect
-          - integers
-          - numbers
-          - partial
-          - prelude
-          - refs
-      mmorph:
-        repo: https://github.com/Thimoteus/purescript-mmorph.git
-        version: v7.0.0
-        dependencies:
-          - free
-          - functors
-          - transformers
-      monad-control:
-        repo: https://github.com/athanclark/purescript-monad-control.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - freet
-          - identity
-          - lists
-      monad-logger:
-        repo: https://github.com/cprussin/purescript-monad-logger.git
-        version: v1.3.1
-        dependencies:
-          - aff
-          - ansi
-          - argonaut
-          - arrays
-          - console
-          - control
-          - effect
-          - foldable-traversable
-          - foreign-object
-          - integers
-          - js-date
-          - maybe
-          - newtype
-          - ordered-collections
-          - prelude
-          - strings
-          - transformers
-          - tuples
-      monad-loops:
-        repo: https://github.com/mlang/purescript-monad-loops.git
-        version: v0.5.0
-        dependencies:
-          - lists
-          - maybe
-          - prelude
-          - tailrec
-          - tuples
-      monad-unlift:
-        repo: https://github.com/athanclark/purescript-monad-unlift.git
-        version: v1.0.1
-        dependencies:
-          - monad-control
-      monoidal:
-        repo: https://github.com/mcneissue/purescript-monoidal.git
-        version: v0.16.0
-        dependencies:
-          - either
-          - profunctor
-          - these
-          - tuples
-      morello:
-        repo: https://github.com/sigma-andex/purescript-morello.git
-        version: v0.3.2
-        dependencies:
-          - arrays
-          - barlow-lens
-          - foldable-traversable
-          - heterogeneous
-          - heterogeneous-extrablatt
-          - newtype
-          - prelude
-          - profunctor
-          - profunctor-lenses
-          - record
-          - tuples
-          - typelevel-prelude
-          - validation
-      motsunabe:
-        repo: https://github.com/justinwoo/purescript-motsunabe.git
-        version: v2.0.0
-        dependencies:
-          - lists
-          - strings
-      nano-id:
-        repo: https://github.com/eikooc/nano-id.git
-        version: v1.1.0
-        dependencies:
-          - aff
-          - effect
-          - lists
-          - maybe
-          - prelude
-          - random
-          - spec
-          - strings
-          - stringutils
-      naturals:
-        repo: https://github.com/LiamGoodacre/purescript-naturals.git
-        version: v3.0.0
-        dependencies:
-          - enums
-          - maybe
-          - prelude
-      nested-functor:
-        repo: https://github.com/acple/purescript-nested-functor.git
-        version: v0.2.1
-        dependencies:
-          - prelude
-          - type-equality
-      newtype:
-        repo: https://github.com/purescript/purescript-newtype.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-          - safe-coerce
-      node-buffer:
-        repo: https://github.com/purescript-node/purescript-node-buffer.git
-        version: v8.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - maybe
-          - st
-          - unsafe-coerce
-      node-buffer-blob:
-        repo: https://github.com/purescript-node/purescript-node-buffer-blob.git
-        version: v1.0.0
-        dependencies:
-          - aff-promise
-          - arraybuffer-types
-          - arrays
-          - console
-          - effect
-          - maybe
-          - media-types
-          - newtype
-          - node-buffer
-          - nullable
-          - prelude
-          - web-streams
-      node-child-process:
-        repo: https://github.com/purescript-node/purescript-node-child-process.git
-        version: v9.0.0
-        dependencies:
-          - exceptions
-          - foreign
-          - foreign-object
-          - functions
-          - node-fs
-          - node-streams
-          - nullable
-          - posix-types
-          - unsafe-coerce
-      node-fs:
-        repo: https://github.com/purescript-node/purescript-node-fs.git
-        version: v8.0.0
-        dependencies:
-          - datetime
-          - effect
-          - either
-          - enums
-          - exceptions
-          - functions
-          - integers
-          - js-date
-          - maybe
-          - node-buffer
-          - node-path
-          - node-streams
-          - nullable
-          - partial
-          - prelude
-          - strings
-          - unsafe-coerce
-      node-fs-aff:
-        repo: https://github.com/purescript-node/purescript-node-fs-aff.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - either
-          - node-fs
-          - node-path
-      node-http:
-        repo: https://github.com/purescript-node/purescript-node-http.git
-        version: v8.0.0
-        dependencies:
-          - arraybuffer-types
-          - contravariant
-          - effect
-          - foreign
-          - foreign-object
-          - maybe
-          - node-buffer
-          - node-net
-          - node-streams
-          - node-url
-          - nullable
-          - options
-          - prelude
-          - unsafe-coerce
-      node-net:
-        repo: https://github.com/purescript-node/purescript-node-net.git
-        version: v4.0.0
-        dependencies:
-          - effect
-          - either
-          - exceptions
-          - foreign
-          - maybe
-          - node-buffer
-          - node-fs
-          - nullable
-          - options
-          - prelude
-          - transformers
-      node-path:
-        repo: https://github.com/purescript-node/purescript-node-path.git
-        version: v5.0.0
-        dependencies:
-          - effect
-      node-process:
-        repo: https://github.com/purescript-node/purescript-node-process.git
-        version: v10.0.0
-        dependencies:
-          - effect
-          - foreign-object
-          - maybe
-          - node-streams
-          - posix-types
-          - prelude
-          - unsafe-coerce
-      node-readline:
-        repo: https://github.com/purescript-node/purescript-node-readline.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - foreign
-          - node-process
-          - node-streams
-          - options
-          - prelude
-      node-streams:
-        repo: https://github.com/purescript-node/purescript-node-streams.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - either
-          - exceptions
-          - node-buffer
-          - nullable
-          - prelude
-      node-streams-aff:
-        repo: https://github.com/jamesdbrock/purescript-node-streams-aff.git
-        version: v2.0.0
-        dependencies:
-          - aff
-          - arrays
-          - effect
-          - either
-          - exceptions
-          - maybe
-          - node-buffer
-          - node-streams
-          - prelude
-          - st
-          - tuples
-      node-url:
-        repo: https://github.com/purescript-node/purescript-node-url.git
-        version: v6.0.0
-        dependencies:
-          - nullable
-      nonempty:
-        repo: https://github.com/purescript/purescript-nonempty.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - maybe
-          - prelude
-          - tuples
-          - unfoldable
-      now:
-        repo: https://github.com/purescript-contrib/purescript-now.git
-        version: v6.0.0
-        dependencies:
-          - datetime
-          - effect
-      npm-package-json:
-        repo: https://github.com/maxdeviant/purescript-npm-package-json.git
-        version: v2.0.0
-        dependencies:
-          - argonaut
-          - control
-          - either
-          - foreign-object
-          - maybe
-          - ordered-collections
-          - prelude
-      nullable:
-        repo: https://github.com/purescript-contrib/purescript-nullable.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - functions
-          - maybe
-      numbers:
-        repo: https://github.com/purescript/purescript-numbers.git
-        version: v9.0.0
-        dependencies:
-          - functions
-          - maybe
-      open-folds:
-        repo: https://github.com/purescript-open-community/purescript-open-folds.git
-        version: v6.3.0
-        dependencies:
-          - bifunctors
-          - console
-          - control
-          - distributive
-          - effect
-          - either
-          - foldable-traversable
-          - identity
-          - invariant
-          - maybe
-          - newtype
-          - ordered-collections
-          - prelude
-          - profunctor
-          - psci-support
-          - tuples
-      open-memoize:
-        repo: https://github.com/purescript-open-community/purescript-open-memoize.git
-        version: v6.1.0
-        dependencies:
-          - console
-          - effect
-          - either
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - psci-support
-          - strings
-          - tuples
-      open-pairing:
-        repo: https://github.com/purescript-open-community/purescript-open-pairing.git
-        version: v6.1.0
-        dependencies:
-          - console
-          - control
-          - effect
-          - either
-          - free
-          - functors
-          - identity
-          - newtype
-          - prelude
-          - psci-support
-          - transformers
-          - tuples
-      options:
-        repo: https://github.com/purescript-contrib/purescript-options.git
-        version: v7.0.0
-        dependencies:
-          - contravariant
-          - foreign
-          - foreign-object
-          - maybe
-          - tuples
-      optparse:
-        repo: https://github.com/f-o-a-m/purescript-optparse.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - control
-          - effect
-          - either
-          - enums
-          - exists
-          - exitcodes
-          - foldable-traversable
-          - free
-          - gen
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - newtype
-          - node-buffer
-          - node-process
-          - node-streams
-          - nonempty
-          - numbers
-          - open-memoize
-          - partial
-          - prelude
-          - quickcheck
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-      ordered-collections:
-        repo: https://github.com/purescript/purescript-ordered-collections.git
-        version: v3.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - gen
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - unfoldable
-      ordered-set:
-        repo: https://github.com/flip111/purescript-ordered-set.git
-        version: v0.4.0
-        dependencies:
-          - argonaut-codecs
-          - arrays
-          - partial
-          - prelude
-          - unfoldable
-      orders:
-        repo: https://github.com/purescript/purescript-orders.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      pairs:
-        repo: https://github.com/sharkdp/purescript-pairs.git
-        version: v9.0.0
-        dependencies:
-          - console
-          - distributive
-          - foldable-traversable
-          - quickcheck
-      parallel:
-        repo: https://github.com/purescript/purescript-parallel.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - functors
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - refs
-          - transformers
-      parsing:
-        repo: https://github.com/purescript-contrib/purescript-parsing.git
-        version: v9.1.0
-        dependencies:
-          - arrays
-          - either
-          - foldable-traversable
-          - identity
-          - integers
-          - lists
-          - maybe
-          - nullable
-          - prelude
-          - strings
-          - transformers
-          - unicode
-      parsing-dataview:
-        repo: https://github.com/jamesdbrock/purescript-parsing-dataview.git
-        version: v3.1.0
-        dependencies:
-          - arraybuffer
-          - arraybuffer-types
-          - effect
-          - float32
-          - maybe
-          - parsing
-          - prelude
-          - transformers
-          - tuples
-          - uint
-      partial:
-        repo: https://github.com/purescript/purescript-partial.git
-        version: v4.0.0
-        dependencies: []
-      pathy:
-        repo: https://github.com/purescript-contrib/purescript-pathy.git
-        version: v9.0.0
-        dependencies:
-          - console
-          - exceptions
-          - lists
-          - partial
-          - profunctor
-          - strings
-          - transformers
-          - typelevel-prelude
-          - unsafe-coerce
-      pha:
-        repo: https://github.com/gbagan/purescript-pha.git
-        version: v0.9.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - datetime
-          - effect
-          - foldable-traversable
-          - free
-          - integers
-          - maybe
-          - prelude
-          - profunctor-lenses
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-          - unsafe-reference
-          - web-dom
-          - web-events
-          - web-html
-          - web-pointerevents
-          - web-uievents
-      phaser:
-        repo: https://github.com/lfarroco/purescript-phaser.git
-        version: v0.6.0
-        dependencies:
-          - canvas
-          - console
-          - effect
-          - maybe
-          - nullable
-          - options
-          - prelude
-          - web-html
-      pipes:
-        repo: https://github.com/felixschl/purescript-pipes.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - lists
-          - mmorph
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      point-free:
-        repo: https://github.com/ursi/purescript-point-free.git
-        version: v1.0.0
-        dependencies:
-          - prelude
-      polymorphic-vectors:
-        repo: https://github.com/artemisSystem/purescript-polymorphic-vectors.git
-        version: v4.0.0
-        dependencies:
-          - distributive
-          - foldable-traversable
-          - numbers
-          - prelude
-          - record
-          - safe-coerce
-          - type-equality
-          - typelevel-prelude
-      posix-types:
-        repo: https://github.com/purescript-node/purescript-posix-types.git
-        version: v6.0.0
-        dependencies:
-          - maybe
-          - prelude
-      precise:
-        repo: https://github.com/purescript-contrib/purescript-precise.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - exceptions
-          - gen
-          - integers
-          - lists
-          - numbers
-          - prelude
-          - strings
-      precise-datetime:
-        repo: https://github.com/awakesecurity/purescript-precise-datetime.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - datetime
-          - decimals
-          - either
-          - enums
-          - foldable-traversable
-          - formatters
-          - integers
-          - js-date
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - strings
-          - tuples
-          - unicode
-      prelude:
-        repo: https://github.com/purescript/purescript-prelude.git
-        version: v6.0.0
-        dependencies: []
-      prettier-printer:
-        repo: https://github.com/paulyoung/purescript-prettier-printer.git
-        version: v3.0.0
-        dependencies:
-          - console
-          - lists
-          - prelude
-          - strings
-          - tuples
-      profunctor:
-        repo: https://github.com/purescript/purescript-profunctor.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - distributive
-          - either
-          - exists
-          - invariant
-          - newtype
-          - prelude
-          - tuples
-      profunctor-lenses:
-        repo: https://github.com/purescript-contrib/purescript-profunctor-lenses.git
-        version: v8.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - const
-          - control
-          - distributive
-          - either
-          - foldable-traversable
-          - foreign-object
-          - functors
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - ordered-collections
-          - partial
-          - prelude
-          - profunctor
-          - record
-          - transformers
-          - tuples
-      protobuf:
-        repo: https://github.com/xc-jp/purescript-protobuf.git
-        version: v4.0.0
-        dependencies:
-          - arraybuffer
-          - arraybuffer-builder
-          - arraybuffer-types
-          - arrays
-          - control
-          - effect
-          - either
-          - enums
-          - exceptions
-          - float32
-          - foldable-traversable
-          - functions
-          - int64
-          - maybe
-          - newtype
-          - parsing
-          - parsing-dataview
-          - prelude
-          - record
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-          - uint
-          - web-encoding
-      ps-cst:
-        repo: https://github.com/purescript-codegen/purescript-ps-cst.git
-        version: v1.2.0
-        dependencies:
-          - ansi
-          - console
-          - dodo-printer
-          - effect
-          - node-fs-aff
-          - node-path
-          - psci-support
-          - record
-          - strings
-      psa-utils:
-        repo: https://github.com/natefaubion/purescript-psa-utils.git
-        version: v8.0.0
-        dependencies:
-          - ansi
-          - argonaut-codecs
-          - argonaut-core
-          - arrays
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - maybe
-          - node-path
-          - ordered-collections
-          - prelude
-          - strings
-          - tuples
-          - unsafe-coerce
-      psc-ide:
-        repo: https://github.com/kRITZCREEK/purescript-psc-ide.git
-        version: v19.0.0
-        dependencies:
-          - aff
-          - argonaut
-          - arrays
-          - console
-          - maybe
-          - node-child-process
-          - node-fs
-          - parallel
-          - random
-      psci-support:
-        repo: https://github.com/purescript/purescript-psci-support.git
-        version: v6.0.0
-        dependencies:
-          - console
-          - effect
-          - prelude
-      qualified-do:
-        repo: https://github.com/artemisSystem/purescript-qualified-do.git
-        version: v2.2.0
-        dependencies:
-          - arrays
-          - control
-          - foldable-traversable
-          - parallel
-          - prelude
-          - unfoldable
-      quantities:
-        repo: https://github.com/sharkdp/purescript-quantities.git
-        version: v12.0.1
-        dependencies:
-          - decimals
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - newtype
-          - nonempty
-          - numbers
-          - pairs
-          - prelude
-          - tuples
-      quickcheck:
-        repo: https://github.com/purescript/purescript-quickcheck.git
-        version: v8.0.1
-        dependencies:
-          - arrays
-          - console
-          - control
-          - effect
-          - either
-          - enums
-          - exceptions
-          - foldable-traversable
-          - gen
-          - identity
-          - integers
-          - lazy
-          - lcg
-          - lists
-          - maybe
-          - newtype
-          - nonempty
-          - numbers
-          - partial
-          - prelude
-          - record
-          - st
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-          - unfoldable
-      quickcheck-combinators:
-        repo: https://github.com/athanclark/purescript-quickcheck-combinators.git
-        version: v0.1.3
-        dependencies:
-          - quickcheck
-          - typelevel
-      quickcheck-laws:
-        repo: https://github.com/purescript-contrib/purescript-quickcheck-laws.git
-        version: v7.0.0
-        dependencies:
-          - enums
-          - quickcheck
-      quickcheck-utf8:
-        repo: https://github.com/openchronology/purescript-quickcheck-utf8.git
-        version: v0.0.0
-        dependencies:
-          - quickcheck
-      quotient:
-        repo: https://github.com/rightfold/purescript-quotient.git
-        version: v3.0.0
-        dependencies:
-          - prelude
-          - quickcheck
-      random:
-        repo: https://github.com/purescript/purescript-random.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - integers
-      rationals:
-        repo: https://github.com/anttih/purescript-rationals.git
-        version: v5.0.0
-        dependencies:
-          - integers
-          - prelude
-      react:
-        repo: https://github.com/purescript-contrib/purescript-react.git
-        version: v10.0.1
-        dependencies:
-          - effect
-          - exceptions
-          - maybe
-          - nullable
-          - prelude
-          - typelevel-prelude
-          - unsafe-coerce
-      react-basic:
-        repo: https://github.com/lumihq/purescript-react-basic.git
-        version: v17.0.0
-        dependencies:
-          - effect
-          - prelude
-          - record
-      react-basic-dom:
-        repo: https://github.com/lumihq/purescript-react-basic-dom.git
-        version: v5.0.0
-        dependencies:
-          - effect
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - nullable
-          - prelude
-          - react-basic
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-file
-          - web-html
-      react-basic-hooks:
-        repo: https://github.com/megamaddu/purescript-react-basic-hooks.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - aff-promise
-          - bifunctors
-          - console
-          - control
-          - datetime
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - functions
-          - indexed-monad
-          - integers
-          - maybe
-          - newtype
-          - now
-          - nullable
-          - ordered-collections
-          - prelude
-          - react-basic
-          - refs
-          - tuples
-          - type-equality
-          - unsafe-coerce
-          - unsafe-reference
-          - web-html
-      react-dom:
-        repo: https://github.com/purescript-contrib/purescript-react-dom.git
-        version: v8.0.0
-        dependencies:
-          - effect
-          - react
-          - web-dom
-      read:
-        repo: https://github.com/truqu/purescript-read.git
-        version: v1.0.1
-        dependencies:
-          - maybe
-          - prelude
-          - strings
-      record:
-        repo: https://github.com/purescript/purescript-record.git
-        version: v4.0.0
-        dependencies:
-          - functions
-          - prelude
-          - unsafe-coerce
-      refined:
-        repo: https://github.com/danieljharvey/purescript-refined.git
-        version: v1.0.0
-        dependencies:
-          - argonaut
-          - effect
-          - prelude
-          - quickcheck
-          - typelevel
-      refs:
-        repo: https://github.com/purescript/purescript-refs.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - prelude
-      remotedata:
-        repo: https://github.com/krisajenkins/purescript-remotedata.git
-        version: v5.0.0
-        dependencies:
-          - bifunctors
-          - either
-          - profunctor-lenses
-      resource:
-        repo: https://github.com/joneshf/purescript-resource.git
-        version: v2.0.1
-        dependencies:
-          - aff
-          - console
-          - control
-          - effect
-          - newtype
-          - prelude
-          - psci-support
-          - refs
-      resourcet:
-        repo: https://github.com/robertdp/purescript-resourcet.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - effect
-          - foldable-traversable
-          - maybe
-          - ordered-collections
-          - parallel
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-      result:
-        repo: https://github.com/ad-si/purescript-result.git
-        version: v1.0.3
-        dependencies:
-          - either
-          - foldable-traversable
-          - prelude
-      return:
-        repo: https://github.com/ursi/purescript-return.git
-        version: v0.2.0
-        dependencies:
-          - foldable-traversable
-          - point-free
-          - prelude
-      ring-modules:
-        repo: https://github.com/f-o-a-m/purescript-ring-modules.git
-        version: v5.0.1
-        dependencies:
-          - prelude
-      routing:
-        repo: https://github.com/purescript-contrib/purescript-routing.git
-        version: v11.0.0
-        dependencies:
-          - aff
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - integers
-          - js-uri
-          - lists
-          - maybe
-          - numbers
-          - partial
-          - prelude
-          - semirings
-          - tuples
-          - validation
-          - web-html
-      routing-duplex:
-        repo: https://github.com/natefaubion/purescript-routing-duplex.git
-        version: v0.6.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - js-uri
-          - lazy
-          - numbers
-          - prelude
-          - profunctor
-          - record
-          - strings
-          - typelevel-prelude
-      run:
-        repo: https://github.com/natefaubion/purescript-run.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - free
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - tailrec
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - variant
-      safe-coerce:
-        repo: https://github.com/purescript/purescript-safe-coerce.git
-        version: v2.0.0
-        dependencies:
-          - unsafe-coerce
-      safely:
-        repo: https://github.com/paf31/purescript-safely.git
-        version: v4.0.1
-        dependencies:
-          - freet
-          - lists
-      selection-foldable:
-        repo: https://github.com/jamieyung/purescript-selection-foldable.git
-        version: v0.2.0
-        dependencies:
-          - filterable
-          - foldable-traversable
-          - maybe
-          - prelude
-      semirings:
-        repo: https://github.com/purescript/purescript-semirings.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - lists
-          - newtype
-          - prelude
-      signal:
-        repo: https://github.com/bodil/purescript-signal.git
-        version: v13.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - foldable-traversable
-          - maybe
-          - prelude
-      simple-emitter:
-        repo: https://github.com/oreshinya/purescript-simple-emitter.git
-        version: v2.0.0
-        dependencies:
-          - ordered-collections
-          - refs
-      sized-matrices:
-        repo: https://github.com/csicar/purescript-sized-matrices.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - distributive
-          - foldable-traversable
-          - maybe
-          - prelude
-          - sized-vectors
-          - strings
-          - typelevel
-          - unfoldable
-          - vectorfield
-      sized-vectors:
-        repo: https://github.com/bodil/purescript-sized-vectors.git
-        version: v5.0.2
-        dependencies:
-          - argonaut
-          - arrays
-          - distributive
-          - foldable-traversable
-          - maybe
-          - prelude
-          - quickcheck
-          - typelevel
-          - unfoldable
-      slug:
-        repo: https://github.com/thomashoneyman/purescript-slug.git
-        version: v3.0.1
-        dependencies:
-          - argonaut-codecs
-          - maybe
-          - prelude
-          - strings
-          - unicode
-      soundfonts:
-        repo: https://github.com/newlandsvalley/purescript-soundfonts.git
-        version: v4.1.0
-        dependencies:
-          - aff
-          - affjax
-          - affjax-web
-          - argonaut-core
-          - arraybuffer-types
-          - arrays
-          - b64
-          - bifunctors
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign-object
-          - http-methods
-          - integers
-          - lists
-          - maybe
-          - midi
-          - ordered-collections
-          - parallel
-          - partial
-          - prelude
-          - strings
-          - transformers
-          - tuples
-      sparse-matrices:
-        repo: https://github.com/Ebmtranceboy/purescript-sparse-matrices.git
-        version: v1.2.1
-        dependencies:
-          - console
-          - effect
-          - prelude
-          - sparse-polynomials
-      sparse-polynomials:
-        repo: https://github.com/Ebmtranceboy/purescript-sparse-polynomials.git
-        version: v1.0.5
-        dependencies:
-          - cartesian
-          - console
-          - effect
-          - ordered-collections
-          - prelude
-          - rationals
-          - tuples
-      spec:
-        repo: https://github.com/purescript-spec/purescript-spec.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - ansi
-          - avar
-          - console
-          - exceptions
-          - foldable-traversable
-          - fork
-          - now
-          - pipes
-          - prelude
-          - strings
-          - transformers
-      spec-discovery:
-        repo: https://github.com/purescript-spec/purescript-spec-discovery.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - aff-promise
-          - arrays
-          - console
-          - effect
-          - foldable-traversable
-          - node-fs
-          - prelude
-          - spec
-      spec-quickcheck:
-        repo: https://github.com/purescript-spec/purescript-spec-quickcheck.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - prelude
-          - quickcheck
-          - random
-          - spec
-      ssrs:
-        repo: https://github.com/PureFunctor/purescript-ssrs.git
-        version: v1.0.0
-        dependencies:
-          - dissect
-          - either
-          - fixed-points
-          - free
-          - lists
-          - prelude
-          - safe-coerce
-          - tailrec
-          - tuples
-          - variant
-      st:
-        repo: https://github.com/purescript/purescript-st.git
-        version: v6.0.0
-        dependencies:
-          - partial
-          - prelude
-          - tailrec
-          - unsafe-coerce
-      strictlypositiveint:
-        repo: https://github.com/jamieyung/purescript-strictlypositiveint.git
-        version: v1.0.1
-        dependencies:
-          - prelude
-      string-parsers:
-        repo: https://github.com/purescript-contrib/purescript-string-parsers.git
-        version: v8.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - prelude
-          - strings
-          - tailrec
-      strings:
-        repo: https://github.com/purescript/purescript-strings.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - enums
-          - foldable-traversable
-          - gen
-          - integers
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-          - unsafe-coerce
-      strings-extra:
-        repo: https://github.com/purescript-contrib/purescript-strings-extra.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - maybe
-          - prelude
-          - strings
-          - unicode
-      stringutils:
-        repo: https://github.com/menelaos/purescript-stringutils.git
-        version: v0.0.12
-        dependencies:
-          - arrays
-          - integers
-          - maybe
-          - partial
-          - prelude
-          - strings
-      substitute:
-        repo: https://github.com/ursi/purescript-substitute.git
-        version: v0.2.3
-        dependencies:
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - prelude
-          - return
-          - strings
-      supply:
-        repo: https://github.com/ajnsit/purescript-supply.git
-        version: v0.2.0
-        dependencies:
-          - console
-          - control
-          - effect
-          - lazy
-          - prelude
-          - refs
-          - tuples
-      tailrec:
-        repo: https://github.com/purescript/purescript-tailrec.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - effect
-          - either
-          - identity
-          - maybe
-          - partial
-          - prelude
-          - refs
-      test-unit:
-        repo: https://github.com/bodil/purescript-test-unit.git
-        version: v17.0.0
-        dependencies:
-          - aff
-          - avar
-          - effect
-          - either
-          - free
-          - js-timers
-          - lists
-          - prelude
-          - quickcheck
-          - strings
-      thermite:
-        repo: https://github.com/paf31/purescript-thermite.git
-        version: v6.3.1
-        dependencies:
-          - aff
-          - coroutines
-          - freet
-          - profunctor-lenses
-          - react
-      thermite-dom:
-        repo: https://github.com/athanclark/purescript-thermite-dom.git
-        version: v0.3.1
-        dependencies:
-          - react
-          - react-dom
-          - thermite
-          - web-html
-      these:
-        repo: https://github.com/purescript-contrib/purescript-these.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - gen
-          - lists
-          - quickcheck
-          - quickcheck-laws
-          - tuples
-      transformers:
-        repo: https://github.com/purescript/purescript-transformers.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - distributive
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - identity
-          - lazy
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      tree-rose:
-        repo: https://github.com/jordanmartinez/purescript-tree-rose.git
-        version: v4.0.2
-        dependencies:
-          - control
-          - foldable-traversable
-          - free
-          - lists
-          - maybe
-          - prelude
-          - tailrec
-      tuples:
-        repo: https://github.com/purescript/purescript-tuples.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - invariant
-          - prelude
-      two-or-more:
-        repo: https://github.com/i-am-the-slime/purescript-two-or-more.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - foldable-traversable
-          - maybe
-          - partial
-          - prelude
-          - psci-support
-          - tuples
-      type-equality:
-        repo: https://github.com/purescript/purescript-type-equality.git
-        version: v4.0.1
-        dependencies: []
-      typelevel:
-        repo: https://github.com/bodil/purescript-typelevel.git
-        version: v6.0.0
-        dependencies:
-          - partial
-          - prelude
-          - tuples
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-lists:
-        repo: https://github.com/PureFunctor/purescript-typelevel-lists.git
-        version: v2.1.0
-        dependencies:
-          - prelude
-          - tuples
-          - typelevel-peano
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-peano:
-        repo: https://github.com/csicar/purescript-typelevel-peano.git
-        version: v1.0.1
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - prelude
-          - psci-support
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-prelude:
-        repo: https://github.com/purescript/purescript-typelevel-prelude.git
-        version: v7.0.0
-        dependencies:
-          - prelude
-          - type-equality
-      typelevel-rows:
-        repo: https://github.com/jordanmartinez/purescript-typelevel-rows.git
-        version: v0.1.0
-        dependencies:
-          - prelude
-      uint:
-        repo: https://github.com/purescript-contrib/purescript-uint.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - enums
-          - gen
-          - maybe
-          - numbers
-          - prelude
-      uncurried-transformers:
-        repo: https://github.com/PureFunctor/purescript-uncurried-transformers.git
-        version: v1.1.0
-        dependencies:
-          - control
-          - effect
-          - either
-          - functions
-          - identity
-          - prelude
-          - safe-coerce
-          - tailrec
-          - transformers
-          - tuples
-      undefined-is-not-a-problem:
-        repo: https://github.com/paluh/purescript-undefined-is-not-a-problem.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - assert
-          - effect
-          - either
-          - foreign
-          - maybe
-          - newtype
-          - prelude
-          - random
-          - tuples
-          - type-equality
-          - unsafe-coerce
-      unfoldable:
-        repo: https://github.com/purescript/purescript-unfoldable.git
-        version: v6.0.0
-        dependencies:
-          - foldable-traversable
-          - maybe
-          - partial
-          - prelude
-          - tuples
-      unicode:
-        repo: https://github.com/purescript-contrib/purescript-unicode.git
-        version: v6.0.0
-        dependencies:
-          - foldable-traversable
-          - maybe
-          - strings
-      unlift:
-        repo: https://github.com/tweag/purescript-unlift.git
-        version: v1.0.1
-        dependencies:
-          - aff
-          - effect
-          - either
-          - freet
-          - identity
-          - lists
-          - maybe
-          - monad-control
-          - prelude
-          - st
-          - transformers
-          - tuples
-      unsafe-coerce:
-        repo: https://github.com/purescript/purescript-unsafe-coerce.git
-        version: v6.0.0
-        dependencies: []
-      unsafe-reference:
-        repo: https://github.com/purescript-contrib/purescript-unsafe-reference.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-      uri:
-        repo: https://github.com/purescript-contrib/purescript-uri.git
-        version: v9.0.0
-        dependencies:
-          - arrays
-          - integers
-          - js-uri
-          - numbers
-          - parsing
-          - prelude
-          - profunctor-lenses
-          - these
-          - transformers
-          - unfoldable
-      validation:
-        repo: https://github.com/purescript/purescript-validation.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - newtype
-          - prelude
-      variant:
-        repo: https://github.com/natefaubion/purescript-variant.git
-        version: v8.0.0
-        dependencies:
-          - enums
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - record
-          - tuples
-          - unsafe-coerce
-      vectorfield:
-        repo: https://github.com/csicar/purescript-vectorfield.git
-        version: v1.0.1
-        dependencies:
-          - console
-          - effect
-          - group
-          - prelude
-          - psci-support
-      versions:
-        repo: https://github.com/hdgarrood/purescript-versions.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - either
-          - foldable-traversable
-          - functions
-          - integers
-          - lists
-          - maybe
-          - orders
-          - parsing
-          - partial
-          - strings
-      web-clipboard:
-        repo: https://github.com/purescript-web/purescript-web-clipboard.git
-        version: v4.0.0
-        dependencies:
-          - web-html
-      web-cssom:
-        repo: https://github.com/purescript-web/purescript-web-cssom.git
-        version: v2.0.0
-        dependencies:
-          - web-dom
-          - web-html
-          - web-uievents
-      web-dom:
-        repo: https://github.com/purescript-web/purescript-web-dom.git
-        version: v6.0.0
-        dependencies:
-          - web-events
-      web-dom-parser:
-        repo: https://github.com/purescript-web/purescript-web-dom-parser.git
-        version: v8.0.0
-        dependencies:
-          - effect
-          - partial
-          - prelude
-          - web-dom
-      web-dom-xpath:
-        repo: https://github.com/purescript-web/purescript-web-dom-xpath.git
-        version: v3.0.0
-        dependencies:
-          - web-dom
-      web-encoding:
-        repo: https://github.com/purescript-web/purescript-web-encoding.git
-        version: v3.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - newtype
-          - prelude
-      web-events:
-        repo: https://github.com/purescript-web/purescript-web-events.git
-        version: v4.0.0
-        dependencies:
-          - datetime
-          - enums
-          - foreign
-          - nullable
-      web-fetch:
-        repo: https://github.com/purescript-web/purescript-web-fetch.git
-        version: v3.0.0
-        dependencies:
-          - effect
-          - foreign-object
-          - http-methods
-          - prelude
-          - record
-          - typelevel-prelude
-          - web-file
-          - web-promise
-          - web-streams
-      web-file:
-        repo: https://github.com/purescript-web/purescript-web-file.git
-        version: v4.0.0
-        dependencies:
-          - foreign
-          - media-types
-          - web-dom
-      web-html:
-        repo: https://github.com/purescript-web/purescript-web-html.git
-        version: v4.0.0
-        dependencies:
-          - js-date
-          - web-dom
-          - web-file
-          - web-storage
-      web-page-visibility:
-        repo: https://git.sr.ht/~toastal/purescript-web-page-visibility
-        version: v2.0.0
-        dependencies:
-          - effect
-          - enums
-          - exceptions
-          - maybe
-          - prelude
-          - strings
-          - web-events
-          - web-html
-      web-pointerevents:
-        repo: https://github.com/purescript-web/purescript-web-pointerevents.git
-        version: v1.0.0
-        dependencies:
-          - effect
-          - maybe
-          - prelude
-          - web-dom
-          - web-uievents
-      web-promise:
-        repo: https://github.com/purescript-web/purescript-web-promise.git
-        version: v3.0.0
-        dependencies:
-          - effect
-          - exceptions
-          - foldable-traversable
-          - functions
-          - maybe
-          - prelude
-      web-socket:
-        repo: https://github.com/purescript-web/purescript-web-socket.git
-        version: v4.0.0
-        dependencies:
-          - arraybuffer-types
-          - web-file
-      web-storage:
-        repo: https://github.com/purescript-web/purescript-web-storage.git
-        version: v5.0.0
-        dependencies:
-          - nullable
-          - web-events
-      web-streams:
-        repo: https://github.com/purescript-web/purescript-web-streams.git
-        version: v3.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - exceptions
-          - nullable
-          - prelude
-          - tuples
-          - web-promise
-      web-touchevents:
-        repo: https://github.com/purescript-web/purescript-web-touchevents.git
-        version: v4.0.0
-        dependencies:
-          - web-uievents
-      web-uievents:
-        repo: https://github.com/purescript-web/purescript-web-uievents.git
-        version: v4.0.0
-        dependencies:
-          - web-html
-      web-workers:
-        repo: https://github.com/gbagan/purescript-web-workers.git
-        version: v1.1.0
-        dependencies:
-          - effect
-          - foreign
-          - maybe
-          - prelude
-          - unsafe-coerce
-          - web-events
-      web-xhr:
-        repo: https://github.com/purescript-web/purescript-web-xhr.git
-        version: v5.0.0
-        dependencies:
-          - arraybuffer-types
-          - datetime
-          - http-methods
-          - web-dom
-          - web-file
-          - web-html
-      yoga-fetch:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-fetch.git
-        version: v1.0.1
-        dependencies:
-          - aff
-          - aff-promise
-          - arraybuffer-types
-          - effect
-          - foreign
-          - foreign-object
-          - newtype
-          - prelude
-          - typelevel-prelude
-          - unsafe-coerce
-      yoga-json:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-json.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - identity
-          - lists
-          - maybe
-          - nullable
-          - partial
-          - prelude
-          - record
-          - transformers
-          - typelevel-prelude
-          - variant
-      yoga-postgres:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-postgres.git
-        version: v6.0.0
-        dependencies:
-          - aff
-          - arrays
-          - datetime
-          - effect
-          - either
-          - enums
-          - foldable-traversable
-          - foreign
-          - integers
-          - maybe
-          - nullable
-          - prelude
-          - transformers
-          - unsafe-coerce
+      abc-parser: 2.0.0
+      ace: 9.0.0
+      aff: 7.1.0
+      aff-bus: 6.0.0
+      aff-coroutines: 9.0.0
+      aff-promise: 4.0.0
+      aff-retry: 2.0.0
+      affjax: 13.0.0
+      affjax-node: 1.0.0
+      affjax-web: 1.0.0
+      ansi: 7.0.0
+      argonaut: 9.0.0
+      argonaut-aeson-generic: 0.4.1
+      argonaut-codecs: 9.1.0
+      argonaut-core: 7.0.0
+      argonaut-generic: 8.0.0
+      argonaut-traversals: 10.0.0
+      argparse-basic: 2.0.0
+      array-builder: 0.1.2
+      arraybuffer: 13.1.1
+      arraybuffer-builder: 3.1.0
+      arraybuffer-types: 3.0.2
+      arrays: 7.1.0
+      arrays-zipper: 2.0.1
+      ask: 1.0.0
+      assert: 6.0.0
+      avar: 5.0.0
+      b64: 0.0.8
+      barbies: 1.0.1
+      barlow-lens: 0.9.0
+      basic-auth: 3.0.1
+      bifunctors: 6.0.0
+      bigints: 7.0.1
+      bolson: 0.3.1
+      bower-json: 3.0.0
+      bucketchain: 1.0.1
+      bucketchain-basic-auth: 1.0.1
+      bucketchain-conditional: 1.0.1
+      bucketchain-cors: 1.0.1
+      bucketchain-csrf: 1.0.1
+      bucketchain-header-utils: 1.0.1
+      bucketchain-health: 1.0.1
+      bucketchain-history-api-fallback: 1.0.1
+      bucketchain-logger: 1.0.1
+      bucketchain-secure: 1.0.1
+      bucketchain-simple-api: 5.0.1
+      bucketchain-sslify: 1.0.1
+      bucketchain-static: 1.0.1
+      call-by-name: 4.0.1
+      canvas: 6.0.0
+      canvas-action: 9.0.0
+      cartesian: 1.0.6
+      catenable-lists: 7.0.0
+      channel: 1.0.0
+      checked-exceptions: 3.1.1
+      classless: 0.1.1
+      classless-arbitrary: 0.1.1
+      classless-decode-json: 0.1.1
+      classless-encode-json: 0.1.3
+      classnames: 2.0.0
+      codec: 6.0.0
+      codec-argonaut: 10.0.0
+      colors: 7.0.1
+      concur-core: 0.5.0
+      concur-react: 0.5.0
+      concurrent-queues: 3.0.0
+      console: 6.0.0
+      const: 6.0.0
+      contravariant: 6.0.0
+      control: 6.0.0
+      convertable-options: 1.0.0
+      coroutines: 7.0.0
+      crypto: 5.0.1
+      css: 6.0.0
+      datetime: 6.1.0
+      datetime-parsing: 0.2.0
+      debug: 6.0.2
+      decimals: 7.1.0
+      default-values: 1.0.1
+      deku: 0.9.9
+      deno: 0.0.5
+      dissect: 1.0.0
+      distributive: 6.0.0
+      dodo-printer: 2.2.1
+      dom-filereader: 7.0.0
+      dom-indexed: 11.0.0
+      dotenv: 3.0.0
+      droplet: 0.5.0
+      dynamic-buffer: 3.0.1
+      echarts-simple: 0.0.1
+      effect: 4.0.0
+      either: 6.1.0
+      elmish: 0.8.3
+      elmish-enzyme: 0.1.1
+      elmish-hooks: 0.9.1
+      elmish-html: 0.7.2
+      elmish-testing-library: 0.3.1
+      email-validate: 7.0.0
+      encoding: 0.0.8
+      enums: 6.0.1
+      error: 2.0.0
+      exceptions: 6.0.0
+      exists: 6.0.0
+      exitcodes: 4.0.0
+      expect-inferred: 3.0.0
+      fahrtwind: 2.0.0
+      fallback: 0.1.0
+      fast-vect: 1.1.0
+      fetch: 1.1.4
+      fetch-argonaut: 1.0.0
+      fetch-core: 4.0.4
+      fetch-yoga-json: 1.1.0
+      filterable: 5.0.0
+      fixed-points: 7.0.0
+      fixed-precision: 5.0.0
+      flame: 1.2.0
+      float32: 2.0.0
+      foldable-traversable: 6.0.0
+      foreign: 7.0.0
+      foreign-object: 4.1.0
+      foreign-readwrite: 3.4.0
+      fork: 6.0.0
+      form-urlencoded: 7.0.0
+      formatters: 7.0.0
+      framer-motion: 1.0.1
+      free: 7.0.0
+      freeap: 7.0.0
+      freer-free: 0.0.1
+      freet: 7.0.0
+      functions: 6.0.0
+      functor1: 3.0.0
+      functors: 5.0.0
+      fuzzy: 0.4.0
+      gen: 4.0.0
+      generate-values: 1.0.1
+      generic-router: 0.0.1
+      geometry-plane: 1.0.3
+      github-actions-toolkit: 0.5.0
+      grain: 3.0.0
+      grain-router: 3.0.0
+      grain-virtualized: 3.0.0
+      graphql-client: 9.3.2
+      graphs: 8.1.0
+      group: 4.1.1
+      halogen: 7.0.0
+      halogen-bootstrap5: 2.1.0
+      halogen-css: 10.0.0
+      halogen-echarts-simple: 0.0.4
+      halogen-formless: 4.0.2
+      halogen-hooks: 0.6.3
+      halogen-hooks-extra: 0.9.0
+      halogen-store: 0.5.4
+      halogen-storybook: 2.0.0
+      halogen-subscriptions: 2.0.0
+      halogen-svg-elems: 7.0.0
+      halogen-vdom: 8.0.0
+      halogen-vdom-string-renderer: 0.5.0
+      heckin: 2.0.1
+      heterogeneous: 0.6.0
+      homogeneous: 0.4.0
+      http-methods: 6.0.0
+      httpure: 0.16.0
+      httpurple: 3.0.1
+      httpurple-argonaut: 1.0.1
+      httpurple-yoga-json: 1.0.0
+      humdrum: 0.0.1
+      hyrule: 2.3.5
+      identity: 6.0.0
+      identy: 4.0.1
+      indexed-monad: 2.1.0
+      int64: 3.0.0
+      integers: 6.0.0
+      interpolate: 5.0.2
+      invariant: 6.0.0
+      jarilo: 1.0.1
+      jelly: 0.9.1
+      jelly-hooks: 0.3.1
+      jelly-router: 0.2.2
+      jelly-signal: 0.3.0
+      jest: 1.0.0
+      js-bigints: 1.2.0
+      js-date: 8.0.0
+      js-fileio: 3.0.0
+      js-promise: 1.0.0
+      js-promise-aff: 1.0.0
+      js-timers: 6.1.0
+      js-uri: 3.1.0
+      justifill: 0.5.0
+      jwt: 0.0.9
+      language-cst-parser: 0.12.1
+      lazy: 6.0.0
+      lazy-joe: 1.0.0
+      lcg: 4.0.0
+      leibniz: 5.0.0
+      linalg: 5.1.0
+      lists: 7.0.0
+      literals: 1.0.2
+      logging: 3.0.0
+      logging-journald: 0.4.0
+      machines: 7.0.0
+      marionette: 1.0.0
+      marionette-commander: 0.1.1
+      marionette-react-basic-hooks: 0.1.1
+      matrices: 5.0.1
+      matryoshka: 1.0.0
+      maybe: 6.0.0
+      mdast-util-from-markdown: 0.2.1
+      media-types: 6.0.0
+      midi: 4.0.0
+      milkis: 9.0.0
+      minibench: 4.0.1
+      mmorph: 7.0.0
+      monad-control: 5.0.0
+      monad-logger: 1.3.1
+      monad-loops: 0.5.0
+      monad-unlift: 1.0.1
+      monoid-extras: 0.0.1
+      monoidal: 0.16.0
+      morello: 0.4.0
+      mote: 3.0.0
+      motsunabe: 2.0.0
+      mysql: 6.0.1
+      n3: 0.1.0
+      nano-id: 1.1.0
+      naturals: 3.0.0
+      nested-functor: 0.2.1
+      newtype: 5.0.0
+      nextui: 0.1.0
+      node-buffer: 8.0.0
+      node-buffer-blob: 1.0.0
+      node-child-process: 9.0.0
+      node-fs: 8.1.1
+      node-fs-aff: 9.1.0
+      node-http: 8.0.0
+      node-net: 4.0.0
+      node-path: 5.0.0
+      node-process: 10.0.0
+      node-readline: 7.0.0
+      node-sqlite3: 8.0.0
+      node-streams: 7.0.0
+      node-streams-aff: 4.0.1
+      node-url: 6.0.0
+      nodemailer: 4.0.1
+      nonempty: 7.0.0
+      now: 6.0.0
+      npm-package-json: 2.0.0
+      nullable: 6.0.0
+      numbers: 9.0.0
+      object-maps: 0.1.1
+      ocarina: 1.5.2
+      open-folds: 6.3.0
+      open-memoize: 6.1.0
+      open-pairing: 6.1.0
+      options: 7.0.0
+      optparse: 5.0.0
+      ordered-collections: 3.0.0
+      ordered-set: 0.4.0
+      orders: 6.0.0
+      pairs: 9.0.0
+      parallel: 6.0.0
+      parsing: 10.2.0
+      parsing-dataview: 3.2.4
+      partial: 4.0.0
+      pathy: 9.0.0
+      pha: 0.9.0
+      phaser: 0.6.0
+      pipes: 8.0.0
+      pirates-charm: 0.0.1
+      point-free: 1.0.0
+      pointed-list: 0.5.1
+      polymorphic-vectors: 4.0.0
+      posix-types: 6.0.0
+      precise: 6.0.0
+      precise-datetime: 7.0.0
+      prelude: 6.0.1
+      prettier-printer: 3.0.0
+      profunctor: 6.0.0
+      profunctor-lenses: 8.0.0
+      protobuf: 4.2.0
+      ps-cst: 1.2.0
+      psa-utils: 8.0.0
+      psc-ide: 19.0.0
+      psci-support: 6.0.0
+      qualified-do: 2.2.0
+      quantities: 12.1.0
+      quickcheck: 8.0.1
+      quickcheck-combinators: 0.1.3
+      quickcheck-laws: 7.0.0
+      quickcheck-utf8: 0.0.0
+      random: 6.0.0
+      rationals: 5.0.1
+      rdf: 0.1.0
+      react: 10.0.1
+      react-aria: 0.2.0
+      react-basic: 17.0.0
+      react-basic-classic: 3.0.0
+      react-basic-dnd: 10.1.0
+      react-basic-dom: 6.0.0
+      react-basic-emotion: 7.1.0
+      react-basic-hooks: 8.1.2
+      react-basic-storybook: 2.0.0
+      react-dom: 8.0.0
+      react-halo: 3.0.0
+      react-icons: 1.0.8
+      react-testing-library: 4.0.1
+      react-virtuoso: 1.0.0
+      read: 1.0.1
+      record: 4.0.0
+      record-extra: 5.0.1
+      record-studio: 1.0.4
+      refs: 6.0.0
+      remotedata: 5.0.0
+      resource: 2.0.1
+      resourcet: 1.0.0
+      result: 1.0.3
+      return: 0.2.0
+      ring-modules: 5.0.1
+      rito: 0.3.2
+      routing: 11.0.0
+      routing-duplex: 0.7.0
+      run: 5.0.0
+      safe-coerce: 2.0.0
+      safely: 4.0.1
+      school-of-music: 1.3.0
+      selection-foldable: 0.2.0
+      semirings: 7.0.0
+      signal: 13.0.0
+      simple-emitter: 3.0.1
+      simple-i18n: 2.0.1
+      simple-json: 9.0.0
+      simple-jwt: 4.0.1
+      simple-ulid: 3.0.0
+      sized-matrices: 1.0.0
+      sized-vectors: 5.0.2
+      slug: 3.0.8
+      small-ffi: 4.0.1
+      soundfonts: 4.1.0
+      sparse-matrices: 1.2.1
+      sparse-polynomials: 1.0.5
+      spec: 7.2.0
+      spec-discovery: 8.0.1
+      spec-quickcheck: 5.0.0
+      splitmix: 2.1.0
+      ssrs: 1.0.0
+      st: 6.2.0
+      strictlypositiveint: 1.0.1
+      string-parsers: 8.0.0
+      strings: 6.0.1
+      strings-extra: 4.0.0
+      stringutils: 0.0.12
+      substitute: 0.2.3
+      sunde: 3.0.0
+      supply: 0.2.0
+      svg-parser: 3.0.0
+      systemd-journald: 0.3.0
+      tagged: 4.0.2
+      tailrec: 6.1.0
+      tecton: 0.1.6
+      tecton-halogen: 0.1.3
+      test-unit: 17.0.0
+      thermite: 6.3.1
+      thermite-dom: 0.3.1
+      these: 6.0.0
+      toppokki: 4.0.0
+      transformers: 6.0.0
+      tree-rose: 4.0.2
+      tuples: 7.0.0
+      two-or-more: 1.0.0
+      type-equality: 4.0.1
+      typelevel: 6.0.0
+      typelevel-lists: 2.1.0
+      typelevel-peano: 1.0.1
+      typelevel-prelude: 7.0.0
+      typelevel-rows: 0.1.0
+      uint: 7.0.0
+      ulid: 3.0.1
+      uncurried-transformers: 1.1.0
+      undefined: 2.0.0
+      undefined-is-not-a-problem: 1.1.0
+      unfoldable: 6.0.0
+      unicode: 6.0.0
+      unlift: 1.0.1
+      unordered-collections: 3.0.1
+      unsafe-coerce: 6.0.0
+      unsafe-reference: 5.0.0
+      untagged-to-tagged: 0.1.4
+      untagged-union: 1.0.0
+      uri: 9.0.0
+      uuid: 9.0.0
+      uuidv4: 1.0.0
+      validation: 6.0.0
+      variant: 8.0.0
+      vectorfield: 1.0.1
+      vectors: 2.1.0
+      versions: 7.0.0
+      visx: 0.0.2
+      web-clipboard: 5.0.0
+      web-cssom: 2.0.0
+      web-dom: 6.0.0
+      web-dom-parser: 8.0.0
+      web-dom-xpath: 3.0.0
+      web-encoding: 3.0.0
+      web-events: 4.0.0
+      web-fetch: 3.0.0
+      web-file: 4.0.0
+      web-html: 4.1.0
+      web-pointerevents: 1.0.0
+      web-proletarian: 1.0.0
+      web-promise: 3.1.0
+      web-resize-observer: 2.0.0
+      web-router: 1.0.0
+      web-socket: 4.0.0
+      web-storage: 5.0.0
+      web-streams: 3.0.0
+      web-touchevents: 4.0.0
+      web-uievents: 4.0.0
+      web-url: 2.0.0
+      web-workers: 1.1.0
+      web-xhr: 5.0.0
+      which: 2.0.0
+      yoga-fetch: 1.0.1
+      yoga-json: 4.0.1
+      yoga-om: 0.1.0
+      yoga-postgres: 6.0.0
+      yoga-tree: 1.0.0
   extra_packages: {}
 packages:
   aff:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-aff.git
-    rev: 2d44d9f9d0d6a416a4103fba2fb39e5160f80e36
+    type: registry
+    version: 7.1.0
+    integrity: sha256-7hOC6uQO9XBAI5FD8F33ChLjFAiZVfd4BJMqlMh7TNU=
     dependencies:
+      - arrays
+      - bifunctors
+      - control
       - datetime
       - effect
+      - either
       - exceptions
+      - foldable-traversable
       - functions
+      - maybe
+      - newtype
       - parallel
+      - prelude
+      - refs
+      - tailrec
       - transformers
       - unsafe-coerce
   aff-promise:
-    type: git
-    url: https://github.com/nwolverson/purescript-aff-promise.git
-    rev: 3aa74e68e3e4c3e38d821375703e0b2f49d831eb
+    type: registry
+    version: 4.0.0
+    integrity: sha256-Kq5EupbUpXeUXx4JqGQE7/RTTz/H6idzWhsocwlEFhM=
     dependencies:
       - aff
       - foreign
   argonaut:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-argonaut.git
-    rev: 7505a47f2edb0c9cacaac4f11dcedf4723a3e9c8
+    type: registry
+    version: 9.0.0
+    integrity: sha256-9sHzkzcFkaMUa9+3FjIybJDYnHtY4Jp4zHOJ84qPTXo=
     dependencies:
       - argonaut-codecs
       - argonaut-core
       - argonaut-traversals
   argonaut-codecs:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-argonaut-codecs.git
-    rev: 176a5dddae28fda9a2ff31ed4bf1efcc148513a4
+    type: registry
+    version: 9.1.0
+    integrity: sha256-N6efXByUeg848ompEqJfVvZuZPfdRYDGlTDFn0G0Oh8=
     dependencies:
       - argonaut-core
       - arrays
@@ -3586,9 +596,9 @@ packages:
       - prelude
       - record
   argonaut-core:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-argonaut-core.git
-    rev: 68da81dd80ec36d3b013eff46dc067a972c22e5d
+    type: registry
+    version: 7.0.0
+    integrity: sha256-RC82GfAjItydxrO24cdX373KHVZiLqybu19b5X8u7B4=
     dependencies:
       - arrays
       - control
@@ -3602,26 +612,26 @@ packages:
       - strings
       - tailrec
   argonaut-generic:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-argonaut-generic.git
-    rev: 2df4080f036762df91a24b22842e389395ef0bdd
+    type: registry
+    version: 8.0.0
+    integrity: sha256-WCqRWoomRKg5BFZnGBS4k4SqBX84fy/X1aJzMyaIeP0=
     dependencies:
       - argonaut-codecs
       - argonaut-core
       - prelude
       - record
   argonaut-traversals:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-argonaut-traversals.git
-    rev: 8d2403d8d57afb568933dbb36063d5670ce770a0
+    type: registry
+    version: 10.0.0
+    integrity: sha256-9nSfqR70rjiNWVVsCoK+jrm9dmyZTx89IKNYO6uNUIk=
     dependencies:
       - argonaut-codecs
       - argonaut-core
       - profunctor-lenses
   arrays:
-    type: git
-    url: https://github.com/purescript/purescript-arrays.git
-    rev: d20bae2f76db6cf29b7b75e26e82b8a54c32295e
+    type: registry
+    version: 7.1.0
+    integrity: sha256-Rvb3AVLal0ZLpmpABgOPIUeYHa4M+c5GwcUP5rQ2trA=
     dependencies:
       - bifunctors
       - control
@@ -3630,15 +640,16 @@ packages:
       - nonempty
       - partial
       - prelude
+      - safe-coerce
       - st
       - tailrec
       - tuples
       - unfoldable
       - unsafe-coerce
   avar:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-avar.git
-    rev: d00f5784d9cc8f079babd62740f5c52b87e5caa5
+    type: registry
+    version: 5.0.0
+    integrity: sha256-e7hf0x4hEpcygXP0LtvfvAQ49Bbj2aWtZT3gqM///0A=
     dependencies:
       - aff
       - effect
@@ -3647,9 +658,9 @@ packages:
       - functions
       - maybe
   bifunctors:
-    type: git
-    url: https://github.com/purescript/purescript-bifunctors.git
-    rev: 16ba2fb6dd7f05528ebd9e2f9ca3a068b325e5b3
+    type: registry
+    version: 6.0.0
+    integrity: sha256-/gZwC9YhNxZNQpnHa5BIYerCGM2jeX9ukZiEvYxm5Nw=
     dependencies:
       - const
       - either
@@ -3657,9 +668,9 @@ packages:
       - prelude
       - tuples
   catenable-lists:
-    type: git
-    url: https://github.com/purescript/purescript-catenable-lists.git
-    rev: 09abe1f4888bc00841ad2b59e56a9e7ce7ebd4ab
+    type: registry
+    version: 7.0.0
+    integrity: sha256-76vYENhwF4BWTBsjeLuErCH2jqVT4M3R1HX+4RwSftA=
     dependencies:
       - control
       - foldable-traversable
@@ -3669,24 +680,24 @@ packages:
       - tuples
       - unfoldable
   console:
-    type: git
-    url: https://github.com/purescript/purescript-console.git
-    rev: 3b83d7b792d03872afeea5e62b4f686ab0f09842
+    type: registry
+    version: 6.0.0
+    integrity: sha256-gJpJ53fCDAL8BiCiJXH0HNAJ9K3gJtLo8GDaCK6hA5U=
     dependencies:
       - effect
       - prelude
   const:
-    type: git
-    url: https://github.com/purescript/purescript-const.git
-    rev: ab9570cf2b6e67f7e441178211db1231cfd75c37
+    type: registry
+    version: 6.0.0
+    integrity: sha256-tNrxDW8D8H4jdHE2HiPzpLy08zkzJMmGHdRqt5BQuTc=
     dependencies:
       - invariant
       - newtype
       - prelude
   contravariant:
-    type: git
-    url: https://github.com/purescript/purescript-contravariant.git
-    rev: 9ad3e105b8855bcc25f4e0893c784789d05a58de
+    type: registry
+    version: 6.0.0
+    integrity: sha256-TP+ooAp3vvmdjfQsQJSichF5B4BPDHp3wAJoWchip6c=
     dependencies:
       - const
       - either
@@ -3694,16 +705,16 @@ packages:
       - prelude
       - tuples
   control:
-    type: git
-    url: https://github.com/purescript/purescript-control.git
-    rev: a6033808790879a17b2729e73747a9ed3fb2264e
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sH7Pg9E96JCPF9PIA6oQ8+BjTyO/BH1ZuE/bOcyj4Jk=
     dependencies:
       - newtype
       - prelude
   datetime:
-    type: git
-    url: https://github.com/purescript/purescript-datetime.git
-    rev: a6a0cf1b0324964ad1854bc3377ed8766ba90e6f
+    type: registry
+    version: 6.1.0
+    integrity: sha256-g/5X5BBegQWLpI9IWD+sY6mcaYpzzlW5lz5NBzaMtyI=
     dependencies:
       - bifunctors
       - control
@@ -3722,9 +733,9 @@ packages:
       - prelude
       - tuples
   distributive:
-    type: git
-    url: https://github.com/purescript/purescript-distributive.git
-    rev: 6005e513642e855ebf6f884d24a35c2803ca252a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-HTDdmEnzigMl+02SJB88j+gAXDx9VKsbvR4MJGDPbOQ=
     dependencies:
       - identity
       - newtype
@@ -3732,24 +743,24 @@ packages:
       - tuples
       - type-equality
   effect:
-    type: git
-    url: https://github.com/purescript/purescript-effect.git
-    rev: a192ddb923027d426d6ea3d8deb030c9aa7c7dda
+    type: registry
+    version: 4.0.0
+    integrity: sha256-eBtZu+HZcMa5HilvI6kaDyVX3ji8p0W9MGKy2K4T6+M=
     dependencies:
       - prelude
   either:
-    type: git
-    url: https://github.com/purescript/purescript-either.git
-    rev: af655a04ed2fd694b6688af39ee20d7907ad0763
+    type: registry
+    version: 6.1.0
+    integrity: sha256-6hgTPisnMWVwQivOu2PKYcH8uqjEOOqDyaDQVUchTpY=
     dependencies:
       - control
       - invariant
       - maybe
       - prelude
   enums:
-    type: git
-    url: https://github.com/purescript/purescript-enums.git
-    rev: bae47961d401f9acf88da38f32e87403e5f0cf2f
+    type: registry
+    version: 6.0.1
+    integrity: sha256-HWaD73JFLorc4A6trKIRUeDMdzE+GpkJaEOM1nTNkC8=
     dependencies:
       - control
       - either
@@ -3762,24 +773,24 @@ packages:
       - tuples
       - unfoldable
   exceptions:
-    type: git
-    url: https://github.com/purescript/purescript-exceptions.git
-    rev: afab3c07c820bb49b6c5be50049db46a964a6161
+    type: registry
+    version: 6.0.0
+    integrity: sha256-y/xTAEIZIARCE+50/u1di0ncebJ+CIwNOLswyOWzMTw=
     dependencies:
       - effect
       - either
       - maybe
       - prelude
   exists:
-    type: git
-    url: https://github.com/purescript/purescript-exists.git
-    rev: f765b4ace7869c27b9c05949e18c843881f9173b
+    type: registry
+    version: 6.0.0
+    integrity: sha256-A0JQHpTfo1dNOj9U5/Fd3xndlRSE0g2IQWOGor2yXn8=
     dependencies:
       - unsafe-coerce
   foldable-traversable:
-    type: git
-    url: https://github.com/purescript/purescript-foldable-traversable.git
-    rev: b3926f870532d287ea59e2d5cd3873b81ef2a93a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-fLeqRYM4jUrZD5H4WqcwUgzU7XfYkzO4zhgtNc3jcWM=
     dependencies:
       - bifunctors
       - const
@@ -3793,9 +804,9 @@ packages:
       - prelude
       - tuples
   foreign:
-    type: git
-    url: https://github.com/purescript/purescript-foreign.git
-    rev: 2dd222d1ec7363fa0a0a7adb0d8eaf81bb7006dd
+    type: registry
+    version: 7.0.0
+    integrity: sha256-1ORiqoS3HW+qfwSZAppHPWy4/6AQysxZ2t29jcdUMNA=
     dependencies:
       - either
       - functions
@@ -3807,9 +818,9 @@ packages:
       - strings
       - transformers
   foreign-object:
-    type: git
-    url: https://github.com/purescript/purescript-foreign-object.git
-    rev: 28a635827a9a6c251df73f68874070d51fe9f756
+    type: registry
+    version: 4.1.0
+    integrity: sha256-q24okj6mT+yGHYQ+ei/pYPj5ih6sTbu7eDv/WU56JVo=
     dependencies:
       - arrays
       - foldable-traversable
@@ -3824,9 +835,9 @@ packages:
       - typelevel-prelude
       - unfoldable
   free:
-    type: git
-    url: https://github.com/purescript/purescript-free.git
-    rev: e2d8fa8023a864363857834e11393483bced5e38
+    type: registry
+    version: 7.0.0
+    integrity: sha256-72auTIZAG6fhz4F94rxyDwgfnHwp+/89rujZpZWrV0w=
     dependencies:
       - catenable-lists
       - control
@@ -3843,15 +854,15 @@ packages:
       - tuples
       - unsafe-coerce
   functions:
-    type: git
-    url: https://github.com/purescript/purescript-functions.git
-    rev: f626f20580483977c5b27a01aac6471e28aff367
+    type: registry
+    version: 6.0.0
+    integrity: sha256-adMyJNEnhGde2unHHAP79gPtlNjNqzgLB8arEOn9hLI=
     dependencies:
       - prelude
   functors:
-    type: git
-    url: https://github.com/purescript/purescript-functors.git
-    rev: 022ffd7a2a7ec12080314f3d217b400674a247b4
+    type: registry
+    version: 5.0.0
+    integrity: sha256-zfPWWYisbD84MqwpJSZFlvM6v86McM68ob8p9s27ywU=
     dependencies:
       - bifunctors
       - const
@@ -3867,9 +878,9 @@ packages:
       - tuples
       - unsafe-coerce
   gen:
-    type: git
-    url: https://github.com/purescript/purescript-gen.git
-    rev: 9fbcc2a1261c32e30d79c5418edef4d96fe76931
+    type: registry
+    version: 4.0.0
+    integrity: sha256-f7yzAXWwr+xnaqEOcvyO3ezKdoes8+WXWdXIHDBCAPI=
     dependencies:
       - either
       - foldable-traversable
@@ -3882,40 +893,40 @@ packages:
       - tuples
       - unfoldable
   identity:
-    type: git
-    url: https://github.com/purescript/purescript-identity.git
-    rev: ef6768f8a52ab0bc943a85f5761ba07c257f639f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-4wY0XZbAksjY6UAg99WkuKyJlQlWAfTi2ssadH0wVMY=
     dependencies:
       - control
       - invariant
       - newtype
       - prelude
   indexed-monad:
-    type: git
-    url: https://github.com/garyb/purescript-indexed-monad.git
-    rev: b95d33cea26bfbbdc17d8d80fb664df2ad79d28b
+    type: registry
+    version: 2.1.0
+    integrity: sha256-VtIx8bIYKg6uhLlsB4ZWpMqs0WoPtNYR6ad1FoBNlys=
     dependencies:
       - control
       - newtype
   integers:
-    type: git
-    url: https://github.com/purescript/purescript-integers.git
-    rev: 54d712b25c594833083d15dc9ff2418eb9c52822
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sf+sK26R1hzwl3NhXR7WAu9zCDjQnfoXwcyGoseX158=
     dependencies:
       - maybe
       - numbers
       - prelude
   invariant:
-    type: git
-    url: https://github.com/purescript/purescript-invariant.git
-    rev: 1d2a196d51e90623adb88496c2cfd759c6736894
+    type: registry
+    version: 6.0.0
+    integrity: sha256-RGWWyYrz0Hs1KjPDA+87Kia67ZFBhfJ5lMGOMCEFoLo=
     dependencies:
       - control
       - prelude
   js-date:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-js-date.git
-    rev: 1ea020316946cc4b87195bca9c54d0c16abaa490
+    type: registry
+    version: 8.0.0
+    integrity: sha256-6TVF4DWg5JL+jRAsoMssYw8rgOVALMUHT1CuNZt8NRo=
     dependencies:
       - datetime
       - effect
@@ -3924,24 +935,24 @@ packages:
       - integers
       - now
   js-timers:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-js-timers.git
-    rev: 7cb728b3e6dc29f355143617e6e9ac770ecd9273
+    type: registry
+    version: 6.1.0
+    integrity: sha256-znHWLSSOYw15P5DTcsAdal2lf7nGA2yayLdOZ2t5r7o=
     dependencies:
       - effect
   lazy:
-    type: git
-    url: https://github.com/purescript/purescript-lazy.git
-    rev: 48347841226b27af5205a1a8ec71e27a93ce86fd
+    type: registry
+    version: 6.0.0
+    integrity: sha256-lMsfFOnlqfe4KzRRiW8ot5ge6HtcU3Eyh2XkXcP5IgU=
     dependencies:
       - control
       - foldable-traversable
       - invariant
       - prelude
   lcg:
-    type: git
-    url: https://github.com/purescript/purescript-lcg.git
-    rev: 67c6c6483a563a59ae036d9dca0f1be2835326a5
+    type: registry
+    version: 4.0.0
+    integrity: sha256-h7ME5cthLfbgJOJdsZcSfFpwXsx4rf8YmhebU+3iSYg=
     dependencies:
       - effect
       - integers
@@ -3950,9 +961,9 @@ packages:
       - prelude
       - random
   lists:
-    type: git
-    url: https://github.com/purescript/purescript-lists.git
-    rev: b113451e5b41cad87d669a3165f955c71cd863e2
+    type: registry
+    version: 7.0.0
+    integrity: sha256-EKF15qYqucuXP2lT/xPxhqy58f0FFT6KHdIB/yBOayI=
     dependencies:
       - bifunctors
       - control
@@ -3967,32 +978,32 @@ packages:
       - tuples
       - unfoldable
   maybe:
-    type: git
-    url: https://github.com/purescript/purescript-maybe.git
-    rev: c6f98ac1088766287106c5d9c8e30e7648d36786
+    type: registry
+    version: 6.0.0
+    integrity: sha256-5cCIb0wPwbat2PRkQhUeZO0jcAmf8jCt2qE0wbC3v2Q=
     dependencies:
       - control
       - invariant
       - newtype
       - prelude
   media-types:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-media-types.git
-    rev: af853de226592f319a953637069a943dd261cba3
+    type: registry
+    version: 6.0.0
+    integrity: sha256-n/4FoGBasbVSYscGVRSyBunQ6CZbL3jsYL+Lp01mc9k=
     dependencies:
       - newtype
       - prelude
   newtype:
-    type: git
-    url: https://github.com/purescript/purescript-newtype.git
-    rev: 29d8e6dd77aec2c975c948364ec3faf26e14ee7b
+    type: registry
+    version: 5.0.0
+    integrity: sha256-gdrQu8oGe9eZE6L3wOI8ql/igOg+zEGB5ITh2g+uttw=
     dependencies:
       - prelude
       - safe-coerce
   nonempty:
-    type: git
-    url: https://github.com/purescript/purescript-nonempty.git
-    rev: 28150ecc7419238b187abd609a92a645273348bb
+    type: registry
+    version: 7.0.0
+    integrity: sha256-54ablJZUHGvvlTJzi3oXyPCuvY6zsrWJuH/dMJ/MFLs=
     dependencies:
       - control
       - foldable-traversable
@@ -4001,31 +1012,31 @@ packages:
       - tuples
       - unfoldable
   now:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-now.git
-    rev: b5ffed2381e5fefc063f484e607e8499e79eaf32
+    type: registry
+    version: 6.0.0
+    integrity: sha256-xZ7x37ZMREfs6GCDw/h+FaKHV/3sPWmtqBZRGTxybQY=
     dependencies:
       - datetime
       - effect
   nullable:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-nullable.git
-    rev: 3202744c6c65e8d1fbba7f4256a1c482078e7fb5
+    type: registry
+    version: 6.0.0
+    integrity: sha256-yiGBVl3AD+Guy4kNWWeN+zl1gCiJK+oeIFtZtPCw4+o=
     dependencies:
       - effect
       - functions
       - maybe
   numbers:
-    type: git
-    url: https://github.com/purescript/purescript-numbers.git
-    rev: 2a53528f18f9415334bae28e7bb3cf3be86342c2
+    type: registry
+    version: 9.0.0
+    integrity: sha256-fDKXExFxMRFgy+v+kbjVbGBIOOQkWGnmm0vtnE3zWRE=
     dependencies:
       - functions
       - maybe
   ordered-collections:
-    type: git
-    url: https://github.com/purescript/purescript-ordered-collections.git
-    rev: 9826b7632d0d0a691173bde308a634195f42a419
+    type: registry
+    version: 3.0.0
+    integrity: sha256-R9WddNBRPkY37gw8XkDCLX2vJ5eI9qdaWDdCp61r2+M=
     dependencies:
       - arrays
       - foldable-traversable
@@ -4039,25 +1050,25 @@ packages:
       - tuples
       - unfoldable
   orders:
-    type: git
-    url: https://github.com/purescript/purescript-orders.git
-    rev: f86db621ec5eef1274145f8b1fd8ebbfe0ed4a2c
+    type: registry
+    version: 6.0.0
+    integrity: sha256-nBA0g3/ai0euH8q9pSbGqk53W2q6agm/dECZTHcoink=
     dependencies:
       - newtype
       - prelude
   pairs:
-    type: git
-    url: https://github.com/sharkdp/purescript-pairs.git
-    rev: f16ba3acc6399dbca0c8632c811f53809d39002c
+    type: registry
+    version: 9.0.0
+    integrity: sha256-4t89MGYuhlxxkK5j+OCUqkuYj8XElYtzO5d00pZoy9M=
     dependencies:
       - console
       - distributive
       - foldable-traversable
       - quickcheck
   parallel:
-    type: git
-    url: https://github.com/purescript/purescript-parallel.git
-    rev: 85290dca837771ac4870071008c933d315ef678f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-VJbkGD0rAKX+NUEeBJbYJ78bEKaZbgow+QwQEfPB6ko=
     dependencies:
       - control
       - effect
@@ -4071,19 +1082,19 @@ packages:
       - refs
       - transformers
   partial:
-    type: git
-    url: https://github.com/purescript/purescript-partial.git
-    rev: 0fa0646f5ea1ec5f0c46dcbd770c705a6c9ad3ec
+    type: registry
+    version: 4.0.0
+    integrity: sha256-fwXerld6Xw1VkReh8yeQsdtLVrjfGiVuC5bA1Wyo/J4=
     dependencies: []
   prelude:
-    type: git
-    url: https://github.com/purescript/purescript-prelude.git
-    rev: 32787f4399c92459c41602131a5858559eb868c5
+    type: registry
+    version: 6.0.1
+    integrity: sha256-o8p6SLYmVPqzXZhQFd2hGAWEwBoXl1swxLG/scpJ0V0=
     dependencies: []
   profunctor:
-    type: git
-    url: https://github.com/purescript/purescript-profunctor.git
-    rev: 0a966a14e7b0c827d44657dc1710cdc712d2e034
+    type: registry
+    version: 6.0.0
+    integrity: sha256-99NzxFgTr4CGlCSRYG1kShL+JhYbihhHtbOk1/0R5zI=
     dependencies:
       - control
       - distributive
@@ -4094,9 +1105,9 @@ packages:
       - prelude
       - tuples
   profunctor-lenses:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-profunctor-lenses.git
-    rev: 973d567afe458fd802cf4f0d9725b6dc35ad9297
+    type: registry
+    version: 8.0.0
+    integrity: sha256-K7f29rHRHgVSb2Y/PaSKtfYPriP6n87BJNO7EhsZHas=
     dependencies:
       - arrays
       - bifunctors
@@ -4119,9 +1130,9 @@ packages:
       - transformers
       - tuples
   quickcheck:
-    type: git
-    url: https://github.com/purescript/purescript-quickcheck.git
-    rev: bf5029f97e6c0d7552d3a08d2ab793a19e2c5e3d
+    type: registry
+    version: 8.0.1
+    integrity: sha256-ZvpccKQCvgslTXZCNmpYW4bUsFzhZd/kQUr2WmxFTGY=
     dependencies:
       - arrays
       - console
@@ -4151,25 +1162,26 @@ packages:
       - tuples
       - unfoldable
   random:
-    type: git
-    url: https://github.com/purescript/purescript-random.git
-    rev: 9540bc965a9596da02fefd9949418bb19c92533a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-CJ611a35MPCE7XQMp0rdC6MCn76znlhisiCRgboAG+Q=
     dependencies:
       - effect
       - integers
   react-basic:
-    type: git
-    url: https://github.com/lumihq/purescript-react-basic.git
-    rev: 821ac4cb55b5919cc6248b45139164ad1a560e3f
+    type: registry
+    version: 17.0.0
+    integrity: sha256-xE5sL14ITpSRCbAnWrp7KAfbzv+Ft0rSaAnjkqKcSVY=
     dependencies:
       - effect
       - prelude
       - record
   react-basic-dom:
-    type: git
-    url: https://github.com/lumihq/purescript-react-basic-dom.git
-    rev: 4ee3cd2ec6086aae1476d08f2348f7f9bce8feac
+    type: registry
+    version: 6.0.0
+    integrity: sha256-uEkFQTvDrKAor7g6WzPsrSrbUvq9sT7Dj7b8PPanSbY=
     dependencies:
+      - arrays
       - effect
       - foldable-traversable
       - foreign-object
@@ -4177,15 +1189,16 @@ packages:
       - nullable
       - prelude
       - react-basic
+      - record
       - unsafe-coerce
       - web-dom
       - web-events
       - web-file
       - web-html
   react-basic-hooks:
-    type: git
-    url: https://github.com/megamaddu/purescript-react-basic-hooks.git
-    rev: 50575f50a68dc8b756b378674dea5c568b8c109d
+    type: registry
+    version: 8.1.2
+    integrity: sha256-Tf/iOS6DXoA5WtAI4wAldUjgSqD9ofVPF13AqJerP6U=
     dependencies:
       - aff
       - aff-promise
@@ -4214,39 +1227,39 @@ packages:
       - unsafe-reference
       - web-html
   record:
-    type: git
-    url: https://github.com/purescript/purescript-record.git
-    rev: c89cd1ada6b636692571fc374196b1c39c4c9f70
+    type: registry
+    version: 4.0.0
+    integrity: sha256-Za5U85bTRJEfGK5Sk4hM41oXy84YQI0I8TL3WUn1Qzg=
     dependencies:
       - functions
       - prelude
       - unsafe-coerce
   refs:
-    type: git
-    url: https://github.com/purescript/purescript-refs.git
-    rev: f8e6216da4cb9309fde1f20cd6f69ac3a3b7f9e8
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Vgwne7jIbD3ZMoLNNETLT8Litw6lIYo3MfYNdtYWj9s=
     dependencies:
       - effect
       - prelude
   safe-coerce:
-    type: git
-    url: https://github.com/purescript/purescript-safe-coerce.git
-    rev: 7fa799ae80a38b8d948efcb52608e58e198b3da7
+    type: registry
+    version: 2.0.0
+    integrity: sha256-a1ibQkiUcbODbLE/WAq7Ttbbh9ex+x33VCQ7GngKudU=
     dependencies:
       - unsafe-coerce
   st:
-    type: git
-    url: https://github.com/purescript/purescript-st.git
-    rev: 2cc7ae1c3318a303378c4a9f3fa0f10ee7cc3589
+    type: registry
+    version: 6.2.0
+    integrity: sha256-z9X0WsOUlPwNx9GlCC+YccCyz8MejC8Wb0C4+9fiBRY=
     dependencies:
       - partial
       - prelude
       - tailrec
       - unsafe-coerce
   strings:
-    type: git
-    url: https://github.com/purescript/purescript-strings.git
-    rev: 4bc6954448d056f8aa7a659695a6ad60ad4fdf19
+    type: registry
+    version: 6.0.1
+    integrity: sha256-WssD3DbX4OPzxSdjvRMX0yvc9+pS7n5gyPv5I2Trb7k=
     dependencies:
       - arrays
       - control
@@ -4265,9 +1278,9 @@ packages:
       - unfoldable
       - unsafe-coerce
   tailrec:
-    type: git
-    url: https://github.com/purescript/purescript-tailrec.git
-    rev: 5e2104aa734b31a17074cc805bf087d72b65afd1
+    type: registry
+    version: 6.1.0
+    integrity: sha256-Xx19ECVDRrDWpz9D2GxQHHV89vd61dnXxQm0IcYQHGk=
     dependencies:
       - bifunctors
       - effect
@@ -4278,9 +1291,9 @@ packages:
       - prelude
       - refs
   test-unit:
-    type: git
-    url: https://github.com/bodil/purescript-test-unit.git
-    rev: 3112d7ebe06d467238058a6384dc75ffd960d335
+    type: registry
+    version: 17.0.0
+    integrity: sha256-aITJ2KngFFjASmG0JjnjybaKWl9dn7Hf2B3Wk4engNs=
     dependencies:
       - aff
       - avar
@@ -4293,9 +1306,9 @@ packages:
       - quickcheck
       - strings
   transformers:
-    type: git
-    url: https://github.com/purescript/purescript-transformers.git
-    rev: be72ab52357d9a665cbf93d73ba1c07c4b0957ee
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Pzw40HjthX77tdPAYzjx43LK3X5Bb7ZspYAp27wksFA=
     dependencies:
       - control
       - distributive
@@ -4312,29 +1325,29 @@ packages:
       - tuples
       - unfoldable
   tuples:
-    type: git
-    url: https://github.com/purescript/purescript-tuples.git
-    rev: 4f52da2729b448c8564369378f1232d8d2dc1d8b
+    type: registry
+    version: 7.0.0
+    integrity: sha256-1rXgTomes9105BjgXqIw0FL6Fz1lqqUTLWOumhWec1M=
     dependencies:
       - control
       - invariant
       - prelude
   type-equality:
-    type: git
-    url: https://github.com/purescript/purescript-type-equality.git
-    rev: 0525b7d39e0fbd81b4209518139fb8ab02695774
+    type: registry
+    version: 4.0.1
+    integrity: sha256-Hs9D6Y71zFi/b+qu5NSbuadUQXe5iv5iWx0226vOHUw=
     dependencies: []
   typelevel-prelude:
-    type: git
-    url: https://github.com/purescript/purescript-typelevel-prelude.git
-    rev: dca2fe3c8cfd5527d4fe70c4bedfda30148405bf
+    type: registry
+    version: 7.0.0
+    integrity: sha256-uFF2ph+vHcQpfPuPf2a3ukJDFmLhApmkpTMviHIWgJM=
     dependencies:
       - prelude
       - type-equality
   unfoldable:
-    type: git
-    url: https://github.com/purescript/purescript-unfoldable.git
-    rev: 493dfe04ed590e20d8f69079df2f58486882748d
+    type: registry
+    version: 6.0.0
+    integrity: sha256-JtikvJdktRap7vr/K4ITlxUX1QexpnqBq0G/InLr6eg=
     dependencies:
       - foldable-traversable
       - maybe
@@ -4342,20 +1355,20 @@ packages:
       - prelude
       - tuples
   unsafe-coerce:
-    type: git
-    url: https://github.com/purescript/purescript-unsafe-coerce.git
-    rev: ab956f82e66e633f647fb3098e8ddd3ec58d689f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-IqIYW4Vkevn8sI+6aUwRGvd87tVL36BBeOr0cGAE7t0=
     dependencies: []
   unsafe-reference:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-unsafe-reference.git
-    rev: 058e23b8b9adcf776a910f9934ff515ddee73af5
+    type: registry
+    version: 5.0.0
+    integrity: sha256-zU7BhfJU14nXQRZG9iADsp0mSiKhz07OcKyjRB2YT+Y=
     dependencies:
       - prelude
   validation:
-    type: git
-    url: https://github.com/purescript/purescript-validation.git
-    rev: a3d9ec2176a7a808d70a01fa7e6f16d10e05429a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-kfFailaIW4spGxbRk4261z/RGT0Sb7Dx5f3qihy0MTw=
     dependencies:
       - bifunctors
       - control
@@ -4364,41 +1377,41 @@ packages:
       - newtype
       - prelude
   web-dom:
-    type: git
-    url: https://github.com/purescript-web/purescript-web-dom.git
-    rev: 568a1ee158b29e6e739e7a9aaed3e35ca4c4305a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-1kSKWFDI4LupdmpjK01b1MMxDFW7jvatEgPgVmCmSBQ=
     dependencies:
       - web-events
   web-events:
-    type: git
-    url: https://github.com/purescript-web/purescript-web-events.git
-    rev: 2124356117be7b764a2f3948032255ac4dab7051
+    type: registry
+    version: 4.0.0
+    integrity: sha256-YDt8b6u1tzGtnWyNRodne57iO8FNSGPaTCVzBUyUn4k=
     dependencies:
       - datetime
       - enums
       - foreign
       - nullable
   web-file:
-    type: git
-    url: https://github.com/purescript-web/purescript-web-file.git
-    rev: 023786ae62bbb8bf58156dd7f02011fa38221ef1
+    type: registry
+    version: 4.0.0
+    integrity: sha256-1h5jPBkvjY71jLEdwVadXCx86/2inNoMBO//Rd3eCSU=
     dependencies:
       - foreign
       - media-types
       - web-dom
   web-html:
-    type: git
-    url: https://github.com/purescript-web/purescript-web-html.git
-    rev: be189cf91b9a19cf493637423522e2fe4a0088cc
+    type: registry
+    version: 4.1.0
+    integrity: sha256-ByqS/h1/yG+hjCOnOQp7L1QpIWzQENNKB1kaHtpEhlE=
     dependencies:
       - js-date
       - web-dom
       - web-file
       - web-storage
   web-storage:
-    type: git
-    url: https://github.com/purescript-web/purescript-web-storage.git
-    rev: 6b74461e136755db70c271dc898d51776363d7e2
+    type: registry
+    version: 5.0.0
+    integrity: sha256-q+6lxcnfWxus0/nDeFVtF1V+tLehZvvXQ0cduYPLksY=
     dependencies:
       - nullable
       - web-events

--- a/exercises/chapter10/spago.yaml
+++ b/exercises/chapter10/spago.yaml
@@ -1,0 +1,34 @@
+package:
+  dependencies:
+    - aff
+    - aff-promise
+    - argonaut
+    - argonaut-generic
+    - arrays
+    - bifunctors
+    - console
+    - control
+    - effect
+    - either
+    - exceptions
+    - foldable-traversable
+    - free
+    - functions
+    - maybe
+    - ordered-collections
+    - pairs
+    - prelude
+    - react-basic
+    - react-basic-dom
+    - react-basic-hooks
+    - strings
+    - test-unit
+    - tuples
+    - validation
+    - web-dom
+    - web-html
+  name: my-project
+workspace:
+  extraPackages: {}
+  packageSet:
+    url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json

--- a/exercises/chapter10/spago.yaml
+++ b/exercises/chapter10/spago.yaml
@@ -31,4 +31,4 @@ package:
 workspace:
   extraPackages: {}
   packageSet:
-    url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
+    registry: 10.0.0

--- a/exercises/chapter11/spago.lock
+++ b/exercises/chapter11/spago.lock
@@ -92,3457 +92,467 @@ workspace:
         - unsafe-coerce
   package_set:
     address:
-      url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
-    compiler: ">=0.15.0 <0.16.0"
+      registry: 10.0.0
+    compiler: ">=0.15.4 <0.16.0"
     content:
-      ace:
-        repo: https://github.com/purescript-contrib/purescript-ace.git
-        version: v9.0.0
-        dependencies:
-          - arrays
-          - effect
-          - foreign
-          - nullable
-          - prelude
-          - web-html
-          - web-uievents
-      aff:
-        repo: https://github.com/purescript-contrib/purescript-aff.git
-        version: v7.0.0
-        dependencies:
-          - datetime
-          - effect
-          - exceptions
-          - functions
-          - parallel
-          - transformers
-          - unsafe-coerce
-      aff-bus:
-        repo: https://github.com/purescript-contrib/purescript-aff-bus.git
-        version: v6.0.0
-        dependencies:
-          - aff
-          - avar
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - lists
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-      aff-coroutines:
-        repo: https://github.com/purescript-contrib/purescript-aff-coroutines.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - avar
-          - coroutines
-          - effect
-      aff-promise:
-        repo: https://github.com/nwolverson/purescript-aff-promise.git
-        version: v4.0.0
-        dependencies:
-          - aff
-          - foreign
-      aff-retry:
-        repo: https://github.com/Unisay/purescript-aff-retry.git
-        version: v2.0.0
-        dependencies:
-          - aff
-          - arrays
-          - datetime
-          - effect
-          - either
-          - exceptions
-          - integers
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - random
-          - transformers
-      affjax:
-        repo: https://github.com/purescript-contrib/purescript-affjax.git
-        version: v13.0.0
-        dependencies:
-          - aff
-          - argonaut-core
-          - arraybuffer-types
-          - foreign
-          - form-urlencoded
-          - http-methods
-          - integers
-          - media-types
-          - nullable
-          - refs
-          - unsafe-coerce
-          - web-xhr
-      affjax-node:
-        repo: https://github.com/purescript-contrib/purescript-affjax-node.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - affjax
-          - either
-          - maybe
-          - prelude
-      affjax-web:
-        repo: https://github.com/purescript-contrib/purescript-affjax-web.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - affjax
-          - either
-          - maybe
-          - prelude
-      ansi:
-        repo: https://github.com/hdgarrood/purescript-ansi.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - lists
-          - strings
-      argonaut:
-        repo: https://github.com/purescript-contrib/purescript-argonaut.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - argonaut-traversals
-      argonaut-codecs:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-codecs.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-core
-          - arrays
-          - effect
-          - foreign-object
-          - identity
-          - integers
-          - maybe
-          - nonempty
-          - ordered-collections
-          - prelude
-          - record
-      argonaut-core:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-core.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - foreign-object
-          - functions
-          - gen
-          - maybe
-          - nonempty
-          - prelude
-          - strings
-          - tailrec
-      argonaut-generic:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-generic.git
-        version: v8.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - prelude
-          - record
-      argonaut-traversals:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-traversals.git
-        version: v10.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - profunctor-lenses
-      argparse-basic:
-        repo: https://github.com/natefaubion/purescript-argparse-basic.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - record
-          - strings
-          - tuples
-          - unfoldable
-      arraybuffer:
-        repo: https://github.com/purescript-contrib/purescript-arraybuffer.git
-        version: v13.0.0
-        dependencies:
-          - arraybuffer-types
-          - arrays
-          - effect
-          - float32
-          - functions
-          - gen
-          - maybe
-          - nullable
-          - prelude
-          - tailrec
-          - uint
-          - unfoldable
-      arraybuffer-builder:
-        repo: https://github.com/jamesdbrock/purescript-arraybuffer-builder.git
-        version: v3.0.1
-        dependencies:
-          - arraybuffer
-          - arraybuffer-types
-          - effect
-          - float32
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - transformers
-          - uint
-      arraybuffer-types:
-        repo: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
-        version: v3.0.2
-        dependencies: []
-      arrays:
-        repo: https://github.com/purescript/purescript-arrays.git
-        version: v7.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - foldable-traversable
-          - maybe
-          - nonempty
-          - partial
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - unfoldable
-          - unsafe-coerce
-      arrays-zipper:
-        repo: https://github.com/JordanMartinez/purescript-arrays-zipper.git
-        version: v2.0.1
-        dependencies:
-          - arrays
-          - control
-          - quickcheck
-      ask:
-        repo: https://github.com/Mateiadrielrafael/purescript-ask.git
-        version: v1.0.0
-        dependencies:
-          - unsafe-coerce
-      assert:
-        repo: https://github.com/purescript/purescript-assert.git
-        version: v6.0.0
-        dependencies:
-          - console
-          - effect
-          - prelude
-      avar:
-        repo: https://github.com/purescript-contrib/purescript-avar.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - exceptions
-          - functions
-          - maybe
-      b64:
-        repo: https://github.com/menelaos/purescript-b64.git
-        version: v0.0.8
-        dependencies:
-          - arraybuffer-types
-          - either
-          - encoding
-          - enums
-          - exceptions
-          - functions
-          - partial
-          - prelude
-          - strings
-      barlow-lens:
-        repo: https://github.com/sigma-andex/purescript-barlow-lens.git
-        version: v0.9.0
-        dependencies:
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - profunctor-lenses
-          - tuples
-          - typelevel-prelude
-      bifunctors:
-        repo: https://github.com/purescript/purescript-bifunctors.git
-        version: v6.0.0
-        dependencies:
-          - const
-          - either
-          - newtype
-          - prelude
-          - tuples
-      bigints:
-        repo: https://github.com/sharkdp/purescript-bigints.git
-        version: v7.0.1
-        dependencies:
-          - integers
-          - maybe
-          - strings
-      bower-json:
-        repo: https://github.com/klntsky/purescript-bower-json.git
-        version: v3.0.0
-        dependencies:
-          - argonaut-codecs
-          - arrays
-          - either
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - newtype
-          - prelude
-          - tuples
-      call-by-name:
-        repo: https://github.com/natefaubion/purescript-call-by-name.git
-        version: v4.0.1
-        dependencies:
-          - control
-          - either
-          - lazy
-          - maybe
-          - unsafe-coerce
-      canvas:
-        repo: https://github.com/purescript-web/purescript-canvas.git
-        version: v6.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - exceptions
-          - functions
-          - maybe
-      canvas-action:
-        repo: https://github.com/artemisSystem/purescript-canvas-action.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - arrays
-          - canvas
-          - colors
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - maybe
-          - numbers
-          - polymorphic-vectors
-          - prelude
-          - refs
-          - run
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-html
-      cartesian:
-        repo: https://github.com/Ebmtranceboy/purescript-cartesian.git
-        version: v1.0.6
-        dependencies:
-          - console
-          - effect
-          - integers
-          - psci-support
-      catenable-lists:
-        repo: https://github.com/purescript/purescript-catenable-lists.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - lists
-          - maybe
-          - prelude
-          - tuples
-          - unfoldable
-      channel:
-        repo: https://github.com/ConnorDillon/purescript-channel.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - assert
-          - avar
-          - console
-          - contravariant
-          - control
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - lazy
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      checked-exceptions:
-        repo: https://github.com/natefaubion/purescript-checked-exceptions.git
-        version: v3.1.1
-        dependencies:
-          - prelude
-          - transformers
-          - variant
-      codec:
-        repo: https://github.com/garyb/purescript-codec.git
-        version: v5.0.0
-        dependencies:
-          - profunctor
-          - transformers
-      codec-argonaut:
-        repo: https://github.com/garyb/purescript-codec-argonaut.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-core
-          - codec
-          - ordered-collections
-          - type-equality
-          - variant
-      colors:
-        repo: https://github.com/purescript-contrib/purescript-colors.git
-        version: v7.0.1
-        dependencies:
-          - arrays
-          - integers
-          - lists
-          - numbers
-          - partial
-          - strings
-      concurrent-queues:
-        repo: https://github.com/purescript-contrib/purescript-concurrent-queues.git
-        version: v3.0.0
-        dependencies:
-          - aff
-          - avar
-          - effect
-      console:
-        repo: https://github.com/purescript/purescript-console.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - prelude
-      const:
-        repo: https://github.com/purescript/purescript-const.git
-        version: v6.0.0
-        dependencies:
-          - invariant
-          - newtype
-          - prelude
-      contravariant:
-        repo: https://github.com/purescript/purescript-contravariant.git
-        version: v6.0.0
-        dependencies:
-          - const
-          - either
-          - newtype
-          - prelude
-          - tuples
-      control:
-        repo: https://github.com/purescript/purescript-control.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      convertable-options:
-        repo: https://github.com/natefaubion/purescript-convertable-options.git
-        version: v1.0.0
-        dependencies:
-          - console
-          - effect
-          - maybe
-          - record
-      coroutines:
-        repo: https://github.com/purescript-contrib/purescript-coroutines.git
-        version: v7.0.0
-        dependencies:
-          - freet
-          - parallel
-          - profunctor
-      css:
-        repo: https://github.com/purescript-contrib/purescript-css.git
-        version: v6.0.0
-        dependencies:
-          - colors
-          - console
-          - effect
-          - nonempty
-          - profunctor
-          - strings
-          - these
-          - transformers
-      datetime:
-        repo: https://github.com/purescript/purescript-datetime.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - either
-          - enums
-          - foldable-traversable
-          - functions
-          - gen
-          - integers
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - ordered-collections
-          - partial
-          - prelude
-          - tuples
-      datetime-parsing:
-        repo: https://github.com/flounders/purescript-datetime-parsing.git
-        version: v0.2.0
-        dependencies:
-          - arrays
-          - datetime
-          - either
-          - enums
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - numbers
-          - parsing
-          - prelude
-          - strings
-          - unicode
-      debug:
-        repo: https://github.com/garyb/purescript-debug.git
-        version: v6.0.0
-        dependencies:
-          - functions
-          - prelude
-      decimals:
-        repo: https://github.com/sharkdp/purescript-decimals.git
-        version: v7.0.0
-        dependencies:
-          - maybe
-      dissect:
-        repo: https://github.com/PureFunctor/purescript-dissect.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - foreign-object
-          - functors
-          - newtype
-          - partial
-          - prelude
-          - tailrec
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - variant
-      distributive:
-        repo: https://github.com/purescript/purescript-distributive.git
-        version: v6.0.0
-        dependencies:
-          - identity
-          - newtype
-          - prelude
-          - tuples
-          - type-equality
-      dodo-printer:
-        repo: https://github.com/natefaubion/purescript-dodo-printer.git
-        version: v2.2.0
-        dependencies:
-          - aff
-          - ansi
-          - avar
-          - console
-          - effect
-          - foldable-traversable
-          - lists
-          - maybe
-          - minibench
-          - node-child-process
-          - node-fs-aff
-          - node-process
-          - psci-support
-          - strings
-      dom-indexed:
-        repo: https://github.com/purescript-halogen/purescript-dom-indexed.git
-        version: v11.0.0
-        dependencies:
-          - media-types
-          - prelude
-          - web-clipboard
-          - web-pointerevents
-          - web-touchevents
-      droplet:
-        repo: https://github.com/easafe/purescript-droplet.git
-        version: v0.4.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - bigints
-          - datetime
-          - debug
-          - effect
-          - either
-          - enums
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - integers
-          - maybe
-          - newtype
-          - nullable
-          - ordered-collections
-          - partial
-          - prelude
-          - profunctor
-          - record
-          - spec
-          - strings
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-      dynamic-buffer:
-        repo: https://github.com/kritzcreek/purescript-dynamic-buffer.git
-        version: v3.0.1
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - refs
-      effect:
-        repo: https://github.com/purescript/purescript-effect.git
-        version: v4.0.0
-        dependencies:
-          - prelude
-      either:
-        repo: https://github.com/purescript/purescript-either.git
-        version: v6.1.0
-        dependencies:
-          - control
-          - invariant
-          - maybe
-          - prelude
-      elmish:
-        repo: https://github.com/collegevine/purescript-elmish.git
-        version: v0.8.1
-        dependencies:
-          - aff
-          - argonaut-core
-          - arrays
-          - bifunctors
-          - console
-          - debug
-          - effect
-          - either
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - functions
-          - integers
-          - js-date
-          - maybe
-          - nullable
-          - partial
-          - prelude
-          - refs
-          - typelevel-prelude
-          - undefined-is-not-a-problem
-          - unsafe-coerce
-          - web-dom
-          - web-html
-      elmish-enzyme:
-        repo: https://github.com/collegevine/purescript-elmish-enzyme.git
-        version: v0.1.1
-        dependencies:
-          - aff
-          - aff-promise
-          - arrays
-          - console
-          - debug
-          - effect
-          - elmish
-          - foldable-traversable
-          - foreign
-          - functions
-          - prelude
-          - transformers
-          - unsafe-coerce
-      elmish-hooks:
-        repo: https://github.com/collegevine/purescript-elmish-hooks.git
-        version: v0.8.2
-        dependencies:
-          - aff
-          - debug
-          - elmish
-          - maybe
-          - prelude
-          - tuples
-          - undefined-is-not-a-problem
-      elmish-html:
-        repo: https://github.com/collegevine/purescript-elmish-html.git
-        version: v0.7.1
-        dependencies:
-          - effect
-          - elmish
-          - foreign
-          - foreign-object
-          - prelude
-          - record
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-html
-      email-validate:
-        repo: https://github.com/cdepillabout/purescript-email-validate.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - string-parsers
-          - transformers
-      encoding:
-        repo: https://github.com/menelaos/purescript-encoding.git
-        version: v0.0.8
-        dependencies:
-          - arraybuffer-types
-          - either
-          - exceptions
-          - functions
-          - prelude
-      enums:
-        repo: https://github.com/purescript/purescript-enums.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - either
-          - gen
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tuples
-          - unfoldable
-      exceptions:
-        repo: https://github.com/purescript/purescript-exceptions.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - either
-          - maybe
-          - prelude
-      exists:
-        repo: https://github.com/purescript/purescript-exists.git
-        version: v6.0.0
-        dependencies:
-          - unsafe-coerce
-      exitcodes:
-        repo: https://github.com/Risto-Stevcev/purescript-exitcodes.git
-        version: v4.0.0
-        dependencies:
-          - enums
-      expect-inferred:
-        repo: https://github.com/justinwoo/purescript-expect-inferred.git
-        version: v3.0.0
-        dependencies:
-          - prelude
-          - typelevel-prelude
-      fast-vect:
-        repo: https://github.com/sigma-andex/purescript-fast-vect.git
-        version: v0.7.0
-        dependencies:
-          - arrays
-          - filterable
-          - foldable-traversable
-          - lists
-          - maybe
-          - ordered-collections
-          - prelude
-          - profunctor
-          - tuples
-          - unfoldable
-      filterable:
-        repo: https://github.com/purescript/purescript-filterable.git
-        version: v5.0.0
-        dependencies:
-          - arrays
-          - either
-          - foldable-traversable
-          - identity
-          - lists
-          - ordered-collections
-      fixed-points:
-        repo: https://github.com/purescript-contrib/purescript-fixed-points.git
-        version: v7.0.0
-        dependencies:
-          - exists
-          - newtype
-          - prelude
-          - transformers
-      fixed-precision:
-        repo: https://github.com/lumihq/purescript-fixed-precision.git
-        version: v5.0.0
-        dependencies:
-          - arrays
-          - bigints
-          - control
-          - integers
-          - maybe
-          - numbers
-          - partial
-          - prelude
-          - strings
-      flame:
-        repo: https://github.com/easafe/purescript-flame.git
-        version: v1.2.0
-        dependencies:
-          - aff
-          - argonaut-codecs
-          - argonaut-core
-          - argonaut-generic
-          - arrays
-          - bifunctors
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - maybe
-          - newtype
-          - nullable
-          - partial
-          - prelude
-          - random
-          - refs
-          - spec
-          - strings
-          - tuples
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-html
-          - web-uievents
-      float32:
-        repo: https://github.com/purescript-contrib/purescript-float32.git
-        version: v2.0.0
-        dependencies:
-          - gen
-          - maybe
-          - prelude
-      foldable-traversable:
-        repo: https://github.com/purescript/purescript-foldable-traversable.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - const
-          - control
-          - either
-          - functors
-          - identity
-          - maybe
-          - newtype
-          - orders
-          - prelude
-          - tuples
-      foreign:
-        repo: https://github.com/purescript/purescript-foreign.git
-        version: v7.0.0
-        dependencies:
-          - either
-          - functions
-          - identity
-          - integers
-          - lists
-          - maybe
-          - prelude
-          - strings
-          - transformers
-      foreign-object:
-        repo: https://github.com/purescript/purescript-foreign-object.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - functions
-          - gen
-          - lists
-          - maybe
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - typelevel-prelude
-          - unfoldable
-      foreign-readwrite:
-        repo: https://github.com/artemisSystem/purescript-foreign-readwrite.git
-        version: v3.0.0
-        dependencies:
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - record
-          - safe-coerce
-          - transformers
-          - unsafe-coerce
-      fork:
-        repo: https://github.com/purescript-contrib/purescript-fork.git
-        version: v6.0.0
-        dependencies:
-          - aff
-      form-urlencoded:
-        repo: https://github.com/purescript-contrib/purescript-form-urlencoded.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - js-uri
-          - maybe
-          - newtype
-          - prelude
-          - strings
-          - tuples
-      formatters:
-        repo: https://github.com/purescript-contrib/purescript-formatters.git
-        version: v7.0.0
-        dependencies:
-          - datetime
-          - fixed-points
-          - lists
-          - numbers
-          - parsing
-          - prelude
-          - transformers
-      free:
-        repo: https://github.com/purescript/purescript-free.git
-        version: v7.0.0
-        dependencies:
-          - catenable-lists
-          - control
-          - distributive
-          - either
-          - exists
-          - foldable-traversable
-          - invariant
-          - lazy
-          - maybe
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-      freeap:
-        repo: https://github.com/ethul/purescript-freeap.git
-        version: v7.0.0
-        dependencies:
-          - const
-          - exists
-          - gen
-          - lists
-      freet:
-        repo: https://github.com/purescript-contrib/purescript-freet.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - bifunctors
-          - effect
-          - either
-          - exists
-          - free
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      functions:
-        repo: https://github.com/purescript/purescript-functions.git
-        version: v6.0.0
-        dependencies:
-          - prelude
-      functors:
-        repo: https://github.com/purescript/purescript-functors.git
-        version: v5.0.0
-        dependencies:
-          - bifunctors
-          - const
-          - contravariant
-          - control
-          - distributive
-          - either
-          - invariant
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - tuples
-          - unsafe-coerce
-      fuzzy:
-        repo: https://github.com/citizennet/purescript-fuzzy.git
-        version: v0.4.0
-        dependencies:
-          - foldable-traversable
-          - foreign-object
-          - newtype
-          - ordered-collections
-          - prelude
-          - rationals
-          - strings
-          - tuples
-      gen:
-        repo: https://github.com/purescript/purescript-gen.git
-        version: v4.0.0
-        dependencies:
-          - either
-          - foldable-traversable
-          - identity
-          - maybe
-          - newtype
-          - nonempty
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      generate-values:
-        repo: https://github.com/jordanmartinez/purescript-generate-values.git
-        version: v1.0.1
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - enums
-          - foldable-traversable
-          - gen
-          - identity
-          - integers
-          - lcg
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - partial
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      geometry-plane:
-        repo: https://github.com/Ebmtranceboy/purescript-geometry-plane.git
-        version: v1.0.3
-        dependencies:
-          - console
-          - effect
-          - psci-support
-          - sparse-polynomials
-      github-actions-toolkit:
-        repo: https://github.com/purescript-contrib/purescript-github-actions-toolkit.git
-        version: v0.5.0
-        dependencies:
-          - aff
-          - aff-promise
-          - effect
-          - foreign-object
-          - node-buffer
-          - node-path
-          - node-streams
-          - nullable
-          - transformers
-      graphs:
-        repo: https://github.com/purescript/purescript-graphs.git
-        version: v8.0.0
-        dependencies:
-          - catenable-lists
-          - ordered-collections
-      group:
-        repo: https://github.com/morganthomas/purescript-group.git
-        version: v4.1.1
-        dependencies:
-          - lists
-      halogen:
-        repo: https://github.com/purescript-halogen/purescript-halogen.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - avar
-          - console
-          - const
-          - dom-indexed
-          - effect
-          - foreign
-          - fork
-          - free
-          - freeap
-          - halogen-subscriptions
-          - halogen-vdom
-          - media-types
-          - nullable
-          - ordered-collections
-          - parallel
-          - profunctor
-          - transformers
-          - unsafe-coerce
-          - unsafe-reference
-          - web-file
-          - web-uievents
-      halogen-css:
-        repo: https://github.com/purescript-halogen/purescript-halogen-css.git
-        version: v10.0.0
-        dependencies:
-          - css
-          - halogen
-      halogen-formless:
-        repo: https://github.com/thomashoneyman/purescript-halogen-formless.git
-        version: v4.0.0
-        dependencies:
-          - convertable-options
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - halogen
-          - heterogeneous
-          - maybe
-          - prelude
-          - record
-          - safe-coerce
-          - type-equality
-          - unsafe-coerce
-          - unsafe-reference
-          - variant
-          - web-events
-          - web-uievents
-      halogen-hooks:
-        repo: https://github.com/thomashoneyman/purescript-halogen-hooks.git
-        version: v0.6.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - effect
-          - exceptions
-          - foldable-traversable
-          - foreign-object
-          - free
-          - freeap
-          - halogen
-          - halogen-subscriptions
-          - maybe
-          - newtype
-          - ordered-collections
-          - parallel
-          - partial
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-          - unsafe-reference
-          - web-dom
-          - web-html
-      halogen-hooks-extra:
-        repo: https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git
-        version: v0.9.0
-        dependencies:
-          - halogen-hooks
-      halogen-store:
-        repo: https://github.com/thomashoneyman/purescript-halogen-store.git
-        version: v0.5.0
-        dependencies:
-          - aff
-          - distributive
-          - effect
-          - fork
-          - halogen
-          - halogen-hooks
-          - halogen-subscriptions
-          - maybe
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-reference
-      halogen-storybook:
-        repo: https://github.com/rnons/purescript-halogen-storybook.git
-        version: v2.0.0
-        dependencies:
-          - foreign-object
-          - halogen
-          - prelude
-          - routing
-      halogen-subscriptions:
-        repo: https://github.com/purescript-halogen/purescript-halogen-subscriptions.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - effect
-          - foldable-traversable
-          - functors
-          - refs
-          - safe-coerce
-          - unsafe-reference
-      halogen-svg-elems:
-        repo: https://github.com/JordanMartinez/purescript-halogen-svg-elems.git
-        version: v6.0.0
-        dependencies:
-          - halogen
-      halogen-vdom:
-        repo: https://github.com/purescript-halogen/purescript-halogen-vdom.git
-        version: v8.0.0
-        dependencies:
-          - bifunctors
-          - effect
-          - foreign
-          - foreign-object
-          - maybe
-          - prelude
-          - refs
-          - tuples
-          - unsafe-coerce
-          - web-html
-      halogen-vdom-string-renderer:
-        repo: https://github.com/purescript-halogen/purescript-halogen-vdom-string-renderer.git
-        version: v0.5.0
-        dependencies:
-          - foreign
-          - halogen-vdom
-          - ordered-collections
-          - prelude
-      heckin:
-        repo: https://github.com/maxdeviant/purescript-heckin.git
-        version: v2.0.1
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - maybe
-          - prelude
-          - strings
-          - transformers
-          - tuples
-          - unicode
-      heterogeneous:
-        repo: https://github.com/natefaubion/purescript-heterogeneous.git
-        version: v0.6.0
-        dependencies:
-          - either
-          - functors
-          - prelude
-          - record
-          - tuples
-          - variant
-      heterogeneous-extrablatt:
-        repo: https://github.com/sigma-andex/purescript-heterogeneous-extrablatt.git
-        version: v0.2.1
-        dependencies:
-          - heterogeneous
-          - prelude
-          - record
-      http-methods:
-        repo: https://github.com/purescript-contrib/purescript-http-methods.git
-        version: v6.0.0
-        dependencies:
-          - either
-          - prelude
-          - strings
-      httpure:
-        repo: https://github.com/citizennet/purescript-httpure.git
-        version: v0.15.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - js-uri
-          - maybe
-          - newtype
-          - node-buffer
-          - node-fs
-          - node-http
-          - node-streams
-          - options
-          - ordered-collections
-          - prelude
-          - refs
-          - strings
-          - tuples
-          - type-equality
-      httpurple:
-        repo: https://github.com/sigma-andex/purescript-httpurple.git
-        version: v1.3.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - js-uri
-          - justifill
-          - maybe
-          - newtype
-          - node-buffer
-          - node-fs
-          - node-http
-          - node-net
-          - node-process
-          - node-streams
-          - options
-          - ordered-collections
-          - posix-types
-          - prelude
-          - profunctor
-          - record
-          - refs
-          - routing-duplex
-          - strings
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-      httpurple-argonaut:
-        repo: https://github.com/sigma-andex/purescript-httpurple-argonaut.git
-        version: v1.0.1
-        dependencies:
-          - argonaut
-          - console
-          - effect
-          - either
-          - httpurple
-          - prelude
-      httpurple-yoga-json:
-        repo: https://github.com/sigma-andex/purescript-httpurple-yoga-json.git
-        version: v1.0.0
-        dependencies:
-          - console
-          - effect
-          - either
-          - foreign
-          - httpurple
-          - lists
-          - prelude
-          - yoga-json
-      identity:
-        repo: https://github.com/purescript/purescript-identity.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - invariant
-          - newtype
-          - prelude
-      indexed-monad:
-        repo: https://github.com/garyb/purescript-indexed-monad.git
-        version: v2.1.0
-        dependencies:
-          - control
-          - newtype
-      int64:
-        repo: https://github.com/purescript-contrib/purescript-int64.git
-        version: v2.0.0
-        dependencies:
-          - effect
-          - foreign
-          - functions
-          - integers
-          - maybe
-          - nullable
-          - prelude
-          - quickcheck
-      integers:
-        repo: https://github.com/purescript/purescript-integers.git
-        version: v6.0.0
-        dependencies:
-          - maybe
-          - numbers
-          - prelude
-      interpolate:
-        repo: https://github.com/jordanmartinez/purescript-interpolate.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-      invariant:
-        repo: https://github.com/purescript/purescript-invariant.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - prelude
-      js-date:
-        repo: https://github.com/purescript-contrib/purescript-js-date.git
-        version: v8.0.0
-        dependencies:
-          - datetime
-          - effect
-          - exceptions
-          - foreign
-          - integers
-          - now
-      js-fileio:
-        repo: https://github.com/newlandsvalley/purescript-js-fileio.git
-        version: v3.0.0
-        dependencies:
-          - aff
-          - effect
-          - prelude
-      js-timers:
-        repo: https://github.com/purescript-contrib/purescript-js-timers.git
-        version: v6.1.0
-        dependencies:
-          - effect
-      js-uri:
-        repo: https://github.com/purescript-contrib/purescript-js-uri.git
-        version: v3.0.0
-        dependencies:
-          - functions
-          - maybe
-      justifill:
-        repo: https://github.com/i-am-the-slime/purescript-justifill.git
-        version: v0.5.0
-        dependencies:
-          - maybe
-          - prelude
-          - record
-          - typelevel-prelude
-      jwt:
-        repo: https://github.com/menelaos/purescript-jwt.git
-        version: v0.0.9
-        dependencies:
-          - argonaut-core
-          - arrays
-          - b64
-          - either
-          - exceptions
-          - prelude
-          - profunctor-lenses
-          - strings
-      language-cst-parser:
-        repo: https://github.com/natefaubion/purescript-language-cst-parser.git
-        version: v0.12.0
-        dependencies:
-          - arrays
-          - const
-          - control
-          - either
-          - foldable-traversable
-          - free
-          - functions
-          - functors
-          - identity
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - ordered-collections
-          - partial
-          - prelude
-          - st
-          - strings
-          - transformers
-          - tuples
-          - typelevel-prelude
-          - unfoldable
-          - unsafe-coerce
-      lazy:
-        repo: https://github.com/purescript/purescript-lazy.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - invariant
-          - prelude
-      lcg:
-        repo: https://github.com/purescript/purescript-lcg.git
-        version: v4.0.0
-        dependencies:
-          - effect
-          - integers
-          - maybe
-          - partial
-          - prelude
-          - random
-      leibniz:
-        repo: https://github.com/paf31/purescript-leibniz.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-          - unsafe-coerce
-      linalg:
-        repo: https://github.com/gbagan/purescript-linalg.git
-        version: v5.1.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - functions
-          - maybe
-          - prelude
-          - tuples
-      lists:
-        repo: https://github.com/purescript/purescript-lists.git
-        version: v7.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - foldable-traversable
-          - lazy
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      logging:
-        repo: https://github.com/rightfold/purescript-logging.git
-        version: v3.0.0
-        dependencies:
-          - console
-          - contravariant
-          - effect
-          - either
-          - prelude
-          - transformers
-          - tuples
-      machines:
-        repo: https://github.com/purescript-contrib/purescript-machines.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - lists
-          - maybe
-          - prelude
-          - profunctor
-          - tuples
-          - unfoldable
-      matrices:
-        repo: https://github.com/kRITZCREEK/purescript-matrices.git
-        version: v5.0.1
-        dependencies:
-          - arrays
-          - strings
-      matryoshka:
-        repo: https://github.com/purescript-contrib/purescript-matryoshka.git
-        version: v1.0.0
-        dependencies:
-          - fixed-points
-          - free
-          - prelude
-          - profunctor
-          - transformers
-      maybe:
-        repo: https://github.com/purescript/purescript-maybe.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - invariant
-          - newtype
-          - prelude
-      media-types:
-        repo: https://github.com/purescript-contrib/purescript-media-types.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      metadata:
-        repo: https://github.com/purescript/purescript-metadata.git
-        version: v0.15.0
-        dependencies: []
-      midi:
-        repo: https://github.com/newlandsvalley/purescript-midi.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - ordered-collections
-          - prelude
-          - signal
-          - string-parsers
-          - strings
-          - tuples
-          - unfoldable
-      minibench:
-        repo: https://github.com/purescript/purescript-minibench.git
-        version: v4.0.0
-        dependencies:
-          - console
-          - effect
-          - integers
-          - numbers
-          - partial
-          - prelude
-          - refs
-      mmorph:
-        repo: https://github.com/Thimoteus/purescript-mmorph.git
-        version: v7.0.0
-        dependencies:
-          - free
-          - functors
-          - transformers
-      monad-control:
-        repo: https://github.com/athanclark/purescript-monad-control.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - freet
-          - identity
-          - lists
-      monad-logger:
-        repo: https://github.com/cprussin/purescript-monad-logger.git
-        version: v1.3.1
-        dependencies:
-          - aff
-          - ansi
-          - argonaut
-          - arrays
-          - console
-          - control
-          - effect
-          - foldable-traversable
-          - foreign-object
-          - integers
-          - js-date
-          - maybe
-          - newtype
-          - ordered-collections
-          - prelude
-          - strings
-          - transformers
-          - tuples
-      monad-loops:
-        repo: https://github.com/mlang/purescript-monad-loops.git
-        version: v0.5.0
-        dependencies:
-          - lists
-          - maybe
-          - prelude
-          - tailrec
-          - tuples
-      monad-unlift:
-        repo: https://github.com/athanclark/purescript-monad-unlift.git
-        version: v1.0.1
-        dependencies:
-          - monad-control
-      monoidal:
-        repo: https://github.com/mcneissue/purescript-monoidal.git
-        version: v0.16.0
-        dependencies:
-          - either
-          - profunctor
-          - these
-          - tuples
-      morello:
-        repo: https://github.com/sigma-andex/purescript-morello.git
-        version: v0.3.2
-        dependencies:
-          - arrays
-          - barlow-lens
-          - foldable-traversable
-          - heterogeneous
-          - heterogeneous-extrablatt
-          - newtype
-          - prelude
-          - profunctor
-          - profunctor-lenses
-          - record
-          - tuples
-          - typelevel-prelude
-          - validation
-      motsunabe:
-        repo: https://github.com/justinwoo/purescript-motsunabe.git
-        version: v2.0.0
-        dependencies:
-          - lists
-          - strings
-      nano-id:
-        repo: https://github.com/eikooc/nano-id.git
-        version: v1.1.0
-        dependencies:
-          - aff
-          - effect
-          - lists
-          - maybe
-          - prelude
-          - random
-          - spec
-          - strings
-          - stringutils
-      naturals:
-        repo: https://github.com/LiamGoodacre/purescript-naturals.git
-        version: v3.0.0
-        dependencies:
-          - enums
-          - maybe
-          - prelude
-      nested-functor:
-        repo: https://github.com/acple/purescript-nested-functor.git
-        version: v0.2.1
-        dependencies:
-          - prelude
-          - type-equality
-      newtype:
-        repo: https://github.com/purescript/purescript-newtype.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-          - safe-coerce
-      node-buffer:
-        repo: https://github.com/purescript-node/purescript-node-buffer.git
-        version: v8.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - maybe
-          - st
-          - unsafe-coerce
-      node-buffer-blob:
-        repo: https://github.com/purescript-node/purescript-node-buffer-blob.git
-        version: v1.0.0
-        dependencies:
-          - aff-promise
-          - arraybuffer-types
-          - arrays
-          - console
-          - effect
-          - maybe
-          - media-types
-          - newtype
-          - node-buffer
-          - nullable
-          - prelude
-          - web-streams
-      node-child-process:
-        repo: https://github.com/purescript-node/purescript-node-child-process.git
-        version: v9.0.0
-        dependencies:
-          - exceptions
-          - foreign
-          - foreign-object
-          - functions
-          - node-fs
-          - node-streams
-          - nullable
-          - posix-types
-          - unsafe-coerce
-      node-fs:
-        repo: https://github.com/purescript-node/purescript-node-fs.git
-        version: v8.0.0
-        dependencies:
-          - datetime
-          - effect
-          - either
-          - enums
-          - exceptions
-          - functions
-          - integers
-          - js-date
-          - maybe
-          - node-buffer
-          - node-path
-          - node-streams
-          - nullable
-          - partial
-          - prelude
-          - strings
-          - unsafe-coerce
-      node-fs-aff:
-        repo: https://github.com/purescript-node/purescript-node-fs-aff.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - either
-          - node-fs
-          - node-path
-      node-http:
-        repo: https://github.com/purescript-node/purescript-node-http.git
-        version: v8.0.0
-        dependencies:
-          - arraybuffer-types
-          - contravariant
-          - effect
-          - foreign
-          - foreign-object
-          - maybe
-          - node-buffer
-          - node-net
-          - node-streams
-          - node-url
-          - nullable
-          - options
-          - prelude
-          - unsafe-coerce
-      node-net:
-        repo: https://github.com/purescript-node/purescript-node-net.git
-        version: v4.0.0
-        dependencies:
-          - effect
-          - either
-          - exceptions
-          - foreign
-          - maybe
-          - node-buffer
-          - node-fs
-          - nullable
-          - options
-          - prelude
-          - transformers
-      node-path:
-        repo: https://github.com/purescript-node/purescript-node-path.git
-        version: v5.0.0
-        dependencies:
-          - effect
-      node-process:
-        repo: https://github.com/purescript-node/purescript-node-process.git
-        version: v10.0.0
-        dependencies:
-          - effect
-          - foreign-object
-          - maybe
-          - node-streams
-          - posix-types
-          - prelude
-          - unsafe-coerce
-      node-readline:
-        repo: https://github.com/purescript-node/purescript-node-readline.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - foreign
-          - node-process
-          - node-streams
-          - options
-          - prelude
-      node-streams:
-        repo: https://github.com/purescript-node/purescript-node-streams.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - either
-          - exceptions
-          - node-buffer
-          - nullable
-          - prelude
-      node-streams-aff:
-        repo: https://github.com/jamesdbrock/purescript-node-streams-aff.git
-        version: v2.0.0
-        dependencies:
-          - aff
-          - arrays
-          - effect
-          - either
-          - exceptions
-          - maybe
-          - node-buffer
-          - node-streams
-          - prelude
-          - st
-          - tuples
-      node-url:
-        repo: https://github.com/purescript-node/purescript-node-url.git
-        version: v6.0.0
-        dependencies:
-          - nullable
-      nonempty:
-        repo: https://github.com/purescript/purescript-nonempty.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - maybe
-          - prelude
-          - tuples
-          - unfoldable
-      now:
-        repo: https://github.com/purescript-contrib/purescript-now.git
-        version: v6.0.0
-        dependencies:
-          - datetime
-          - effect
-      npm-package-json:
-        repo: https://github.com/maxdeviant/purescript-npm-package-json.git
-        version: v2.0.0
-        dependencies:
-          - argonaut
-          - control
-          - either
-          - foreign-object
-          - maybe
-          - ordered-collections
-          - prelude
-      nullable:
-        repo: https://github.com/purescript-contrib/purescript-nullable.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - functions
-          - maybe
-      numbers:
-        repo: https://github.com/purescript/purescript-numbers.git
-        version: v9.0.0
-        dependencies:
-          - functions
-          - maybe
-      open-folds:
-        repo: https://github.com/purescript-open-community/purescript-open-folds.git
-        version: v6.3.0
-        dependencies:
-          - bifunctors
-          - console
-          - control
-          - distributive
-          - effect
-          - either
-          - foldable-traversable
-          - identity
-          - invariant
-          - maybe
-          - newtype
-          - ordered-collections
-          - prelude
-          - profunctor
-          - psci-support
-          - tuples
-      open-memoize:
-        repo: https://github.com/purescript-open-community/purescript-open-memoize.git
-        version: v6.1.0
-        dependencies:
-          - console
-          - effect
-          - either
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - psci-support
-          - strings
-          - tuples
-      open-pairing:
-        repo: https://github.com/purescript-open-community/purescript-open-pairing.git
-        version: v6.1.0
-        dependencies:
-          - console
-          - control
-          - effect
-          - either
-          - free
-          - functors
-          - identity
-          - newtype
-          - prelude
-          - psci-support
-          - transformers
-          - tuples
-      options:
-        repo: https://github.com/purescript-contrib/purescript-options.git
-        version: v7.0.0
-        dependencies:
-          - contravariant
-          - foreign
-          - foreign-object
-          - maybe
-          - tuples
-      optparse:
-        repo: https://github.com/f-o-a-m/purescript-optparse.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - control
-          - effect
-          - either
-          - enums
-          - exists
-          - exitcodes
-          - foldable-traversable
-          - free
-          - gen
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - newtype
-          - node-buffer
-          - node-process
-          - node-streams
-          - nonempty
-          - numbers
-          - open-memoize
-          - partial
-          - prelude
-          - quickcheck
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-      ordered-collections:
-        repo: https://github.com/purescript/purescript-ordered-collections.git
-        version: v3.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - gen
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - unfoldable
-      ordered-set:
-        repo: https://github.com/flip111/purescript-ordered-set.git
-        version: v0.4.0
-        dependencies:
-          - argonaut-codecs
-          - arrays
-          - partial
-          - prelude
-          - unfoldable
-      orders:
-        repo: https://github.com/purescript/purescript-orders.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      pairs:
-        repo: https://github.com/sharkdp/purescript-pairs.git
-        version: v9.0.0
-        dependencies:
-          - console
-          - distributive
-          - foldable-traversable
-          - quickcheck
-      parallel:
-        repo: https://github.com/purescript/purescript-parallel.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - functors
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - refs
-          - transformers
-      parsing:
-        repo: https://github.com/purescript-contrib/purescript-parsing.git
-        version: v9.1.0
-        dependencies:
-          - arrays
-          - either
-          - foldable-traversable
-          - identity
-          - integers
-          - lists
-          - maybe
-          - nullable
-          - prelude
-          - strings
-          - transformers
-          - unicode
-      parsing-dataview:
-        repo: https://github.com/jamesdbrock/purescript-parsing-dataview.git
-        version: v3.1.0
-        dependencies:
-          - arraybuffer
-          - arraybuffer-types
-          - effect
-          - float32
-          - maybe
-          - parsing
-          - prelude
-          - transformers
-          - tuples
-          - uint
-      partial:
-        repo: https://github.com/purescript/purescript-partial.git
-        version: v4.0.0
-        dependencies: []
-      pathy:
-        repo: https://github.com/purescript-contrib/purescript-pathy.git
-        version: v9.0.0
-        dependencies:
-          - console
-          - exceptions
-          - lists
-          - partial
-          - profunctor
-          - strings
-          - transformers
-          - typelevel-prelude
-          - unsafe-coerce
-      pha:
-        repo: https://github.com/gbagan/purescript-pha.git
-        version: v0.9.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - datetime
-          - effect
-          - foldable-traversable
-          - free
-          - integers
-          - maybe
-          - prelude
-          - profunctor-lenses
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-          - unsafe-reference
-          - web-dom
-          - web-events
-          - web-html
-          - web-pointerevents
-          - web-uievents
-      phaser:
-        repo: https://github.com/lfarroco/purescript-phaser.git
-        version: v0.6.0
-        dependencies:
-          - canvas
-          - console
-          - effect
-          - maybe
-          - nullable
-          - options
-          - prelude
-          - web-html
-      pipes:
-        repo: https://github.com/felixschl/purescript-pipes.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - lists
-          - mmorph
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      point-free:
-        repo: https://github.com/ursi/purescript-point-free.git
-        version: v1.0.0
-        dependencies:
-          - prelude
-      polymorphic-vectors:
-        repo: https://github.com/artemisSystem/purescript-polymorphic-vectors.git
-        version: v4.0.0
-        dependencies:
-          - distributive
-          - foldable-traversable
-          - numbers
-          - prelude
-          - record
-          - safe-coerce
-          - type-equality
-          - typelevel-prelude
-      posix-types:
-        repo: https://github.com/purescript-node/purescript-posix-types.git
-        version: v6.0.0
-        dependencies:
-          - maybe
-          - prelude
-      precise:
-        repo: https://github.com/purescript-contrib/purescript-precise.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - exceptions
-          - gen
-          - integers
-          - lists
-          - numbers
-          - prelude
-          - strings
-      precise-datetime:
-        repo: https://github.com/awakesecurity/purescript-precise-datetime.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - datetime
-          - decimals
-          - either
-          - enums
-          - foldable-traversable
-          - formatters
-          - integers
-          - js-date
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - strings
-          - tuples
-          - unicode
-      prelude:
-        repo: https://github.com/purescript/purescript-prelude.git
-        version: v6.0.0
-        dependencies: []
-      prettier-printer:
-        repo: https://github.com/paulyoung/purescript-prettier-printer.git
-        version: v3.0.0
-        dependencies:
-          - console
-          - lists
-          - prelude
-          - strings
-          - tuples
-      profunctor:
-        repo: https://github.com/purescript/purescript-profunctor.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - distributive
-          - either
-          - exists
-          - invariant
-          - newtype
-          - prelude
-          - tuples
-      profunctor-lenses:
-        repo: https://github.com/purescript-contrib/purescript-profunctor-lenses.git
-        version: v8.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - const
-          - control
-          - distributive
-          - either
-          - foldable-traversable
-          - foreign-object
-          - functors
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - ordered-collections
-          - partial
-          - prelude
-          - profunctor
-          - record
-          - transformers
-          - tuples
-      protobuf:
-        repo: https://github.com/xc-jp/purescript-protobuf.git
-        version: v4.0.0
-        dependencies:
-          - arraybuffer
-          - arraybuffer-builder
-          - arraybuffer-types
-          - arrays
-          - control
-          - effect
-          - either
-          - enums
-          - exceptions
-          - float32
-          - foldable-traversable
-          - functions
-          - int64
-          - maybe
-          - newtype
-          - parsing
-          - parsing-dataview
-          - prelude
-          - record
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-          - uint
-          - web-encoding
-      ps-cst:
-        repo: https://github.com/purescript-codegen/purescript-ps-cst.git
-        version: v1.2.0
-        dependencies:
-          - ansi
-          - console
-          - dodo-printer
-          - effect
-          - node-fs-aff
-          - node-path
-          - psci-support
-          - record
-          - strings
-      psa-utils:
-        repo: https://github.com/natefaubion/purescript-psa-utils.git
-        version: v8.0.0
-        dependencies:
-          - ansi
-          - argonaut-codecs
-          - argonaut-core
-          - arrays
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - maybe
-          - node-path
-          - ordered-collections
-          - prelude
-          - strings
-          - tuples
-          - unsafe-coerce
-      psc-ide:
-        repo: https://github.com/kRITZCREEK/purescript-psc-ide.git
-        version: v19.0.0
-        dependencies:
-          - aff
-          - argonaut
-          - arrays
-          - console
-          - maybe
-          - node-child-process
-          - node-fs
-          - parallel
-          - random
-      psci-support:
-        repo: https://github.com/purescript/purescript-psci-support.git
-        version: v6.0.0
-        dependencies:
-          - console
-          - effect
-          - prelude
-      qualified-do:
-        repo: https://github.com/artemisSystem/purescript-qualified-do.git
-        version: v2.2.0
-        dependencies:
-          - arrays
-          - control
-          - foldable-traversable
-          - parallel
-          - prelude
-          - unfoldable
-      quantities:
-        repo: https://github.com/sharkdp/purescript-quantities.git
-        version: v12.0.1
-        dependencies:
-          - decimals
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - newtype
-          - nonempty
-          - numbers
-          - pairs
-          - prelude
-          - tuples
-      quickcheck:
-        repo: https://github.com/purescript/purescript-quickcheck.git
-        version: v8.0.1
-        dependencies:
-          - arrays
-          - console
-          - control
-          - effect
-          - either
-          - enums
-          - exceptions
-          - foldable-traversable
-          - gen
-          - identity
-          - integers
-          - lazy
-          - lcg
-          - lists
-          - maybe
-          - newtype
-          - nonempty
-          - numbers
-          - partial
-          - prelude
-          - record
-          - st
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-          - unfoldable
-      quickcheck-combinators:
-        repo: https://github.com/athanclark/purescript-quickcheck-combinators.git
-        version: v0.1.3
-        dependencies:
-          - quickcheck
-          - typelevel
-      quickcheck-laws:
-        repo: https://github.com/purescript-contrib/purescript-quickcheck-laws.git
-        version: v7.0.0
-        dependencies:
-          - enums
-          - quickcheck
-      quickcheck-utf8:
-        repo: https://github.com/openchronology/purescript-quickcheck-utf8.git
-        version: v0.0.0
-        dependencies:
-          - quickcheck
-      quotient:
-        repo: https://github.com/rightfold/purescript-quotient.git
-        version: v3.0.0
-        dependencies:
-          - prelude
-          - quickcheck
-      random:
-        repo: https://github.com/purescript/purescript-random.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - integers
-      rationals:
-        repo: https://github.com/anttih/purescript-rationals.git
-        version: v5.0.0
-        dependencies:
-          - integers
-          - prelude
-      react:
-        repo: https://github.com/purescript-contrib/purescript-react.git
-        version: v10.0.1
-        dependencies:
-          - effect
-          - exceptions
-          - maybe
-          - nullable
-          - prelude
-          - typelevel-prelude
-          - unsafe-coerce
-      react-basic:
-        repo: https://github.com/lumihq/purescript-react-basic.git
-        version: v17.0.0
-        dependencies:
-          - effect
-          - prelude
-          - record
-      react-basic-dom:
-        repo: https://github.com/lumihq/purescript-react-basic-dom.git
-        version: v5.0.0
-        dependencies:
-          - effect
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - nullable
-          - prelude
-          - react-basic
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-file
-          - web-html
-      react-basic-hooks:
-        repo: https://github.com/megamaddu/purescript-react-basic-hooks.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - aff-promise
-          - bifunctors
-          - console
-          - control
-          - datetime
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - functions
-          - indexed-monad
-          - integers
-          - maybe
-          - newtype
-          - now
-          - nullable
-          - ordered-collections
-          - prelude
-          - react-basic
-          - refs
-          - tuples
-          - type-equality
-          - unsafe-coerce
-          - unsafe-reference
-          - web-html
-      react-dom:
-        repo: https://github.com/purescript-contrib/purescript-react-dom.git
-        version: v8.0.0
-        dependencies:
-          - effect
-          - react
-          - web-dom
-      read:
-        repo: https://github.com/truqu/purescript-read.git
-        version: v1.0.1
-        dependencies:
-          - maybe
-          - prelude
-          - strings
-      record:
-        repo: https://github.com/purescript/purescript-record.git
-        version: v4.0.0
-        dependencies:
-          - functions
-          - prelude
-          - unsafe-coerce
-      refined:
-        repo: https://github.com/danieljharvey/purescript-refined.git
-        version: v1.0.0
-        dependencies:
-          - argonaut
-          - effect
-          - prelude
-          - quickcheck
-          - typelevel
-      refs:
-        repo: https://github.com/purescript/purescript-refs.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - prelude
-      remotedata:
-        repo: https://github.com/krisajenkins/purescript-remotedata.git
-        version: v5.0.0
-        dependencies:
-          - bifunctors
-          - either
-          - profunctor-lenses
-      resource:
-        repo: https://github.com/joneshf/purescript-resource.git
-        version: v2.0.1
-        dependencies:
-          - aff
-          - console
-          - control
-          - effect
-          - newtype
-          - prelude
-          - psci-support
-          - refs
-      resourcet:
-        repo: https://github.com/robertdp/purescript-resourcet.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - effect
-          - foldable-traversable
-          - maybe
-          - ordered-collections
-          - parallel
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-      result:
-        repo: https://github.com/ad-si/purescript-result.git
-        version: v1.0.3
-        dependencies:
-          - either
-          - foldable-traversable
-          - prelude
-      return:
-        repo: https://github.com/ursi/purescript-return.git
-        version: v0.2.0
-        dependencies:
-          - foldable-traversable
-          - point-free
-          - prelude
-      ring-modules:
-        repo: https://github.com/f-o-a-m/purescript-ring-modules.git
-        version: v5.0.1
-        dependencies:
-          - prelude
-      routing:
-        repo: https://github.com/purescript-contrib/purescript-routing.git
-        version: v11.0.0
-        dependencies:
-          - aff
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - integers
-          - js-uri
-          - lists
-          - maybe
-          - numbers
-          - partial
-          - prelude
-          - semirings
-          - tuples
-          - validation
-          - web-html
-      routing-duplex:
-        repo: https://github.com/natefaubion/purescript-routing-duplex.git
-        version: v0.6.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - js-uri
-          - lazy
-          - numbers
-          - prelude
-          - profunctor
-          - record
-          - strings
-          - typelevel-prelude
-      run:
-        repo: https://github.com/natefaubion/purescript-run.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - free
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - tailrec
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - variant
-      safe-coerce:
-        repo: https://github.com/purescript/purescript-safe-coerce.git
-        version: v2.0.0
-        dependencies:
-          - unsafe-coerce
-      safely:
-        repo: https://github.com/paf31/purescript-safely.git
-        version: v4.0.1
-        dependencies:
-          - freet
-          - lists
-      selection-foldable:
-        repo: https://github.com/jamieyung/purescript-selection-foldable.git
-        version: v0.2.0
-        dependencies:
-          - filterable
-          - foldable-traversable
-          - maybe
-          - prelude
-      semirings:
-        repo: https://github.com/purescript/purescript-semirings.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - lists
-          - newtype
-          - prelude
-      signal:
-        repo: https://github.com/bodil/purescript-signal.git
-        version: v13.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - foldable-traversable
-          - maybe
-          - prelude
-      simple-emitter:
-        repo: https://github.com/oreshinya/purescript-simple-emitter.git
-        version: v2.0.0
-        dependencies:
-          - ordered-collections
-          - refs
-      sized-matrices:
-        repo: https://github.com/csicar/purescript-sized-matrices.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - distributive
-          - foldable-traversable
-          - maybe
-          - prelude
-          - sized-vectors
-          - strings
-          - typelevel
-          - unfoldable
-          - vectorfield
-      sized-vectors:
-        repo: https://github.com/bodil/purescript-sized-vectors.git
-        version: v5.0.2
-        dependencies:
-          - argonaut
-          - arrays
-          - distributive
-          - foldable-traversable
-          - maybe
-          - prelude
-          - quickcheck
-          - typelevel
-          - unfoldable
-      slug:
-        repo: https://github.com/thomashoneyman/purescript-slug.git
-        version: v3.0.1
-        dependencies:
-          - argonaut-codecs
-          - maybe
-          - prelude
-          - strings
-          - unicode
-      soundfonts:
-        repo: https://github.com/newlandsvalley/purescript-soundfonts.git
-        version: v4.1.0
-        dependencies:
-          - aff
-          - affjax
-          - affjax-web
-          - argonaut-core
-          - arraybuffer-types
-          - arrays
-          - b64
-          - bifunctors
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign-object
-          - http-methods
-          - integers
-          - lists
-          - maybe
-          - midi
-          - ordered-collections
-          - parallel
-          - partial
-          - prelude
-          - strings
-          - transformers
-          - tuples
-      sparse-matrices:
-        repo: https://github.com/Ebmtranceboy/purescript-sparse-matrices.git
-        version: v1.2.1
-        dependencies:
-          - console
-          - effect
-          - prelude
-          - sparse-polynomials
-      sparse-polynomials:
-        repo: https://github.com/Ebmtranceboy/purescript-sparse-polynomials.git
-        version: v1.0.5
-        dependencies:
-          - cartesian
-          - console
-          - effect
-          - ordered-collections
-          - prelude
-          - rationals
-          - tuples
-      spec:
-        repo: https://github.com/purescript-spec/purescript-spec.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - ansi
-          - avar
-          - console
-          - exceptions
-          - foldable-traversable
-          - fork
-          - now
-          - pipes
-          - prelude
-          - strings
-          - transformers
-      spec-discovery:
-        repo: https://github.com/purescript-spec/purescript-spec-discovery.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - aff-promise
-          - arrays
-          - console
-          - effect
-          - foldable-traversable
-          - node-fs
-          - prelude
-          - spec
-      spec-quickcheck:
-        repo: https://github.com/purescript-spec/purescript-spec-quickcheck.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - prelude
-          - quickcheck
-          - random
-          - spec
-      ssrs:
-        repo: https://github.com/PureFunctor/purescript-ssrs.git
-        version: v1.0.0
-        dependencies:
-          - dissect
-          - either
-          - fixed-points
-          - free
-          - lists
-          - prelude
-          - safe-coerce
-          - tailrec
-          - tuples
-          - variant
-      st:
-        repo: https://github.com/purescript/purescript-st.git
-        version: v6.0.0
-        dependencies:
-          - partial
-          - prelude
-          - tailrec
-          - unsafe-coerce
-      strictlypositiveint:
-        repo: https://github.com/jamieyung/purescript-strictlypositiveint.git
-        version: v1.0.1
-        dependencies:
-          - prelude
-      string-parsers:
-        repo: https://github.com/purescript-contrib/purescript-string-parsers.git
-        version: v8.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - prelude
-          - strings
-          - tailrec
-      strings:
-        repo: https://github.com/purescript/purescript-strings.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - enums
-          - foldable-traversable
-          - gen
-          - integers
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-          - unsafe-coerce
-      strings-extra:
-        repo: https://github.com/purescript-contrib/purescript-strings-extra.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - maybe
-          - prelude
-          - strings
-          - unicode
-      stringutils:
-        repo: https://github.com/menelaos/purescript-stringutils.git
-        version: v0.0.12
-        dependencies:
-          - arrays
-          - integers
-          - maybe
-          - partial
-          - prelude
-          - strings
-      substitute:
-        repo: https://github.com/ursi/purescript-substitute.git
-        version: v0.2.3
-        dependencies:
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - prelude
-          - return
-          - strings
-      supply:
-        repo: https://github.com/ajnsit/purescript-supply.git
-        version: v0.2.0
-        dependencies:
-          - console
-          - control
-          - effect
-          - lazy
-          - prelude
-          - refs
-          - tuples
-      tailrec:
-        repo: https://github.com/purescript/purescript-tailrec.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - effect
-          - either
-          - identity
-          - maybe
-          - partial
-          - prelude
-          - refs
-      test-unit:
-        repo: https://github.com/bodil/purescript-test-unit.git
-        version: v17.0.0
-        dependencies:
-          - aff
-          - avar
-          - effect
-          - either
-          - free
-          - js-timers
-          - lists
-          - prelude
-          - quickcheck
-          - strings
-      thermite:
-        repo: https://github.com/paf31/purescript-thermite.git
-        version: v6.3.1
-        dependencies:
-          - aff
-          - coroutines
-          - freet
-          - profunctor-lenses
-          - react
-      thermite-dom:
-        repo: https://github.com/athanclark/purescript-thermite-dom.git
-        version: v0.3.1
-        dependencies:
-          - react
-          - react-dom
-          - thermite
-          - web-html
-      these:
-        repo: https://github.com/purescript-contrib/purescript-these.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - gen
-          - lists
-          - quickcheck
-          - quickcheck-laws
-          - tuples
-      transformers:
-        repo: https://github.com/purescript/purescript-transformers.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - distributive
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - identity
-          - lazy
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      tree-rose:
-        repo: https://github.com/jordanmartinez/purescript-tree-rose.git
-        version: v4.0.2
-        dependencies:
-          - control
-          - foldable-traversable
-          - free
-          - lists
-          - maybe
-          - prelude
-          - tailrec
-      tuples:
-        repo: https://github.com/purescript/purescript-tuples.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - invariant
-          - prelude
-      two-or-more:
-        repo: https://github.com/i-am-the-slime/purescript-two-or-more.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - foldable-traversable
-          - maybe
-          - partial
-          - prelude
-          - psci-support
-          - tuples
-      type-equality:
-        repo: https://github.com/purescript/purescript-type-equality.git
-        version: v4.0.1
-        dependencies: []
-      typelevel:
-        repo: https://github.com/bodil/purescript-typelevel.git
-        version: v6.0.0
-        dependencies:
-          - partial
-          - prelude
-          - tuples
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-lists:
-        repo: https://github.com/PureFunctor/purescript-typelevel-lists.git
-        version: v2.1.0
-        dependencies:
-          - prelude
-          - tuples
-          - typelevel-peano
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-peano:
-        repo: https://github.com/csicar/purescript-typelevel-peano.git
-        version: v1.0.1
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - prelude
-          - psci-support
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-prelude:
-        repo: https://github.com/purescript/purescript-typelevel-prelude.git
-        version: v7.0.0
-        dependencies:
-          - prelude
-          - type-equality
-      typelevel-rows:
-        repo: https://github.com/jordanmartinez/purescript-typelevel-rows.git
-        version: v0.1.0
-        dependencies:
-          - prelude
-      uint:
-        repo: https://github.com/purescript-contrib/purescript-uint.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - enums
-          - gen
-          - maybe
-          - numbers
-          - prelude
-      uncurried-transformers:
-        repo: https://github.com/PureFunctor/purescript-uncurried-transformers.git
-        version: v1.1.0
-        dependencies:
-          - control
-          - effect
-          - either
-          - functions
-          - identity
-          - prelude
-          - safe-coerce
-          - tailrec
-          - transformers
-          - tuples
-      undefined-is-not-a-problem:
-        repo: https://github.com/paluh/purescript-undefined-is-not-a-problem.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - assert
-          - effect
-          - either
-          - foreign
-          - maybe
-          - newtype
-          - prelude
-          - random
-          - tuples
-          - type-equality
-          - unsafe-coerce
-      unfoldable:
-        repo: https://github.com/purescript/purescript-unfoldable.git
-        version: v6.0.0
-        dependencies:
-          - foldable-traversable
-          - maybe
-          - partial
-          - prelude
-          - tuples
-      unicode:
-        repo: https://github.com/purescript-contrib/purescript-unicode.git
-        version: v6.0.0
-        dependencies:
-          - foldable-traversable
-          - maybe
-          - strings
-      unlift:
-        repo: https://github.com/tweag/purescript-unlift.git
-        version: v1.0.1
-        dependencies:
-          - aff
-          - effect
-          - either
-          - freet
-          - identity
-          - lists
-          - maybe
-          - monad-control
-          - prelude
-          - st
-          - transformers
-          - tuples
-      unsafe-coerce:
-        repo: https://github.com/purescript/purescript-unsafe-coerce.git
-        version: v6.0.0
-        dependencies: []
-      unsafe-reference:
-        repo: https://github.com/purescript-contrib/purescript-unsafe-reference.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-      uri:
-        repo: https://github.com/purescript-contrib/purescript-uri.git
-        version: v9.0.0
-        dependencies:
-          - arrays
-          - integers
-          - js-uri
-          - numbers
-          - parsing
-          - prelude
-          - profunctor-lenses
-          - these
-          - transformers
-          - unfoldable
-      validation:
-        repo: https://github.com/purescript/purescript-validation.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - newtype
-          - prelude
-      variant:
-        repo: https://github.com/natefaubion/purescript-variant.git
-        version: v8.0.0
-        dependencies:
-          - enums
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - record
-          - tuples
-          - unsafe-coerce
-      vectorfield:
-        repo: https://github.com/csicar/purescript-vectorfield.git
-        version: v1.0.1
-        dependencies:
-          - console
-          - effect
-          - group
-          - prelude
-          - psci-support
-      versions:
-        repo: https://github.com/hdgarrood/purescript-versions.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - either
-          - foldable-traversable
-          - functions
-          - integers
-          - lists
-          - maybe
-          - orders
-          - parsing
-          - partial
-          - strings
-      web-clipboard:
-        repo: https://github.com/purescript-web/purescript-web-clipboard.git
-        version: v4.0.0
-        dependencies:
-          - web-html
-      web-cssom:
-        repo: https://github.com/purescript-web/purescript-web-cssom.git
-        version: v2.0.0
-        dependencies:
-          - web-dom
-          - web-html
-          - web-uievents
-      web-dom:
-        repo: https://github.com/purescript-web/purescript-web-dom.git
-        version: v6.0.0
-        dependencies:
-          - web-events
-      web-dom-parser:
-        repo: https://github.com/purescript-web/purescript-web-dom-parser.git
-        version: v8.0.0
-        dependencies:
-          - effect
-          - partial
-          - prelude
-          - web-dom
-      web-dom-xpath:
-        repo: https://github.com/purescript-web/purescript-web-dom-xpath.git
-        version: v3.0.0
-        dependencies:
-          - web-dom
-      web-encoding:
-        repo: https://github.com/purescript-web/purescript-web-encoding.git
-        version: v3.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - newtype
-          - prelude
-      web-events:
-        repo: https://github.com/purescript-web/purescript-web-events.git
-        version: v4.0.0
-        dependencies:
-          - datetime
-          - enums
-          - foreign
-          - nullable
-      web-fetch:
-        repo: https://github.com/purescript-web/purescript-web-fetch.git
-        version: v3.0.0
-        dependencies:
-          - effect
-          - foreign-object
-          - http-methods
-          - prelude
-          - record
-          - typelevel-prelude
-          - web-file
-          - web-promise
-          - web-streams
-      web-file:
-        repo: https://github.com/purescript-web/purescript-web-file.git
-        version: v4.0.0
-        dependencies:
-          - foreign
-          - media-types
-          - web-dom
-      web-html:
-        repo: https://github.com/purescript-web/purescript-web-html.git
-        version: v4.0.0
-        dependencies:
-          - js-date
-          - web-dom
-          - web-file
-          - web-storage
-      web-page-visibility:
-        repo: https://git.sr.ht/~toastal/purescript-web-page-visibility
-        version: v2.0.0
-        dependencies:
-          - effect
-          - enums
-          - exceptions
-          - maybe
-          - prelude
-          - strings
-          - web-events
-          - web-html
-      web-pointerevents:
-        repo: https://github.com/purescript-web/purescript-web-pointerevents.git
-        version: v1.0.0
-        dependencies:
-          - effect
-          - maybe
-          - prelude
-          - web-dom
-          - web-uievents
-      web-promise:
-        repo: https://github.com/purescript-web/purescript-web-promise.git
-        version: v3.0.0
-        dependencies:
-          - effect
-          - exceptions
-          - foldable-traversable
-          - functions
-          - maybe
-          - prelude
-      web-socket:
-        repo: https://github.com/purescript-web/purescript-web-socket.git
-        version: v4.0.0
-        dependencies:
-          - arraybuffer-types
-          - web-file
-      web-storage:
-        repo: https://github.com/purescript-web/purescript-web-storage.git
-        version: v5.0.0
-        dependencies:
-          - nullable
-          - web-events
-      web-streams:
-        repo: https://github.com/purescript-web/purescript-web-streams.git
-        version: v3.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - exceptions
-          - nullable
-          - prelude
-          - tuples
-          - web-promise
-      web-touchevents:
-        repo: https://github.com/purescript-web/purescript-web-touchevents.git
-        version: v4.0.0
-        dependencies:
-          - web-uievents
-      web-uievents:
-        repo: https://github.com/purescript-web/purescript-web-uievents.git
-        version: v4.0.0
-        dependencies:
-          - web-html
-      web-workers:
-        repo: https://github.com/gbagan/purescript-web-workers.git
-        version: v1.1.0
-        dependencies:
-          - effect
-          - foreign
-          - maybe
-          - prelude
-          - unsafe-coerce
-          - web-events
-      web-xhr:
-        repo: https://github.com/purescript-web/purescript-web-xhr.git
-        version: v5.0.0
-        dependencies:
-          - arraybuffer-types
-          - datetime
-          - http-methods
-          - web-dom
-          - web-file
-          - web-html
-      yoga-fetch:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-fetch.git
-        version: v1.0.1
-        dependencies:
-          - aff
-          - aff-promise
-          - arraybuffer-types
-          - effect
-          - foreign
-          - foreign-object
-          - newtype
-          - prelude
-          - typelevel-prelude
-          - unsafe-coerce
-      yoga-json:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-json.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - identity
-          - lists
-          - maybe
-          - nullable
-          - partial
-          - prelude
-          - record
-          - transformers
-          - typelevel-prelude
-          - variant
-      yoga-postgres:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-postgres.git
-        version: v6.0.0
-        dependencies:
-          - aff
-          - arrays
-          - datetime
-          - effect
-          - either
-          - enums
-          - foldable-traversable
-          - foreign
-          - integers
-          - maybe
-          - nullable
-          - prelude
-          - transformers
-          - unsafe-coerce
+      abc-parser: 2.0.0
+      ace: 9.0.0
+      aff: 7.1.0
+      aff-bus: 6.0.0
+      aff-coroutines: 9.0.0
+      aff-promise: 4.0.0
+      aff-retry: 2.0.0
+      affjax: 13.0.0
+      affjax-node: 1.0.0
+      affjax-web: 1.0.0
+      ansi: 7.0.0
+      argonaut: 9.0.0
+      argonaut-aeson-generic: 0.4.1
+      argonaut-codecs: 9.1.0
+      argonaut-core: 7.0.0
+      argonaut-generic: 8.0.0
+      argonaut-traversals: 10.0.0
+      argparse-basic: 2.0.0
+      array-builder: 0.1.2
+      arraybuffer: 13.1.1
+      arraybuffer-builder: 3.1.0
+      arraybuffer-types: 3.0.2
+      arrays: 7.1.0
+      arrays-zipper: 2.0.1
+      ask: 1.0.0
+      assert: 6.0.0
+      avar: 5.0.0
+      b64: 0.0.8
+      barbies: 1.0.1
+      barlow-lens: 0.9.0
+      basic-auth: 3.0.1
+      bifunctors: 6.0.0
+      bigints: 7.0.1
+      bolson: 0.3.1
+      bower-json: 3.0.0
+      bucketchain: 1.0.1
+      bucketchain-basic-auth: 1.0.1
+      bucketchain-conditional: 1.0.1
+      bucketchain-cors: 1.0.1
+      bucketchain-csrf: 1.0.1
+      bucketchain-header-utils: 1.0.1
+      bucketchain-health: 1.0.1
+      bucketchain-history-api-fallback: 1.0.1
+      bucketchain-logger: 1.0.1
+      bucketchain-secure: 1.0.1
+      bucketchain-simple-api: 5.0.1
+      bucketchain-sslify: 1.0.1
+      bucketchain-static: 1.0.1
+      call-by-name: 4.0.1
+      canvas: 6.0.0
+      canvas-action: 9.0.0
+      cartesian: 1.0.6
+      catenable-lists: 7.0.0
+      channel: 1.0.0
+      checked-exceptions: 3.1.1
+      classless: 0.1.1
+      classless-arbitrary: 0.1.1
+      classless-decode-json: 0.1.1
+      classless-encode-json: 0.1.3
+      classnames: 2.0.0
+      codec: 6.0.0
+      codec-argonaut: 10.0.0
+      colors: 7.0.1
+      concur-core: 0.5.0
+      concur-react: 0.5.0
+      concurrent-queues: 3.0.0
+      console: 6.0.0
+      const: 6.0.0
+      contravariant: 6.0.0
+      control: 6.0.0
+      convertable-options: 1.0.0
+      coroutines: 7.0.0
+      crypto: 5.0.1
+      css: 6.0.0
+      datetime: 6.1.0
+      datetime-parsing: 0.2.0
+      debug: 6.0.2
+      decimals: 7.1.0
+      default-values: 1.0.1
+      deku: 0.9.9
+      deno: 0.0.5
+      dissect: 1.0.0
+      distributive: 6.0.0
+      dodo-printer: 2.2.1
+      dom-filereader: 7.0.0
+      dom-indexed: 11.0.0
+      dotenv: 3.0.0
+      droplet: 0.5.0
+      dynamic-buffer: 3.0.1
+      echarts-simple: 0.0.1
+      effect: 4.0.0
+      either: 6.1.0
+      elmish: 0.8.3
+      elmish-enzyme: 0.1.1
+      elmish-hooks: 0.9.1
+      elmish-html: 0.7.2
+      elmish-testing-library: 0.3.1
+      email-validate: 7.0.0
+      encoding: 0.0.8
+      enums: 6.0.1
+      error: 2.0.0
+      exceptions: 6.0.0
+      exists: 6.0.0
+      exitcodes: 4.0.0
+      expect-inferred: 3.0.0
+      fahrtwind: 2.0.0
+      fallback: 0.1.0
+      fast-vect: 1.1.0
+      fetch: 1.1.4
+      fetch-argonaut: 1.0.0
+      fetch-core: 4.0.4
+      fetch-yoga-json: 1.1.0
+      filterable: 5.0.0
+      fixed-points: 7.0.0
+      fixed-precision: 5.0.0
+      flame: 1.2.0
+      float32: 2.0.0
+      foldable-traversable: 6.0.0
+      foreign: 7.0.0
+      foreign-object: 4.1.0
+      foreign-readwrite: 3.4.0
+      fork: 6.0.0
+      form-urlencoded: 7.0.0
+      formatters: 7.0.0
+      framer-motion: 1.0.1
+      free: 7.0.0
+      freeap: 7.0.0
+      freer-free: 0.0.1
+      freet: 7.0.0
+      functions: 6.0.0
+      functor1: 3.0.0
+      functors: 5.0.0
+      fuzzy: 0.4.0
+      gen: 4.0.0
+      generate-values: 1.0.1
+      generic-router: 0.0.1
+      geometry-plane: 1.0.3
+      github-actions-toolkit: 0.5.0
+      grain: 3.0.0
+      grain-router: 3.0.0
+      grain-virtualized: 3.0.0
+      graphql-client: 9.3.2
+      graphs: 8.1.0
+      group: 4.1.1
+      halogen: 7.0.0
+      halogen-bootstrap5: 2.1.0
+      halogen-css: 10.0.0
+      halogen-echarts-simple: 0.0.4
+      halogen-formless: 4.0.2
+      halogen-hooks: 0.6.3
+      halogen-hooks-extra: 0.9.0
+      halogen-store: 0.5.4
+      halogen-storybook: 2.0.0
+      halogen-subscriptions: 2.0.0
+      halogen-svg-elems: 7.0.0
+      halogen-vdom: 8.0.0
+      halogen-vdom-string-renderer: 0.5.0
+      heckin: 2.0.1
+      heterogeneous: 0.6.0
+      homogeneous: 0.4.0
+      http-methods: 6.0.0
+      httpure: 0.16.0
+      httpurple: 3.0.1
+      httpurple-argonaut: 1.0.1
+      httpurple-yoga-json: 1.0.0
+      humdrum: 0.0.1
+      hyrule: 2.3.5
+      identity: 6.0.0
+      identy: 4.0.1
+      indexed-monad: 2.1.0
+      int64: 3.0.0
+      integers: 6.0.0
+      interpolate: 5.0.2
+      invariant: 6.0.0
+      jarilo: 1.0.1
+      jelly: 0.9.1
+      jelly-hooks: 0.3.1
+      jelly-router: 0.2.2
+      jelly-signal: 0.3.0
+      jest: 1.0.0
+      js-bigints: 1.2.0
+      js-date: 8.0.0
+      js-fileio: 3.0.0
+      js-promise: 1.0.0
+      js-promise-aff: 1.0.0
+      js-timers: 6.1.0
+      js-uri: 3.1.0
+      justifill: 0.5.0
+      jwt: 0.0.9
+      language-cst-parser: 0.12.1
+      lazy: 6.0.0
+      lazy-joe: 1.0.0
+      lcg: 4.0.0
+      leibniz: 5.0.0
+      linalg: 5.1.0
+      lists: 7.0.0
+      literals: 1.0.2
+      logging: 3.0.0
+      logging-journald: 0.4.0
+      machines: 7.0.0
+      marionette: 1.0.0
+      marionette-commander: 0.1.1
+      marionette-react-basic-hooks: 0.1.1
+      matrices: 5.0.1
+      matryoshka: 1.0.0
+      maybe: 6.0.0
+      mdast-util-from-markdown: 0.2.1
+      media-types: 6.0.0
+      midi: 4.0.0
+      milkis: 9.0.0
+      minibench: 4.0.1
+      mmorph: 7.0.0
+      monad-control: 5.0.0
+      monad-logger: 1.3.1
+      monad-loops: 0.5.0
+      monad-unlift: 1.0.1
+      monoid-extras: 0.0.1
+      monoidal: 0.16.0
+      morello: 0.4.0
+      mote: 3.0.0
+      motsunabe: 2.0.0
+      mysql: 6.0.1
+      n3: 0.1.0
+      nano-id: 1.1.0
+      naturals: 3.0.0
+      nested-functor: 0.2.1
+      newtype: 5.0.0
+      nextui: 0.1.0
+      node-buffer: 8.0.0
+      node-buffer-blob: 1.0.0
+      node-child-process: 9.0.0
+      node-fs: 8.1.1
+      node-fs-aff: 9.1.0
+      node-http: 8.0.0
+      node-net: 4.0.0
+      node-path: 5.0.0
+      node-process: 10.0.0
+      node-readline: 7.0.0
+      node-sqlite3: 8.0.0
+      node-streams: 7.0.0
+      node-streams-aff: 4.0.1
+      node-url: 6.0.0
+      nodemailer: 4.0.1
+      nonempty: 7.0.0
+      now: 6.0.0
+      npm-package-json: 2.0.0
+      nullable: 6.0.0
+      numbers: 9.0.0
+      object-maps: 0.1.1
+      ocarina: 1.5.2
+      open-folds: 6.3.0
+      open-memoize: 6.1.0
+      open-pairing: 6.1.0
+      options: 7.0.0
+      optparse: 5.0.0
+      ordered-collections: 3.0.0
+      ordered-set: 0.4.0
+      orders: 6.0.0
+      pairs: 9.0.0
+      parallel: 6.0.0
+      parsing: 10.2.0
+      parsing-dataview: 3.2.4
+      partial: 4.0.0
+      pathy: 9.0.0
+      pha: 0.9.0
+      phaser: 0.6.0
+      pipes: 8.0.0
+      pirates-charm: 0.0.1
+      point-free: 1.0.0
+      pointed-list: 0.5.1
+      polymorphic-vectors: 4.0.0
+      posix-types: 6.0.0
+      precise: 6.0.0
+      precise-datetime: 7.0.0
+      prelude: 6.0.1
+      prettier-printer: 3.0.0
+      profunctor: 6.0.0
+      profunctor-lenses: 8.0.0
+      protobuf: 4.2.0
+      ps-cst: 1.2.0
+      psa-utils: 8.0.0
+      psc-ide: 19.0.0
+      psci-support: 6.0.0
+      qualified-do: 2.2.0
+      quantities: 12.1.0
+      quickcheck: 8.0.1
+      quickcheck-combinators: 0.1.3
+      quickcheck-laws: 7.0.0
+      quickcheck-utf8: 0.0.0
+      random: 6.0.0
+      rationals: 5.0.1
+      rdf: 0.1.0
+      react: 10.0.1
+      react-aria: 0.2.0
+      react-basic: 17.0.0
+      react-basic-classic: 3.0.0
+      react-basic-dnd: 10.1.0
+      react-basic-dom: 6.0.0
+      react-basic-emotion: 7.1.0
+      react-basic-hooks: 8.1.2
+      react-basic-storybook: 2.0.0
+      react-dom: 8.0.0
+      react-halo: 3.0.0
+      react-icons: 1.0.8
+      react-testing-library: 4.0.1
+      react-virtuoso: 1.0.0
+      read: 1.0.1
+      record: 4.0.0
+      record-extra: 5.0.1
+      record-studio: 1.0.4
+      refs: 6.0.0
+      remotedata: 5.0.0
+      resource: 2.0.1
+      resourcet: 1.0.0
+      result: 1.0.3
+      return: 0.2.0
+      ring-modules: 5.0.1
+      rito: 0.3.2
+      routing: 11.0.0
+      routing-duplex: 0.7.0
+      run: 5.0.0
+      safe-coerce: 2.0.0
+      safely: 4.0.1
+      school-of-music: 1.3.0
+      selection-foldable: 0.2.0
+      semirings: 7.0.0
+      signal: 13.0.0
+      simple-emitter: 3.0.1
+      simple-i18n: 2.0.1
+      simple-json: 9.0.0
+      simple-jwt: 4.0.1
+      simple-ulid: 3.0.0
+      sized-matrices: 1.0.0
+      sized-vectors: 5.0.2
+      slug: 3.0.8
+      small-ffi: 4.0.1
+      soundfonts: 4.1.0
+      sparse-matrices: 1.2.1
+      sparse-polynomials: 1.0.5
+      spec: 7.2.0
+      spec-discovery: 8.0.1
+      spec-quickcheck: 5.0.0
+      splitmix: 2.1.0
+      ssrs: 1.0.0
+      st: 6.2.0
+      strictlypositiveint: 1.0.1
+      string-parsers: 8.0.0
+      strings: 6.0.1
+      strings-extra: 4.0.0
+      stringutils: 0.0.12
+      substitute: 0.2.3
+      sunde: 3.0.0
+      supply: 0.2.0
+      svg-parser: 3.0.0
+      systemd-journald: 0.3.0
+      tagged: 4.0.2
+      tailrec: 6.1.0
+      tecton: 0.1.6
+      tecton-halogen: 0.1.3
+      test-unit: 17.0.0
+      thermite: 6.3.1
+      thermite-dom: 0.3.1
+      these: 6.0.0
+      toppokki: 4.0.0
+      transformers: 6.0.0
+      tree-rose: 4.0.2
+      tuples: 7.0.0
+      two-or-more: 1.0.0
+      type-equality: 4.0.1
+      typelevel: 6.0.0
+      typelevel-lists: 2.1.0
+      typelevel-peano: 1.0.1
+      typelevel-prelude: 7.0.0
+      typelevel-rows: 0.1.0
+      uint: 7.0.0
+      ulid: 3.0.1
+      uncurried-transformers: 1.1.0
+      undefined: 2.0.0
+      undefined-is-not-a-problem: 1.1.0
+      unfoldable: 6.0.0
+      unicode: 6.0.0
+      unlift: 1.0.1
+      unordered-collections: 3.0.1
+      unsafe-coerce: 6.0.0
+      unsafe-reference: 5.0.0
+      untagged-to-tagged: 0.1.4
+      untagged-union: 1.0.0
+      uri: 9.0.0
+      uuid: 9.0.0
+      uuidv4: 1.0.0
+      validation: 6.0.0
+      variant: 8.0.0
+      vectorfield: 1.0.1
+      vectors: 2.1.0
+      versions: 7.0.0
+      visx: 0.0.2
+      web-clipboard: 5.0.0
+      web-cssom: 2.0.0
+      web-dom: 6.0.0
+      web-dom-parser: 8.0.0
+      web-dom-xpath: 3.0.0
+      web-encoding: 3.0.0
+      web-events: 4.0.0
+      web-fetch: 3.0.0
+      web-file: 4.0.0
+      web-html: 4.1.0
+      web-pointerevents: 1.0.0
+      web-proletarian: 1.0.0
+      web-promise: 3.1.0
+      web-resize-observer: 2.0.0
+      web-router: 1.0.0
+      web-socket: 4.0.0
+      web-storage: 5.0.0
+      web-streams: 3.0.0
+      web-touchevents: 4.0.0
+      web-uievents: 4.0.0
+      web-url: 2.0.0
+      web-workers: 1.1.0
+      web-xhr: 5.0.0
+      which: 2.0.0
+      yoga-fetch: 1.0.1
+      yoga-json: 4.0.1
+      yoga-om: 0.1.0
+      yoga-postgres: 6.0.0
+      yoga-tree: 1.0.0
   extra_packages: {}
 packages:
   aff:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-aff.git
-    rev: 2d44d9f9d0d6a416a4103fba2fb39e5160f80e36
+    type: registry
+    version: 7.1.0
+    integrity: sha256-7hOC6uQO9XBAI5FD8F33ChLjFAiZVfd4BJMqlMh7TNU=
     dependencies:
+      - arrays
+      - bifunctors
+      - control
       - datetime
       - effect
+      - either
       - exceptions
+      - foldable-traversable
       - functions
+      - maybe
+      - newtype
       - parallel
+      - prelude
+      - refs
+      - tailrec
       - transformers
       - unsafe-coerce
   arraybuffer-types:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
-    rev: 9b0b7a0f9ee034e039f3d3a2a9c3f74eb7c9264a
+    type: registry
+    version: 3.0.2
+    integrity: sha256-mQKokysYVkooS4uXbO+yovmV/s8b138Ws3zQvOwIHRA=
     dependencies: []
   arrays:
-    type: git
-    url: https://github.com/purescript/purescript-arrays.git
-    rev: d20bae2f76db6cf29b7b75e26e82b8a54c32295e
+    type: registry
+    version: 7.1.0
+    integrity: sha256-Rvb3AVLal0ZLpmpABgOPIUeYHa4M+c5GwcUP5rQ2trA=
     dependencies:
       - bifunctors
       - control
@@ -3551,15 +561,16 @@ packages:
       - nonempty
       - partial
       - prelude
+      - safe-coerce
       - st
       - tailrec
       - tuples
       - unfoldable
       - unsafe-coerce
   avar:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-avar.git
-    rev: d00f5784d9cc8f079babd62740f5c52b87e5caa5
+    type: registry
+    version: 5.0.0
+    integrity: sha256-e7hf0x4hEpcygXP0LtvfvAQ49Bbj2aWtZT3gqM///0A=
     dependencies:
       - aff
       - effect
@@ -3568,9 +579,9 @@ packages:
       - functions
       - maybe
   bifunctors:
-    type: git
-    url: https://github.com/purescript/purescript-bifunctors.git
-    rev: 16ba2fb6dd7f05528ebd9e2f9ca3a068b325e5b3
+    type: registry
+    version: 6.0.0
+    integrity: sha256-/gZwC9YhNxZNQpnHa5BIYerCGM2jeX9ukZiEvYxm5Nw=
     dependencies:
       - const
       - either
@@ -3578,9 +589,9 @@ packages:
       - prelude
       - tuples
   catenable-lists:
-    type: git
-    url: https://github.com/purescript/purescript-catenable-lists.git
-    rev: 09abe1f4888bc00841ad2b59e56a9e7ce7ebd4ab
+    type: registry
+    version: 7.0.0
+    integrity: sha256-76vYENhwF4BWTBsjeLuErCH2jqVT4M3R1HX+4RwSftA=
     dependencies:
       - control
       - foldable-traversable
@@ -3590,24 +601,24 @@ packages:
       - tuples
       - unfoldable
   console:
-    type: git
-    url: https://github.com/purescript/purescript-console.git
-    rev: 3b83d7b792d03872afeea5e62b4f686ab0f09842
+    type: registry
+    version: 6.0.0
+    integrity: sha256-gJpJ53fCDAL8BiCiJXH0HNAJ9K3gJtLo8GDaCK6hA5U=
     dependencies:
       - effect
       - prelude
   const:
-    type: git
-    url: https://github.com/purescript/purescript-const.git
-    rev: ab9570cf2b6e67f7e441178211db1231cfd75c37
+    type: registry
+    version: 6.0.0
+    integrity: sha256-tNrxDW8D8H4jdHE2HiPzpLy08zkzJMmGHdRqt5BQuTc=
     dependencies:
       - invariant
       - newtype
       - prelude
   contravariant:
-    type: git
-    url: https://github.com/purescript/purescript-contravariant.git
-    rev: 9ad3e105b8855bcc25f4e0893c784789d05a58de
+    type: registry
+    version: 6.0.0
+    integrity: sha256-TP+ooAp3vvmdjfQsQJSichF5B4BPDHp3wAJoWchip6c=
     dependencies:
       - const
       - either
@@ -3615,16 +626,16 @@ packages:
       - prelude
       - tuples
   control:
-    type: git
-    url: https://github.com/purescript/purescript-control.git
-    rev: a6033808790879a17b2729e73747a9ed3fb2264e
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sH7Pg9E96JCPF9PIA6oQ8+BjTyO/BH1ZuE/bOcyj4Jk=
     dependencies:
       - newtype
       - prelude
   datetime:
-    type: git
-    url: https://github.com/purescript/purescript-datetime.git
-    rev: a6a0cf1b0324964ad1854bc3377ed8766ba90e6f
+    type: registry
+    version: 6.1.0
+    integrity: sha256-g/5X5BBegQWLpI9IWD+sY6mcaYpzzlW5lz5NBzaMtyI=
     dependencies:
       - bifunctors
       - control
@@ -3643,9 +654,9 @@ packages:
       - prelude
       - tuples
   distributive:
-    type: git
-    url: https://github.com/purescript/purescript-distributive.git
-    rev: 6005e513642e855ebf6f884d24a35c2803ca252a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-HTDdmEnzigMl+02SJB88j+gAXDx9VKsbvR4MJGDPbOQ=
     dependencies:
       - identity
       - newtype
@@ -3653,24 +664,24 @@ packages:
       - tuples
       - type-equality
   effect:
-    type: git
-    url: https://github.com/purescript/purescript-effect.git
-    rev: a192ddb923027d426d6ea3d8deb030c9aa7c7dda
+    type: registry
+    version: 4.0.0
+    integrity: sha256-eBtZu+HZcMa5HilvI6kaDyVX3ji8p0W9MGKy2K4T6+M=
     dependencies:
       - prelude
   either:
-    type: git
-    url: https://github.com/purescript/purescript-either.git
-    rev: af655a04ed2fd694b6688af39ee20d7907ad0763
+    type: registry
+    version: 6.1.0
+    integrity: sha256-6hgTPisnMWVwQivOu2PKYcH8uqjEOOqDyaDQVUchTpY=
     dependencies:
       - control
       - invariant
       - maybe
       - prelude
   enums:
-    type: git
-    url: https://github.com/purescript/purescript-enums.git
-    rev: bae47961d401f9acf88da38f32e87403e5f0cf2f
+    type: registry
+    version: 6.0.1
+    integrity: sha256-HWaD73JFLorc4A6trKIRUeDMdzE+GpkJaEOM1nTNkC8=
     dependencies:
       - control
       - either
@@ -3683,30 +694,30 @@ packages:
       - tuples
       - unfoldable
   exceptions:
-    type: git
-    url: https://github.com/purescript/purescript-exceptions.git
-    rev: afab3c07c820bb49b6c5be50049db46a964a6161
+    type: registry
+    version: 6.0.0
+    integrity: sha256-y/xTAEIZIARCE+50/u1di0ncebJ+CIwNOLswyOWzMTw=
     dependencies:
       - effect
       - either
       - maybe
       - prelude
   exists:
-    type: git
-    url: https://github.com/purescript/purescript-exists.git
-    rev: f765b4ace7869c27b9c05949e18c843881f9173b
+    type: registry
+    version: 6.0.0
+    integrity: sha256-A0JQHpTfo1dNOj9U5/Fd3xndlRSE0g2IQWOGor2yXn8=
     dependencies:
       - unsafe-coerce
   exitcodes:
-    type: git
-    url: https://github.com/Risto-Stevcev/purescript-exitcodes.git
-    rev: 8a9a93fd1776aba4a14cdc9a31094c9e05b05348
+    type: registry
+    version: 4.0.0
+    integrity: sha256-4wxViTbyOoyKJ/WaRGI6+hZmgMKI5Miv16lSwefiLSM=
     dependencies:
       - enums
   foldable-traversable:
-    type: git
-    url: https://github.com/purescript/purescript-foldable-traversable.git
-    rev: b3926f870532d287ea59e2d5cd3873b81ef2a93a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-fLeqRYM4jUrZD5H4WqcwUgzU7XfYkzO4zhgtNc3jcWM=
     dependencies:
       - bifunctors
       - const
@@ -3720,9 +731,9 @@ packages:
       - prelude
       - tuples
   foreign:
-    type: git
-    url: https://github.com/purescript/purescript-foreign.git
-    rev: 2dd222d1ec7363fa0a0a7adb0d8eaf81bb7006dd
+    type: registry
+    version: 7.0.0
+    integrity: sha256-1ORiqoS3HW+qfwSZAppHPWy4/6AQysxZ2t29jcdUMNA=
     dependencies:
       - either
       - functions
@@ -3734,9 +745,9 @@ packages:
       - strings
       - transformers
   foreign-object:
-    type: git
-    url: https://github.com/purescript/purescript-foreign-object.git
-    rev: 28a635827a9a6c251df73f68874070d51fe9f756
+    type: registry
+    version: 4.1.0
+    integrity: sha256-q24okj6mT+yGHYQ+ei/pYPj5ih6sTbu7eDv/WU56JVo=
     dependencies:
       - arrays
       - foldable-traversable
@@ -3751,9 +762,9 @@ packages:
       - typelevel-prelude
       - unfoldable
   free:
-    type: git
-    url: https://github.com/purescript/purescript-free.git
-    rev: e2d8fa8023a864363857834e11393483bced5e38
+    type: registry
+    version: 7.0.0
+    integrity: sha256-72auTIZAG6fhz4F94rxyDwgfnHwp+/89rujZpZWrV0w=
     dependencies:
       - catenable-lists
       - control
@@ -3770,15 +781,15 @@ packages:
       - tuples
       - unsafe-coerce
   functions:
-    type: git
-    url: https://github.com/purescript/purescript-functions.git
-    rev: f626f20580483977c5b27a01aac6471e28aff367
+    type: registry
+    version: 6.0.0
+    integrity: sha256-adMyJNEnhGde2unHHAP79gPtlNjNqzgLB8arEOn9hLI=
     dependencies:
       - prelude
   functors:
-    type: git
-    url: https://github.com/purescript/purescript-functors.git
-    rev: 022ffd7a2a7ec12080314f3d217b400674a247b4
+    type: registry
+    version: 5.0.0
+    integrity: sha256-zfPWWYisbD84MqwpJSZFlvM6v86McM68ob8p9s27ywU=
     dependencies:
       - bifunctors
       - const
@@ -3794,9 +805,9 @@ packages:
       - tuples
       - unsafe-coerce
   gen:
-    type: git
-    url: https://github.com/purescript/purescript-gen.git
-    rev: 9fbcc2a1261c32e30d79c5418edef4d96fe76931
+    type: registry
+    version: 4.0.0
+    integrity: sha256-f7yzAXWwr+xnaqEOcvyO3ezKdoes8+WXWdXIHDBCAPI=
     dependencies:
       - either
       - foldable-traversable
@@ -3809,48 +820,48 @@ packages:
       - tuples
       - unfoldable
   identity:
-    type: git
-    url: https://github.com/purescript/purescript-identity.git
-    rev: ef6768f8a52ab0bc943a85f5761ba07c257f639f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-4wY0XZbAksjY6UAg99WkuKyJlQlWAfTi2ssadH0wVMY=
     dependencies:
       - control
       - invariant
       - newtype
       - prelude
   integers:
-    type: git
-    url: https://github.com/purescript/purescript-integers.git
-    rev: 54d712b25c594833083d15dc9ff2418eb9c52822
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sf+sK26R1hzwl3NhXR7WAu9zCDjQnfoXwcyGoseX158=
     dependencies:
       - maybe
       - numbers
       - prelude
   invariant:
-    type: git
-    url: https://github.com/purescript/purescript-invariant.git
-    rev: 1d2a196d51e90623adb88496c2cfd759c6736894
+    type: registry
+    version: 6.0.0
+    integrity: sha256-RGWWyYrz0Hs1KjPDA+87Kia67ZFBhfJ5lMGOMCEFoLo=
     dependencies:
       - control
       - prelude
   js-timers:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-js-timers.git
-    rev: 7cb728b3e6dc29f355143617e6e9ac770ecd9273
+    type: registry
+    version: 6.1.0
+    integrity: sha256-znHWLSSOYw15P5DTcsAdal2lf7nGA2yayLdOZ2t5r7o=
     dependencies:
       - effect
   lazy:
-    type: git
-    url: https://github.com/purescript/purescript-lazy.git
-    rev: 48347841226b27af5205a1a8ec71e27a93ce86fd
+    type: registry
+    version: 6.0.0
+    integrity: sha256-lMsfFOnlqfe4KzRRiW8ot5ge6HtcU3Eyh2XkXcP5IgU=
     dependencies:
       - control
       - foldable-traversable
       - invariant
       - prelude
   lcg:
-    type: git
-    url: https://github.com/purescript/purescript-lcg.git
-    rev: 67c6c6483a563a59ae036d9dca0f1be2835326a5
+    type: registry
+    version: 4.0.0
+    integrity: sha256-h7ME5cthLfbgJOJdsZcSfFpwXsx4rf8YmhebU+3iSYg=
     dependencies:
       - effect
       - integers
@@ -3859,9 +870,9 @@ packages:
       - prelude
       - random
   lists:
-    type: git
-    url: https://github.com/purescript/purescript-lists.git
-    rev: b113451e5b41cad87d669a3165f955c71cd863e2
+    type: registry
+    version: 7.0.0
+    integrity: sha256-EKF15qYqucuXP2lT/xPxhqy58f0FFT6KHdIB/yBOayI=
     dependencies:
       - bifunctors
       - control
@@ -3876,25 +887,25 @@ packages:
       - tuples
       - unfoldable
   maybe:
-    type: git
-    url: https://github.com/purescript/purescript-maybe.git
-    rev: c6f98ac1088766287106c5d9c8e30e7648d36786
+    type: registry
+    version: 6.0.0
+    integrity: sha256-5cCIb0wPwbat2PRkQhUeZO0jcAmf8jCt2qE0wbC3v2Q=
     dependencies:
       - control
       - invariant
       - newtype
       - prelude
   newtype:
-    type: git
-    url: https://github.com/purescript/purescript-newtype.git
-    rev: 29d8e6dd77aec2c975c948364ec3faf26e14ee7b
+    type: registry
+    version: 5.0.0
+    integrity: sha256-gdrQu8oGe9eZE6L3wOI8ql/igOg+zEGB5ITh2g+uttw=
     dependencies:
       - prelude
       - safe-coerce
   node-buffer:
-    type: git
-    url: https://github.com/purescript-node/purescript-node-buffer.git
-    rev: 7be7bd082b7d3e15de2ed5a626d43af746bdb35e
+    type: registry
+    version: 8.0.0
+    integrity: sha256-RwOTB8yTS4Jjqc55JqxRcVaMXP+cYJ5aww0XH1Z/I8A=
     dependencies:
       - arraybuffer-types
       - effect
@@ -3902,9 +913,9 @@ packages:
       - st
       - unsafe-coerce
   node-process:
-    type: git
-    url: https://github.com/purescript-node/purescript-node-process.git
-    rev: 9d126d9d4f898723e7cab69895770bbac0c3a0b8
+    type: registry
+    version: 10.0.0
+    integrity: sha256-YzUqf7HWkGEQVRmkxUpL1x2GzKqKLyEyR7mkP68xcZs=
     dependencies:
       - effect
       - foreign-object
@@ -3914,9 +925,9 @@ packages:
       - prelude
       - unsafe-coerce
   node-readline:
-    type: git
-    url: https://github.com/purescript-node/purescript-node-readline.git
-    rev: fbe80a949275f15643b80f9db7c01d5a6b4031ed
+    type: registry
+    version: 7.0.0
+    integrity: sha256-zlJEPH1/nbRYuEaLXIaHiuHjMWXC8GoTZJZjSSJCCeo=
     dependencies:
       - effect
       - foreign
@@ -3925,9 +936,9 @@ packages:
       - options
       - prelude
   node-streams:
-    type: git
-    url: https://github.com/purescript-node/purescript-node-streams.git
-    rev: 8395652f9f347101fe042f58726edc592ae5086c
+    type: registry
+    version: 7.0.0
+    integrity: sha256-EGCA+hp6chlxDlQ8UG3RIaIIL1R0OckKnqP+KPAX1y4=
     dependencies:
       - effect
       - either
@@ -3936,9 +947,9 @@ packages:
       - nullable
       - prelude
   nonempty:
-    type: git
-    url: https://github.com/purescript/purescript-nonempty.git
-    rev: 28150ecc7419238b187abd609a92a645273348bb
+    type: registry
+    version: 7.0.0
+    integrity: sha256-54ablJZUHGvvlTJzi3oXyPCuvY6zsrWJuH/dMJ/MFLs=
     dependencies:
       - control
       - foldable-traversable
@@ -3947,24 +958,24 @@ packages:
       - tuples
       - unfoldable
   nullable:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-nullable.git
-    rev: 3202744c6c65e8d1fbba7f4256a1c482078e7fb5
+    type: registry
+    version: 6.0.0
+    integrity: sha256-yiGBVl3AD+Guy4kNWWeN+zl1gCiJK+oeIFtZtPCw4+o=
     dependencies:
       - effect
       - functions
       - maybe
   numbers:
-    type: git
-    url: https://github.com/purescript/purescript-numbers.git
-    rev: 2a53528f18f9415334bae28e7bb3cf3be86342c2
+    type: registry
+    version: 9.0.0
+    integrity: sha256-fDKXExFxMRFgy+v+kbjVbGBIOOQkWGnmm0vtnE3zWRE=
     dependencies:
       - functions
       - maybe
   open-memoize:
-    type: git
-    url: https://github.com/purescript-open-community/purescript-open-memoize.git
-    rev: 20d5c14d3033d19044e2d49c11d02278bda72a54
+    type: registry
+    version: 6.1.0
+    integrity: sha256-ws/Cix/wgUKvrbPPxTqDSGCPpkTIvP1adTYLHAquBC4=
     dependencies:
       - console
       - effect
@@ -3979,9 +990,9 @@ packages:
       - strings
       - tuples
   options:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-options.git
-    rev: 93e4eb4610975cb7b3bb290273396707e7384c38
+    type: registry
+    version: 7.0.0
+    integrity: sha256-treC6h+jvzcWhplPaF/aMENCOx+JGk+ysa5pL1BGHtg=
     dependencies:
       - contravariant
       - foreign
@@ -3989,9 +1000,9 @@ packages:
       - maybe
       - tuples
   optparse:
-    type: git
-    url: https://github.com/f-o-a-m/purescript-optparse.git
-    rev: dbc4c385e6c436eed4299ae2c0bb2cc278cf2410
+    type: registry
+    version: 5.0.0
+    integrity: sha256-Y1xqUrnOB5934wKssPyWVdF4kqA6ITXwSasdEOkxZT8=
     dependencies:
       - aff
       - arrays
@@ -4025,9 +1036,9 @@ packages:
       - transformers
       - tuples
   ordered-collections:
-    type: git
-    url: https://github.com/purescript/purescript-ordered-collections.git
-    rev: 9826b7632d0d0a691173bde308a634195f42a419
+    type: registry
+    version: 3.0.0
+    integrity: sha256-R9WddNBRPkY37gw8XkDCLX2vJ5eI9qdaWDdCp61r2+M=
     dependencies:
       - arrays
       - foldable-traversable
@@ -4041,16 +1052,16 @@ packages:
       - tuples
       - unfoldable
   orders:
-    type: git
-    url: https://github.com/purescript/purescript-orders.git
-    rev: f86db621ec5eef1274145f8b1fd8ebbfe0ed4a2c
+    type: registry
+    version: 6.0.0
+    integrity: sha256-nBA0g3/ai0euH8q9pSbGqk53W2q6agm/dECZTHcoink=
     dependencies:
       - newtype
       - prelude
   parallel:
-    type: git
-    url: https://github.com/purescript/purescript-parallel.git
-    rev: 85290dca837771ac4870071008c933d315ef678f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-VJbkGD0rAKX+NUEeBJbYJ78bEKaZbgow+QwQEfPB6ko=
     dependencies:
       - control
       - effect
@@ -4064,26 +1075,26 @@ packages:
       - refs
       - transformers
   partial:
-    type: git
-    url: https://github.com/purescript/purescript-partial.git
-    rev: 0fa0646f5ea1ec5f0c46dcbd770c705a6c9ad3ec
+    type: registry
+    version: 4.0.0
+    integrity: sha256-fwXerld6Xw1VkReh8yeQsdtLVrjfGiVuC5bA1Wyo/J4=
     dependencies: []
   posix-types:
-    type: git
-    url: https://github.com/purescript-node/purescript-posix-types.git
-    rev: b79ff37f87846ca5caab2123cf84148e700d40d1
+    type: registry
+    version: 6.0.0
+    integrity: sha256-ZfFz8RR1lee/o/Prccyeut3Q+9tYd08mlR72sIh6GzA=
     dependencies:
       - maybe
       - prelude
   prelude:
-    type: git
-    url: https://github.com/purescript/purescript-prelude.git
-    rev: 32787f4399c92459c41602131a5858559eb868c5
+    type: registry
+    version: 6.0.1
+    integrity: sha256-o8p6SLYmVPqzXZhQFd2hGAWEwBoXl1swxLG/scpJ0V0=
     dependencies: []
   profunctor:
-    type: git
-    url: https://github.com/purescript/purescript-profunctor.git
-    rev: 0a966a14e7b0c827d44657dc1710cdc712d2e034
+    type: registry
+    version: 6.0.0
+    integrity: sha256-99NzxFgTr4CGlCSRYG1kShL+JhYbihhHtbOk1/0R5zI=
     dependencies:
       - control
       - distributive
@@ -4094,17 +1105,17 @@ packages:
       - prelude
       - tuples
   psci-support:
-    type: git
-    url: https://github.com/purescript/purescript-psci-support.git
-    rev: 897cdb543548cb6078d69b6413b54841404eda72
+    type: registry
+    version: 6.0.0
+    integrity: sha256-C6ql4P9TEP06hft/1Z5QumPA4yARR4VIxDdhmL1EO+Y=
     dependencies:
       - console
       - effect
       - prelude
   quickcheck:
-    type: git
-    url: https://github.com/purescript/purescript-quickcheck.git
-    rev: bf5029f97e6c0d7552d3a08d2ab793a19e2c5e3d
+    type: registry
+    version: 8.0.1
+    integrity: sha256-ZvpccKQCvgslTXZCNmpYW4bUsFzhZd/kQUr2WmxFTGY=
     dependencies:
       - arrays
       - console
@@ -4134,46 +1145,46 @@ packages:
       - tuples
       - unfoldable
   random:
-    type: git
-    url: https://github.com/purescript/purescript-random.git
-    rev: 9540bc965a9596da02fefd9949418bb19c92533a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-CJ611a35MPCE7XQMp0rdC6MCn76znlhisiCRgboAG+Q=
     dependencies:
       - effect
       - integers
   record:
-    type: git
-    url: https://github.com/purescript/purescript-record.git
-    rev: c89cd1ada6b636692571fc374196b1c39c4c9f70
+    type: registry
+    version: 4.0.0
+    integrity: sha256-Za5U85bTRJEfGK5Sk4hM41oXy84YQI0I8TL3WUn1Qzg=
     dependencies:
       - functions
       - prelude
       - unsafe-coerce
   refs:
-    type: git
-    url: https://github.com/purescript/purescript-refs.git
-    rev: f8e6216da4cb9309fde1f20cd6f69ac3a3b7f9e8
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Vgwne7jIbD3ZMoLNNETLT8Litw6lIYo3MfYNdtYWj9s=
     dependencies:
       - effect
       - prelude
   safe-coerce:
-    type: git
-    url: https://github.com/purescript/purescript-safe-coerce.git
-    rev: 7fa799ae80a38b8d948efcb52608e58e198b3da7
+    type: registry
+    version: 2.0.0
+    integrity: sha256-a1ibQkiUcbODbLE/WAq7Ttbbh9ex+x33VCQ7GngKudU=
     dependencies:
       - unsafe-coerce
   st:
-    type: git
-    url: https://github.com/purescript/purescript-st.git
-    rev: 2cc7ae1c3318a303378c4a9f3fa0f10ee7cc3589
+    type: registry
+    version: 6.2.0
+    integrity: sha256-z9X0WsOUlPwNx9GlCC+YccCyz8MejC8Wb0C4+9fiBRY=
     dependencies:
       - partial
       - prelude
       - tailrec
       - unsafe-coerce
   strings:
-    type: git
-    url: https://github.com/purescript/purescript-strings.git
-    rev: 4bc6954448d056f8aa7a659695a6ad60ad4fdf19
+    type: registry
+    version: 6.0.1
+    integrity: sha256-WssD3DbX4OPzxSdjvRMX0yvc9+pS7n5gyPv5I2Trb7k=
     dependencies:
       - arrays
       - control
@@ -4192,9 +1203,9 @@ packages:
       - unfoldable
       - unsafe-coerce
   tailrec:
-    type: git
-    url: https://github.com/purescript/purescript-tailrec.git
-    rev: 5e2104aa734b31a17074cc805bf087d72b65afd1
+    type: registry
+    version: 6.1.0
+    integrity: sha256-Xx19ECVDRrDWpz9D2GxQHHV89vd61dnXxQm0IcYQHGk=
     dependencies:
       - bifunctors
       - effect
@@ -4205,9 +1216,9 @@ packages:
       - prelude
       - refs
   test-unit:
-    type: git
-    url: https://github.com/bodil/purescript-test-unit.git
-    rev: 3112d7ebe06d467238058a6384dc75ffd960d335
+    type: registry
+    version: 17.0.0
+    integrity: sha256-aITJ2KngFFjASmG0JjnjybaKWl9dn7Hf2B3Wk4engNs=
     dependencies:
       - aff
       - avar
@@ -4220,9 +1231,9 @@ packages:
       - quickcheck
       - strings
   transformers:
-    type: git
-    url: https://github.com/purescript/purescript-transformers.git
-    rev: be72ab52357d9a665cbf93d73ba1c07c4b0957ee
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Pzw40HjthX77tdPAYzjx43LK3X5Bb7ZspYAp27wksFA=
     dependencies:
       - control
       - distributive
@@ -4239,29 +1250,29 @@ packages:
       - tuples
       - unfoldable
   tuples:
-    type: git
-    url: https://github.com/purescript/purescript-tuples.git
-    rev: 4f52da2729b448c8564369378f1232d8d2dc1d8b
+    type: registry
+    version: 7.0.0
+    integrity: sha256-1rXgTomes9105BjgXqIw0FL6Fz1lqqUTLWOumhWec1M=
     dependencies:
       - control
       - invariant
       - prelude
   type-equality:
-    type: git
-    url: https://github.com/purescript/purescript-type-equality.git
-    rev: 0525b7d39e0fbd81b4209518139fb8ab02695774
+    type: registry
+    version: 4.0.1
+    integrity: sha256-Hs9D6Y71zFi/b+qu5NSbuadUQXe5iv5iWx0226vOHUw=
     dependencies: []
   typelevel-prelude:
-    type: git
-    url: https://github.com/purescript/purescript-typelevel-prelude.git
-    rev: dca2fe3c8cfd5527d4fe70c4bedfda30148405bf
+    type: registry
+    version: 7.0.0
+    integrity: sha256-uFF2ph+vHcQpfPuPf2a3ukJDFmLhApmkpTMviHIWgJM=
     dependencies:
       - prelude
       - type-equality
   unfoldable:
-    type: git
-    url: https://github.com/purescript/purescript-unfoldable.git
-    rev: 493dfe04ed590e20d8f69079df2f58486882748d
+    type: registry
+    version: 6.0.0
+    integrity: sha256-JtikvJdktRap7vr/K4ITlxUX1QexpnqBq0G/InLr6eg=
     dependencies:
       - foldable-traversable
       - maybe
@@ -4269,7 +1280,7 @@ packages:
       - prelude
       - tuples
   unsafe-coerce:
-    type: git
-    url: https://github.com/purescript/purescript-unsafe-coerce.git
-    rev: ab956f82e66e633f647fb3098e8ddd3ec58d689f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-IqIYW4Vkevn8sI+6aUwRGvd87tVL36BBeOr0cGAE7t0=
     dependencies: []

--- a/exercises/chapter11/spago.lock
+++ b/exercises/chapter11/spago.lock
@@ -1,0 +1,4275 @@
+workspace:
+  packages:
+    my-project:
+      path: ./
+      dependencies:
+        - arrays
+        - console
+        - control
+        - effect
+        - either
+        - foldable-traversable
+        - identity
+        - lists
+        - maybe
+        - newtype
+        - node-readline
+        - optparse
+        - ordered-collections
+        - prelude
+        - strings
+        - test-unit
+        - transformers
+        - tuples
+      test_dependencies: []
+      build_plan:
+        - aff
+        - arraybuffer-types
+        - arrays
+        - avar
+        - bifunctors
+        - catenable-lists
+        - console
+        - const
+        - contravariant
+        - control
+        - datetime
+        - distributive
+        - effect
+        - either
+        - enums
+        - exceptions
+        - exists
+        - exitcodes
+        - foldable-traversable
+        - foreign
+        - foreign-object
+        - free
+        - functions
+        - functors
+        - gen
+        - identity
+        - integers
+        - invariant
+        - js-timers
+        - lazy
+        - lcg
+        - lists
+        - maybe
+        - newtype
+        - node-buffer
+        - node-process
+        - node-readline
+        - node-streams
+        - nonempty
+        - nullable
+        - numbers
+        - open-memoize
+        - options
+        - optparse
+        - ordered-collections
+        - orders
+        - parallel
+        - partial
+        - posix-types
+        - prelude
+        - profunctor
+        - psci-support
+        - quickcheck
+        - random
+        - record
+        - refs
+        - safe-coerce
+        - st
+        - strings
+        - tailrec
+        - test-unit
+        - transformers
+        - tuples
+        - type-equality
+        - typelevel-prelude
+        - unfoldable
+        - unsafe-coerce
+  package_set:
+    address:
+      url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
+    compiler: ">=0.15.0 <0.16.0"
+    content:
+      ace:
+        repo: https://github.com/purescript-contrib/purescript-ace.git
+        version: v9.0.0
+        dependencies:
+          - arrays
+          - effect
+          - foreign
+          - nullable
+          - prelude
+          - web-html
+          - web-uievents
+      aff:
+        repo: https://github.com/purescript-contrib/purescript-aff.git
+        version: v7.0.0
+        dependencies:
+          - datetime
+          - effect
+          - exceptions
+          - functions
+          - parallel
+          - transformers
+          - unsafe-coerce
+      aff-bus:
+        repo: https://github.com/purescript-contrib/purescript-aff-bus.git
+        version: v6.0.0
+        dependencies:
+          - aff
+          - avar
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - lists
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+      aff-coroutines:
+        repo: https://github.com/purescript-contrib/purescript-aff-coroutines.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - avar
+          - coroutines
+          - effect
+      aff-promise:
+        repo: https://github.com/nwolverson/purescript-aff-promise.git
+        version: v4.0.0
+        dependencies:
+          - aff
+          - foreign
+      aff-retry:
+        repo: https://github.com/Unisay/purescript-aff-retry.git
+        version: v2.0.0
+        dependencies:
+          - aff
+          - arrays
+          - datetime
+          - effect
+          - either
+          - exceptions
+          - integers
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - random
+          - transformers
+      affjax:
+        repo: https://github.com/purescript-contrib/purescript-affjax.git
+        version: v13.0.0
+        dependencies:
+          - aff
+          - argonaut-core
+          - arraybuffer-types
+          - foreign
+          - form-urlencoded
+          - http-methods
+          - integers
+          - media-types
+          - nullable
+          - refs
+          - unsafe-coerce
+          - web-xhr
+      affjax-node:
+        repo: https://github.com/purescript-contrib/purescript-affjax-node.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - affjax
+          - either
+          - maybe
+          - prelude
+      affjax-web:
+        repo: https://github.com/purescript-contrib/purescript-affjax-web.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - affjax
+          - either
+          - maybe
+          - prelude
+      ansi:
+        repo: https://github.com/hdgarrood/purescript-ansi.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - lists
+          - strings
+      argonaut:
+        repo: https://github.com/purescript-contrib/purescript-argonaut.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - argonaut-traversals
+      argonaut-codecs:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-codecs.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-core
+          - arrays
+          - effect
+          - foreign-object
+          - identity
+          - integers
+          - maybe
+          - nonempty
+          - ordered-collections
+          - prelude
+          - record
+      argonaut-core:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-core.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - foreign-object
+          - functions
+          - gen
+          - maybe
+          - nonempty
+          - prelude
+          - strings
+          - tailrec
+      argonaut-generic:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-generic.git
+        version: v8.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - prelude
+          - record
+      argonaut-traversals:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-traversals.git
+        version: v10.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - profunctor-lenses
+      argparse-basic:
+        repo: https://github.com/natefaubion/purescript-argparse-basic.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - record
+          - strings
+          - tuples
+          - unfoldable
+      arraybuffer:
+        repo: https://github.com/purescript-contrib/purescript-arraybuffer.git
+        version: v13.0.0
+        dependencies:
+          - arraybuffer-types
+          - arrays
+          - effect
+          - float32
+          - functions
+          - gen
+          - maybe
+          - nullable
+          - prelude
+          - tailrec
+          - uint
+          - unfoldable
+      arraybuffer-builder:
+        repo: https://github.com/jamesdbrock/purescript-arraybuffer-builder.git
+        version: v3.0.1
+        dependencies:
+          - arraybuffer
+          - arraybuffer-types
+          - effect
+          - float32
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - transformers
+          - uint
+      arraybuffer-types:
+        repo: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
+        version: v3.0.2
+        dependencies: []
+      arrays:
+        repo: https://github.com/purescript/purescript-arrays.git
+        version: v7.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - foldable-traversable
+          - maybe
+          - nonempty
+          - partial
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - unfoldable
+          - unsafe-coerce
+      arrays-zipper:
+        repo: https://github.com/JordanMartinez/purescript-arrays-zipper.git
+        version: v2.0.1
+        dependencies:
+          - arrays
+          - control
+          - quickcheck
+      ask:
+        repo: https://github.com/Mateiadrielrafael/purescript-ask.git
+        version: v1.0.0
+        dependencies:
+          - unsafe-coerce
+      assert:
+        repo: https://github.com/purescript/purescript-assert.git
+        version: v6.0.0
+        dependencies:
+          - console
+          - effect
+          - prelude
+      avar:
+        repo: https://github.com/purescript-contrib/purescript-avar.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - exceptions
+          - functions
+          - maybe
+      b64:
+        repo: https://github.com/menelaos/purescript-b64.git
+        version: v0.0.8
+        dependencies:
+          - arraybuffer-types
+          - either
+          - encoding
+          - enums
+          - exceptions
+          - functions
+          - partial
+          - prelude
+          - strings
+      barlow-lens:
+        repo: https://github.com/sigma-andex/purescript-barlow-lens.git
+        version: v0.9.0
+        dependencies:
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - profunctor-lenses
+          - tuples
+          - typelevel-prelude
+      bifunctors:
+        repo: https://github.com/purescript/purescript-bifunctors.git
+        version: v6.0.0
+        dependencies:
+          - const
+          - either
+          - newtype
+          - prelude
+          - tuples
+      bigints:
+        repo: https://github.com/sharkdp/purescript-bigints.git
+        version: v7.0.1
+        dependencies:
+          - integers
+          - maybe
+          - strings
+      bower-json:
+        repo: https://github.com/klntsky/purescript-bower-json.git
+        version: v3.0.0
+        dependencies:
+          - argonaut-codecs
+          - arrays
+          - either
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - newtype
+          - prelude
+          - tuples
+      call-by-name:
+        repo: https://github.com/natefaubion/purescript-call-by-name.git
+        version: v4.0.1
+        dependencies:
+          - control
+          - either
+          - lazy
+          - maybe
+          - unsafe-coerce
+      canvas:
+        repo: https://github.com/purescript-web/purescript-canvas.git
+        version: v6.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - exceptions
+          - functions
+          - maybe
+      canvas-action:
+        repo: https://github.com/artemisSystem/purescript-canvas-action.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - arrays
+          - canvas
+          - colors
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - maybe
+          - numbers
+          - polymorphic-vectors
+          - prelude
+          - refs
+          - run
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-html
+      cartesian:
+        repo: https://github.com/Ebmtranceboy/purescript-cartesian.git
+        version: v1.0.6
+        dependencies:
+          - console
+          - effect
+          - integers
+          - psci-support
+      catenable-lists:
+        repo: https://github.com/purescript/purescript-catenable-lists.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - lists
+          - maybe
+          - prelude
+          - tuples
+          - unfoldable
+      channel:
+        repo: https://github.com/ConnorDillon/purescript-channel.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - assert
+          - avar
+          - console
+          - contravariant
+          - control
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - lazy
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      checked-exceptions:
+        repo: https://github.com/natefaubion/purescript-checked-exceptions.git
+        version: v3.1.1
+        dependencies:
+          - prelude
+          - transformers
+          - variant
+      codec:
+        repo: https://github.com/garyb/purescript-codec.git
+        version: v5.0.0
+        dependencies:
+          - profunctor
+          - transformers
+      codec-argonaut:
+        repo: https://github.com/garyb/purescript-codec-argonaut.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-core
+          - codec
+          - ordered-collections
+          - type-equality
+          - variant
+      colors:
+        repo: https://github.com/purescript-contrib/purescript-colors.git
+        version: v7.0.1
+        dependencies:
+          - arrays
+          - integers
+          - lists
+          - numbers
+          - partial
+          - strings
+      concurrent-queues:
+        repo: https://github.com/purescript-contrib/purescript-concurrent-queues.git
+        version: v3.0.0
+        dependencies:
+          - aff
+          - avar
+          - effect
+      console:
+        repo: https://github.com/purescript/purescript-console.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - prelude
+      const:
+        repo: https://github.com/purescript/purescript-const.git
+        version: v6.0.0
+        dependencies:
+          - invariant
+          - newtype
+          - prelude
+      contravariant:
+        repo: https://github.com/purescript/purescript-contravariant.git
+        version: v6.0.0
+        dependencies:
+          - const
+          - either
+          - newtype
+          - prelude
+          - tuples
+      control:
+        repo: https://github.com/purescript/purescript-control.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      convertable-options:
+        repo: https://github.com/natefaubion/purescript-convertable-options.git
+        version: v1.0.0
+        dependencies:
+          - console
+          - effect
+          - maybe
+          - record
+      coroutines:
+        repo: https://github.com/purescript-contrib/purescript-coroutines.git
+        version: v7.0.0
+        dependencies:
+          - freet
+          - parallel
+          - profunctor
+      css:
+        repo: https://github.com/purescript-contrib/purescript-css.git
+        version: v6.0.0
+        dependencies:
+          - colors
+          - console
+          - effect
+          - nonempty
+          - profunctor
+          - strings
+          - these
+          - transformers
+      datetime:
+        repo: https://github.com/purescript/purescript-datetime.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - either
+          - enums
+          - foldable-traversable
+          - functions
+          - gen
+          - integers
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - ordered-collections
+          - partial
+          - prelude
+          - tuples
+      datetime-parsing:
+        repo: https://github.com/flounders/purescript-datetime-parsing.git
+        version: v0.2.0
+        dependencies:
+          - arrays
+          - datetime
+          - either
+          - enums
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - numbers
+          - parsing
+          - prelude
+          - strings
+          - unicode
+      debug:
+        repo: https://github.com/garyb/purescript-debug.git
+        version: v6.0.0
+        dependencies:
+          - functions
+          - prelude
+      decimals:
+        repo: https://github.com/sharkdp/purescript-decimals.git
+        version: v7.0.0
+        dependencies:
+          - maybe
+      dissect:
+        repo: https://github.com/PureFunctor/purescript-dissect.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - foreign-object
+          - functors
+          - newtype
+          - partial
+          - prelude
+          - tailrec
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - variant
+      distributive:
+        repo: https://github.com/purescript/purescript-distributive.git
+        version: v6.0.0
+        dependencies:
+          - identity
+          - newtype
+          - prelude
+          - tuples
+          - type-equality
+      dodo-printer:
+        repo: https://github.com/natefaubion/purescript-dodo-printer.git
+        version: v2.2.0
+        dependencies:
+          - aff
+          - ansi
+          - avar
+          - console
+          - effect
+          - foldable-traversable
+          - lists
+          - maybe
+          - minibench
+          - node-child-process
+          - node-fs-aff
+          - node-process
+          - psci-support
+          - strings
+      dom-indexed:
+        repo: https://github.com/purescript-halogen/purescript-dom-indexed.git
+        version: v11.0.0
+        dependencies:
+          - media-types
+          - prelude
+          - web-clipboard
+          - web-pointerevents
+          - web-touchevents
+      droplet:
+        repo: https://github.com/easafe/purescript-droplet.git
+        version: v0.4.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - bigints
+          - datetime
+          - debug
+          - effect
+          - either
+          - enums
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - integers
+          - maybe
+          - newtype
+          - nullable
+          - ordered-collections
+          - partial
+          - prelude
+          - profunctor
+          - record
+          - spec
+          - strings
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+      dynamic-buffer:
+        repo: https://github.com/kritzcreek/purescript-dynamic-buffer.git
+        version: v3.0.1
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - refs
+      effect:
+        repo: https://github.com/purescript/purescript-effect.git
+        version: v4.0.0
+        dependencies:
+          - prelude
+      either:
+        repo: https://github.com/purescript/purescript-either.git
+        version: v6.1.0
+        dependencies:
+          - control
+          - invariant
+          - maybe
+          - prelude
+      elmish:
+        repo: https://github.com/collegevine/purescript-elmish.git
+        version: v0.8.1
+        dependencies:
+          - aff
+          - argonaut-core
+          - arrays
+          - bifunctors
+          - console
+          - debug
+          - effect
+          - either
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - functions
+          - integers
+          - js-date
+          - maybe
+          - nullable
+          - partial
+          - prelude
+          - refs
+          - typelevel-prelude
+          - undefined-is-not-a-problem
+          - unsafe-coerce
+          - web-dom
+          - web-html
+      elmish-enzyme:
+        repo: https://github.com/collegevine/purescript-elmish-enzyme.git
+        version: v0.1.1
+        dependencies:
+          - aff
+          - aff-promise
+          - arrays
+          - console
+          - debug
+          - effect
+          - elmish
+          - foldable-traversable
+          - foreign
+          - functions
+          - prelude
+          - transformers
+          - unsafe-coerce
+      elmish-hooks:
+        repo: https://github.com/collegevine/purescript-elmish-hooks.git
+        version: v0.8.2
+        dependencies:
+          - aff
+          - debug
+          - elmish
+          - maybe
+          - prelude
+          - tuples
+          - undefined-is-not-a-problem
+      elmish-html:
+        repo: https://github.com/collegevine/purescript-elmish-html.git
+        version: v0.7.1
+        dependencies:
+          - effect
+          - elmish
+          - foreign
+          - foreign-object
+          - prelude
+          - record
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-html
+      email-validate:
+        repo: https://github.com/cdepillabout/purescript-email-validate.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - string-parsers
+          - transformers
+      encoding:
+        repo: https://github.com/menelaos/purescript-encoding.git
+        version: v0.0.8
+        dependencies:
+          - arraybuffer-types
+          - either
+          - exceptions
+          - functions
+          - prelude
+      enums:
+        repo: https://github.com/purescript/purescript-enums.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - either
+          - gen
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tuples
+          - unfoldable
+      exceptions:
+        repo: https://github.com/purescript/purescript-exceptions.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - either
+          - maybe
+          - prelude
+      exists:
+        repo: https://github.com/purescript/purescript-exists.git
+        version: v6.0.0
+        dependencies:
+          - unsafe-coerce
+      exitcodes:
+        repo: https://github.com/Risto-Stevcev/purescript-exitcodes.git
+        version: v4.0.0
+        dependencies:
+          - enums
+      expect-inferred:
+        repo: https://github.com/justinwoo/purescript-expect-inferred.git
+        version: v3.0.0
+        dependencies:
+          - prelude
+          - typelevel-prelude
+      fast-vect:
+        repo: https://github.com/sigma-andex/purescript-fast-vect.git
+        version: v0.7.0
+        dependencies:
+          - arrays
+          - filterable
+          - foldable-traversable
+          - lists
+          - maybe
+          - ordered-collections
+          - prelude
+          - profunctor
+          - tuples
+          - unfoldable
+      filterable:
+        repo: https://github.com/purescript/purescript-filterable.git
+        version: v5.0.0
+        dependencies:
+          - arrays
+          - either
+          - foldable-traversable
+          - identity
+          - lists
+          - ordered-collections
+      fixed-points:
+        repo: https://github.com/purescript-contrib/purescript-fixed-points.git
+        version: v7.0.0
+        dependencies:
+          - exists
+          - newtype
+          - prelude
+          - transformers
+      fixed-precision:
+        repo: https://github.com/lumihq/purescript-fixed-precision.git
+        version: v5.0.0
+        dependencies:
+          - arrays
+          - bigints
+          - control
+          - integers
+          - maybe
+          - numbers
+          - partial
+          - prelude
+          - strings
+      flame:
+        repo: https://github.com/easafe/purescript-flame.git
+        version: v1.2.0
+        dependencies:
+          - aff
+          - argonaut-codecs
+          - argonaut-core
+          - argonaut-generic
+          - arrays
+          - bifunctors
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - maybe
+          - newtype
+          - nullable
+          - partial
+          - prelude
+          - random
+          - refs
+          - spec
+          - strings
+          - tuples
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-html
+          - web-uievents
+      float32:
+        repo: https://github.com/purescript-contrib/purescript-float32.git
+        version: v2.0.0
+        dependencies:
+          - gen
+          - maybe
+          - prelude
+      foldable-traversable:
+        repo: https://github.com/purescript/purescript-foldable-traversable.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - const
+          - control
+          - either
+          - functors
+          - identity
+          - maybe
+          - newtype
+          - orders
+          - prelude
+          - tuples
+      foreign:
+        repo: https://github.com/purescript/purescript-foreign.git
+        version: v7.0.0
+        dependencies:
+          - either
+          - functions
+          - identity
+          - integers
+          - lists
+          - maybe
+          - prelude
+          - strings
+          - transformers
+      foreign-object:
+        repo: https://github.com/purescript/purescript-foreign-object.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - functions
+          - gen
+          - lists
+          - maybe
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - typelevel-prelude
+          - unfoldable
+      foreign-readwrite:
+        repo: https://github.com/artemisSystem/purescript-foreign-readwrite.git
+        version: v3.0.0
+        dependencies:
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - record
+          - safe-coerce
+          - transformers
+          - unsafe-coerce
+      fork:
+        repo: https://github.com/purescript-contrib/purescript-fork.git
+        version: v6.0.0
+        dependencies:
+          - aff
+      form-urlencoded:
+        repo: https://github.com/purescript-contrib/purescript-form-urlencoded.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - js-uri
+          - maybe
+          - newtype
+          - prelude
+          - strings
+          - tuples
+      formatters:
+        repo: https://github.com/purescript-contrib/purescript-formatters.git
+        version: v7.0.0
+        dependencies:
+          - datetime
+          - fixed-points
+          - lists
+          - numbers
+          - parsing
+          - prelude
+          - transformers
+      free:
+        repo: https://github.com/purescript/purescript-free.git
+        version: v7.0.0
+        dependencies:
+          - catenable-lists
+          - control
+          - distributive
+          - either
+          - exists
+          - foldable-traversable
+          - invariant
+          - lazy
+          - maybe
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+      freeap:
+        repo: https://github.com/ethul/purescript-freeap.git
+        version: v7.0.0
+        dependencies:
+          - const
+          - exists
+          - gen
+          - lists
+      freet:
+        repo: https://github.com/purescript-contrib/purescript-freet.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - bifunctors
+          - effect
+          - either
+          - exists
+          - free
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      functions:
+        repo: https://github.com/purescript/purescript-functions.git
+        version: v6.0.0
+        dependencies:
+          - prelude
+      functors:
+        repo: https://github.com/purescript/purescript-functors.git
+        version: v5.0.0
+        dependencies:
+          - bifunctors
+          - const
+          - contravariant
+          - control
+          - distributive
+          - either
+          - invariant
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - tuples
+          - unsafe-coerce
+      fuzzy:
+        repo: https://github.com/citizennet/purescript-fuzzy.git
+        version: v0.4.0
+        dependencies:
+          - foldable-traversable
+          - foreign-object
+          - newtype
+          - ordered-collections
+          - prelude
+          - rationals
+          - strings
+          - tuples
+      gen:
+        repo: https://github.com/purescript/purescript-gen.git
+        version: v4.0.0
+        dependencies:
+          - either
+          - foldable-traversable
+          - identity
+          - maybe
+          - newtype
+          - nonempty
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      generate-values:
+        repo: https://github.com/jordanmartinez/purescript-generate-values.git
+        version: v1.0.1
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - enums
+          - foldable-traversable
+          - gen
+          - identity
+          - integers
+          - lcg
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - partial
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      geometry-plane:
+        repo: https://github.com/Ebmtranceboy/purescript-geometry-plane.git
+        version: v1.0.3
+        dependencies:
+          - console
+          - effect
+          - psci-support
+          - sparse-polynomials
+      github-actions-toolkit:
+        repo: https://github.com/purescript-contrib/purescript-github-actions-toolkit.git
+        version: v0.5.0
+        dependencies:
+          - aff
+          - aff-promise
+          - effect
+          - foreign-object
+          - node-buffer
+          - node-path
+          - node-streams
+          - nullable
+          - transformers
+      graphs:
+        repo: https://github.com/purescript/purescript-graphs.git
+        version: v8.0.0
+        dependencies:
+          - catenable-lists
+          - ordered-collections
+      group:
+        repo: https://github.com/morganthomas/purescript-group.git
+        version: v4.1.1
+        dependencies:
+          - lists
+      halogen:
+        repo: https://github.com/purescript-halogen/purescript-halogen.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - avar
+          - console
+          - const
+          - dom-indexed
+          - effect
+          - foreign
+          - fork
+          - free
+          - freeap
+          - halogen-subscriptions
+          - halogen-vdom
+          - media-types
+          - nullable
+          - ordered-collections
+          - parallel
+          - profunctor
+          - transformers
+          - unsafe-coerce
+          - unsafe-reference
+          - web-file
+          - web-uievents
+      halogen-css:
+        repo: https://github.com/purescript-halogen/purescript-halogen-css.git
+        version: v10.0.0
+        dependencies:
+          - css
+          - halogen
+      halogen-formless:
+        repo: https://github.com/thomashoneyman/purescript-halogen-formless.git
+        version: v4.0.0
+        dependencies:
+          - convertable-options
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - halogen
+          - heterogeneous
+          - maybe
+          - prelude
+          - record
+          - safe-coerce
+          - type-equality
+          - unsafe-coerce
+          - unsafe-reference
+          - variant
+          - web-events
+          - web-uievents
+      halogen-hooks:
+        repo: https://github.com/thomashoneyman/purescript-halogen-hooks.git
+        version: v0.6.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - effect
+          - exceptions
+          - foldable-traversable
+          - foreign-object
+          - free
+          - freeap
+          - halogen
+          - halogen-subscriptions
+          - maybe
+          - newtype
+          - ordered-collections
+          - parallel
+          - partial
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+          - unsafe-reference
+          - web-dom
+          - web-html
+      halogen-hooks-extra:
+        repo: https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git
+        version: v0.9.0
+        dependencies:
+          - halogen-hooks
+      halogen-store:
+        repo: https://github.com/thomashoneyman/purescript-halogen-store.git
+        version: v0.5.0
+        dependencies:
+          - aff
+          - distributive
+          - effect
+          - fork
+          - halogen
+          - halogen-hooks
+          - halogen-subscriptions
+          - maybe
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-reference
+      halogen-storybook:
+        repo: https://github.com/rnons/purescript-halogen-storybook.git
+        version: v2.0.0
+        dependencies:
+          - foreign-object
+          - halogen
+          - prelude
+          - routing
+      halogen-subscriptions:
+        repo: https://github.com/purescript-halogen/purescript-halogen-subscriptions.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - effect
+          - foldable-traversable
+          - functors
+          - refs
+          - safe-coerce
+          - unsafe-reference
+      halogen-svg-elems:
+        repo: https://github.com/JordanMartinez/purescript-halogen-svg-elems.git
+        version: v6.0.0
+        dependencies:
+          - halogen
+      halogen-vdom:
+        repo: https://github.com/purescript-halogen/purescript-halogen-vdom.git
+        version: v8.0.0
+        dependencies:
+          - bifunctors
+          - effect
+          - foreign
+          - foreign-object
+          - maybe
+          - prelude
+          - refs
+          - tuples
+          - unsafe-coerce
+          - web-html
+      halogen-vdom-string-renderer:
+        repo: https://github.com/purescript-halogen/purescript-halogen-vdom-string-renderer.git
+        version: v0.5.0
+        dependencies:
+          - foreign
+          - halogen-vdom
+          - ordered-collections
+          - prelude
+      heckin:
+        repo: https://github.com/maxdeviant/purescript-heckin.git
+        version: v2.0.1
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - maybe
+          - prelude
+          - strings
+          - transformers
+          - tuples
+          - unicode
+      heterogeneous:
+        repo: https://github.com/natefaubion/purescript-heterogeneous.git
+        version: v0.6.0
+        dependencies:
+          - either
+          - functors
+          - prelude
+          - record
+          - tuples
+          - variant
+      heterogeneous-extrablatt:
+        repo: https://github.com/sigma-andex/purescript-heterogeneous-extrablatt.git
+        version: v0.2.1
+        dependencies:
+          - heterogeneous
+          - prelude
+          - record
+      http-methods:
+        repo: https://github.com/purescript-contrib/purescript-http-methods.git
+        version: v6.0.0
+        dependencies:
+          - either
+          - prelude
+          - strings
+      httpure:
+        repo: https://github.com/citizennet/purescript-httpure.git
+        version: v0.15.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - js-uri
+          - maybe
+          - newtype
+          - node-buffer
+          - node-fs
+          - node-http
+          - node-streams
+          - options
+          - ordered-collections
+          - prelude
+          - refs
+          - strings
+          - tuples
+          - type-equality
+      httpurple:
+        repo: https://github.com/sigma-andex/purescript-httpurple.git
+        version: v1.3.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - js-uri
+          - justifill
+          - maybe
+          - newtype
+          - node-buffer
+          - node-fs
+          - node-http
+          - node-net
+          - node-process
+          - node-streams
+          - options
+          - ordered-collections
+          - posix-types
+          - prelude
+          - profunctor
+          - record
+          - refs
+          - routing-duplex
+          - strings
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+      httpurple-argonaut:
+        repo: https://github.com/sigma-andex/purescript-httpurple-argonaut.git
+        version: v1.0.1
+        dependencies:
+          - argonaut
+          - console
+          - effect
+          - either
+          - httpurple
+          - prelude
+      httpurple-yoga-json:
+        repo: https://github.com/sigma-andex/purescript-httpurple-yoga-json.git
+        version: v1.0.0
+        dependencies:
+          - console
+          - effect
+          - either
+          - foreign
+          - httpurple
+          - lists
+          - prelude
+          - yoga-json
+      identity:
+        repo: https://github.com/purescript/purescript-identity.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - invariant
+          - newtype
+          - prelude
+      indexed-monad:
+        repo: https://github.com/garyb/purescript-indexed-monad.git
+        version: v2.1.0
+        dependencies:
+          - control
+          - newtype
+      int64:
+        repo: https://github.com/purescript-contrib/purescript-int64.git
+        version: v2.0.0
+        dependencies:
+          - effect
+          - foreign
+          - functions
+          - integers
+          - maybe
+          - nullable
+          - prelude
+          - quickcheck
+      integers:
+        repo: https://github.com/purescript/purescript-integers.git
+        version: v6.0.0
+        dependencies:
+          - maybe
+          - numbers
+          - prelude
+      interpolate:
+        repo: https://github.com/jordanmartinez/purescript-interpolate.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+      invariant:
+        repo: https://github.com/purescript/purescript-invariant.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - prelude
+      js-date:
+        repo: https://github.com/purescript-contrib/purescript-js-date.git
+        version: v8.0.0
+        dependencies:
+          - datetime
+          - effect
+          - exceptions
+          - foreign
+          - integers
+          - now
+      js-fileio:
+        repo: https://github.com/newlandsvalley/purescript-js-fileio.git
+        version: v3.0.0
+        dependencies:
+          - aff
+          - effect
+          - prelude
+      js-timers:
+        repo: https://github.com/purescript-contrib/purescript-js-timers.git
+        version: v6.1.0
+        dependencies:
+          - effect
+      js-uri:
+        repo: https://github.com/purescript-contrib/purescript-js-uri.git
+        version: v3.0.0
+        dependencies:
+          - functions
+          - maybe
+      justifill:
+        repo: https://github.com/i-am-the-slime/purescript-justifill.git
+        version: v0.5.0
+        dependencies:
+          - maybe
+          - prelude
+          - record
+          - typelevel-prelude
+      jwt:
+        repo: https://github.com/menelaos/purescript-jwt.git
+        version: v0.0.9
+        dependencies:
+          - argonaut-core
+          - arrays
+          - b64
+          - either
+          - exceptions
+          - prelude
+          - profunctor-lenses
+          - strings
+      language-cst-parser:
+        repo: https://github.com/natefaubion/purescript-language-cst-parser.git
+        version: v0.12.0
+        dependencies:
+          - arrays
+          - const
+          - control
+          - either
+          - foldable-traversable
+          - free
+          - functions
+          - functors
+          - identity
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - ordered-collections
+          - partial
+          - prelude
+          - st
+          - strings
+          - transformers
+          - tuples
+          - typelevel-prelude
+          - unfoldable
+          - unsafe-coerce
+      lazy:
+        repo: https://github.com/purescript/purescript-lazy.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - invariant
+          - prelude
+      lcg:
+        repo: https://github.com/purescript/purescript-lcg.git
+        version: v4.0.0
+        dependencies:
+          - effect
+          - integers
+          - maybe
+          - partial
+          - prelude
+          - random
+      leibniz:
+        repo: https://github.com/paf31/purescript-leibniz.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+          - unsafe-coerce
+      linalg:
+        repo: https://github.com/gbagan/purescript-linalg.git
+        version: v5.1.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - functions
+          - maybe
+          - prelude
+          - tuples
+      lists:
+        repo: https://github.com/purescript/purescript-lists.git
+        version: v7.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - foldable-traversable
+          - lazy
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      logging:
+        repo: https://github.com/rightfold/purescript-logging.git
+        version: v3.0.0
+        dependencies:
+          - console
+          - contravariant
+          - effect
+          - either
+          - prelude
+          - transformers
+          - tuples
+      machines:
+        repo: https://github.com/purescript-contrib/purescript-machines.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - lists
+          - maybe
+          - prelude
+          - profunctor
+          - tuples
+          - unfoldable
+      matrices:
+        repo: https://github.com/kRITZCREEK/purescript-matrices.git
+        version: v5.0.1
+        dependencies:
+          - arrays
+          - strings
+      matryoshka:
+        repo: https://github.com/purescript-contrib/purescript-matryoshka.git
+        version: v1.0.0
+        dependencies:
+          - fixed-points
+          - free
+          - prelude
+          - profunctor
+          - transformers
+      maybe:
+        repo: https://github.com/purescript/purescript-maybe.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - invariant
+          - newtype
+          - prelude
+      media-types:
+        repo: https://github.com/purescript-contrib/purescript-media-types.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      metadata:
+        repo: https://github.com/purescript/purescript-metadata.git
+        version: v0.15.0
+        dependencies: []
+      midi:
+        repo: https://github.com/newlandsvalley/purescript-midi.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - ordered-collections
+          - prelude
+          - signal
+          - string-parsers
+          - strings
+          - tuples
+          - unfoldable
+      minibench:
+        repo: https://github.com/purescript/purescript-minibench.git
+        version: v4.0.0
+        dependencies:
+          - console
+          - effect
+          - integers
+          - numbers
+          - partial
+          - prelude
+          - refs
+      mmorph:
+        repo: https://github.com/Thimoteus/purescript-mmorph.git
+        version: v7.0.0
+        dependencies:
+          - free
+          - functors
+          - transformers
+      monad-control:
+        repo: https://github.com/athanclark/purescript-monad-control.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - freet
+          - identity
+          - lists
+      monad-logger:
+        repo: https://github.com/cprussin/purescript-monad-logger.git
+        version: v1.3.1
+        dependencies:
+          - aff
+          - ansi
+          - argonaut
+          - arrays
+          - console
+          - control
+          - effect
+          - foldable-traversable
+          - foreign-object
+          - integers
+          - js-date
+          - maybe
+          - newtype
+          - ordered-collections
+          - prelude
+          - strings
+          - transformers
+          - tuples
+      monad-loops:
+        repo: https://github.com/mlang/purescript-monad-loops.git
+        version: v0.5.0
+        dependencies:
+          - lists
+          - maybe
+          - prelude
+          - tailrec
+          - tuples
+      monad-unlift:
+        repo: https://github.com/athanclark/purescript-monad-unlift.git
+        version: v1.0.1
+        dependencies:
+          - monad-control
+      monoidal:
+        repo: https://github.com/mcneissue/purescript-monoidal.git
+        version: v0.16.0
+        dependencies:
+          - either
+          - profunctor
+          - these
+          - tuples
+      morello:
+        repo: https://github.com/sigma-andex/purescript-morello.git
+        version: v0.3.2
+        dependencies:
+          - arrays
+          - barlow-lens
+          - foldable-traversable
+          - heterogeneous
+          - heterogeneous-extrablatt
+          - newtype
+          - prelude
+          - profunctor
+          - profunctor-lenses
+          - record
+          - tuples
+          - typelevel-prelude
+          - validation
+      motsunabe:
+        repo: https://github.com/justinwoo/purescript-motsunabe.git
+        version: v2.0.0
+        dependencies:
+          - lists
+          - strings
+      nano-id:
+        repo: https://github.com/eikooc/nano-id.git
+        version: v1.1.0
+        dependencies:
+          - aff
+          - effect
+          - lists
+          - maybe
+          - prelude
+          - random
+          - spec
+          - strings
+          - stringutils
+      naturals:
+        repo: https://github.com/LiamGoodacre/purescript-naturals.git
+        version: v3.0.0
+        dependencies:
+          - enums
+          - maybe
+          - prelude
+      nested-functor:
+        repo: https://github.com/acple/purescript-nested-functor.git
+        version: v0.2.1
+        dependencies:
+          - prelude
+          - type-equality
+      newtype:
+        repo: https://github.com/purescript/purescript-newtype.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+          - safe-coerce
+      node-buffer:
+        repo: https://github.com/purescript-node/purescript-node-buffer.git
+        version: v8.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - maybe
+          - st
+          - unsafe-coerce
+      node-buffer-blob:
+        repo: https://github.com/purescript-node/purescript-node-buffer-blob.git
+        version: v1.0.0
+        dependencies:
+          - aff-promise
+          - arraybuffer-types
+          - arrays
+          - console
+          - effect
+          - maybe
+          - media-types
+          - newtype
+          - node-buffer
+          - nullable
+          - prelude
+          - web-streams
+      node-child-process:
+        repo: https://github.com/purescript-node/purescript-node-child-process.git
+        version: v9.0.0
+        dependencies:
+          - exceptions
+          - foreign
+          - foreign-object
+          - functions
+          - node-fs
+          - node-streams
+          - nullable
+          - posix-types
+          - unsafe-coerce
+      node-fs:
+        repo: https://github.com/purescript-node/purescript-node-fs.git
+        version: v8.0.0
+        dependencies:
+          - datetime
+          - effect
+          - either
+          - enums
+          - exceptions
+          - functions
+          - integers
+          - js-date
+          - maybe
+          - node-buffer
+          - node-path
+          - node-streams
+          - nullable
+          - partial
+          - prelude
+          - strings
+          - unsafe-coerce
+      node-fs-aff:
+        repo: https://github.com/purescript-node/purescript-node-fs-aff.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - either
+          - node-fs
+          - node-path
+      node-http:
+        repo: https://github.com/purescript-node/purescript-node-http.git
+        version: v8.0.0
+        dependencies:
+          - arraybuffer-types
+          - contravariant
+          - effect
+          - foreign
+          - foreign-object
+          - maybe
+          - node-buffer
+          - node-net
+          - node-streams
+          - node-url
+          - nullable
+          - options
+          - prelude
+          - unsafe-coerce
+      node-net:
+        repo: https://github.com/purescript-node/purescript-node-net.git
+        version: v4.0.0
+        dependencies:
+          - effect
+          - either
+          - exceptions
+          - foreign
+          - maybe
+          - node-buffer
+          - node-fs
+          - nullable
+          - options
+          - prelude
+          - transformers
+      node-path:
+        repo: https://github.com/purescript-node/purescript-node-path.git
+        version: v5.0.0
+        dependencies:
+          - effect
+      node-process:
+        repo: https://github.com/purescript-node/purescript-node-process.git
+        version: v10.0.0
+        dependencies:
+          - effect
+          - foreign-object
+          - maybe
+          - node-streams
+          - posix-types
+          - prelude
+          - unsafe-coerce
+      node-readline:
+        repo: https://github.com/purescript-node/purescript-node-readline.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - foreign
+          - node-process
+          - node-streams
+          - options
+          - prelude
+      node-streams:
+        repo: https://github.com/purescript-node/purescript-node-streams.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - either
+          - exceptions
+          - node-buffer
+          - nullable
+          - prelude
+      node-streams-aff:
+        repo: https://github.com/jamesdbrock/purescript-node-streams-aff.git
+        version: v2.0.0
+        dependencies:
+          - aff
+          - arrays
+          - effect
+          - either
+          - exceptions
+          - maybe
+          - node-buffer
+          - node-streams
+          - prelude
+          - st
+          - tuples
+      node-url:
+        repo: https://github.com/purescript-node/purescript-node-url.git
+        version: v6.0.0
+        dependencies:
+          - nullable
+      nonempty:
+        repo: https://github.com/purescript/purescript-nonempty.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - maybe
+          - prelude
+          - tuples
+          - unfoldable
+      now:
+        repo: https://github.com/purescript-contrib/purescript-now.git
+        version: v6.0.0
+        dependencies:
+          - datetime
+          - effect
+      npm-package-json:
+        repo: https://github.com/maxdeviant/purescript-npm-package-json.git
+        version: v2.0.0
+        dependencies:
+          - argonaut
+          - control
+          - either
+          - foreign-object
+          - maybe
+          - ordered-collections
+          - prelude
+      nullable:
+        repo: https://github.com/purescript-contrib/purescript-nullable.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - functions
+          - maybe
+      numbers:
+        repo: https://github.com/purescript/purescript-numbers.git
+        version: v9.0.0
+        dependencies:
+          - functions
+          - maybe
+      open-folds:
+        repo: https://github.com/purescript-open-community/purescript-open-folds.git
+        version: v6.3.0
+        dependencies:
+          - bifunctors
+          - console
+          - control
+          - distributive
+          - effect
+          - either
+          - foldable-traversable
+          - identity
+          - invariant
+          - maybe
+          - newtype
+          - ordered-collections
+          - prelude
+          - profunctor
+          - psci-support
+          - tuples
+      open-memoize:
+        repo: https://github.com/purescript-open-community/purescript-open-memoize.git
+        version: v6.1.0
+        dependencies:
+          - console
+          - effect
+          - either
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - psci-support
+          - strings
+          - tuples
+      open-pairing:
+        repo: https://github.com/purescript-open-community/purescript-open-pairing.git
+        version: v6.1.0
+        dependencies:
+          - console
+          - control
+          - effect
+          - either
+          - free
+          - functors
+          - identity
+          - newtype
+          - prelude
+          - psci-support
+          - transformers
+          - tuples
+      options:
+        repo: https://github.com/purescript-contrib/purescript-options.git
+        version: v7.0.0
+        dependencies:
+          - contravariant
+          - foreign
+          - foreign-object
+          - maybe
+          - tuples
+      optparse:
+        repo: https://github.com/f-o-a-m/purescript-optparse.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - control
+          - effect
+          - either
+          - enums
+          - exists
+          - exitcodes
+          - foldable-traversable
+          - free
+          - gen
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - newtype
+          - node-buffer
+          - node-process
+          - node-streams
+          - nonempty
+          - numbers
+          - open-memoize
+          - partial
+          - prelude
+          - quickcheck
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+      ordered-collections:
+        repo: https://github.com/purescript/purescript-ordered-collections.git
+        version: v3.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - gen
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - unfoldable
+      ordered-set:
+        repo: https://github.com/flip111/purescript-ordered-set.git
+        version: v0.4.0
+        dependencies:
+          - argonaut-codecs
+          - arrays
+          - partial
+          - prelude
+          - unfoldable
+      orders:
+        repo: https://github.com/purescript/purescript-orders.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      pairs:
+        repo: https://github.com/sharkdp/purescript-pairs.git
+        version: v9.0.0
+        dependencies:
+          - console
+          - distributive
+          - foldable-traversable
+          - quickcheck
+      parallel:
+        repo: https://github.com/purescript/purescript-parallel.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - functors
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - refs
+          - transformers
+      parsing:
+        repo: https://github.com/purescript-contrib/purescript-parsing.git
+        version: v9.1.0
+        dependencies:
+          - arrays
+          - either
+          - foldable-traversable
+          - identity
+          - integers
+          - lists
+          - maybe
+          - nullable
+          - prelude
+          - strings
+          - transformers
+          - unicode
+      parsing-dataview:
+        repo: https://github.com/jamesdbrock/purescript-parsing-dataview.git
+        version: v3.1.0
+        dependencies:
+          - arraybuffer
+          - arraybuffer-types
+          - effect
+          - float32
+          - maybe
+          - parsing
+          - prelude
+          - transformers
+          - tuples
+          - uint
+      partial:
+        repo: https://github.com/purescript/purescript-partial.git
+        version: v4.0.0
+        dependencies: []
+      pathy:
+        repo: https://github.com/purescript-contrib/purescript-pathy.git
+        version: v9.0.0
+        dependencies:
+          - console
+          - exceptions
+          - lists
+          - partial
+          - profunctor
+          - strings
+          - transformers
+          - typelevel-prelude
+          - unsafe-coerce
+      pha:
+        repo: https://github.com/gbagan/purescript-pha.git
+        version: v0.9.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - datetime
+          - effect
+          - foldable-traversable
+          - free
+          - integers
+          - maybe
+          - prelude
+          - profunctor-lenses
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+          - unsafe-reference
+          - web-dom
+          - web-events
+          - web-html
+          - web-pointerevents
+          - web-uievents
+      phaser:
+        repo: https://github.com/lfarroco/purescript-phaser.git
+        version: v0.6.0
+        dependencies:
+          - canvas
+          - console
+          - effect
+          - maybe
+          - nullable
+          - options
+          - prelude
+          - web-html
+      pipes:
+        repo: https://github.com/felixschl/purescript-pipes.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - lists
+          - mmorph
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      point-free:
+        repo: https://github.com/ursi/purescript-point-free.git
+        version: v1.0.0
+        dependencies:
+          - prelude
+      polymorphic-vectors:
+        repo: https://github.com/artemisSystem/purescript-polymorphic-vectors.git
+        version: v4.0.0
+        dependencies:
+          - distributive
+          - foldable-traversable
+          - numbers
+          - prelude
+          - record
+          - safe-coerce
+          - type-equality
+          - typelevel-prelude
+      posix-types:
+        repo: https://github.com/purescript-node/purescript-posix-types.git
+        version: v6.0.0
+        dependencies:
+          - maybe
+          - prelude
+      precise:
+        repo: https://github.com/purescript-contrib/purescript-precise.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - exceptions
+          - gen
+          - integers
+          - lists
+          - numbers
+          - prelude
+          - strings
+      precise-datetime:
+        repo: https://github.com/awakesecurity/purescript-precise-datetime.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - datetime
+          - decimals
+          - either
+          - enums
+          - foldable-traversable
+          - formatters
+          - integers
+          - js-date
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - strings
+          - tuples
+          - unicode
+      prelude:
+        repo: https://github.com/purescript/purescript-prelude.git
+        version: v6.0.0
+        dependencies: []
+      prettier-printer:
+        repo: https://github.com/paulyoung/purescript-prettier-printer.git
+        version: v3.0.0
+        dependencies:
+          - console
+          - lists
+          - prelude
+          - strings
+          - tuples
+      profunctor:
+        repo: https://github.com/purescript/purescript-profunctor.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - distributive
+          - either
+          - exists
+          - invariant
+          - newtype
+          - prelude
+          - tuples
+      profunctor-lenses:
+        repo: https://github.com/purescript-contrib/purescript-profunctor-lenses.git
+        version: v8.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - const
+          - control
+          - distributive
+          - either
+          - foldable-traversable
+          - foreign-object
+          - functors
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - ordered-collections
+          - partial
+          - prelude
+          - profunctor
+          - record
+          - transformers
+          - tuples
+      protobuf:
+        repo: https://github.com/xc-jp/purescript-protobuf.git
+        version: v4.0.0
+        dependencies:
+          - arraybuffer
+          - arraybuffer-builder
+          - arraybuffer-types
+          - arrays
+          - control
+          - effect
+          - either
+          - enums
+          - exceptions
+          - float32
+          - foldable-traversable
+          - functions
+          - int64
+          - maybe
+          - newtype
+          - parsing
+          - parsing-dataview
+          - prelude
+          - record
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+          - uint
+          - web-encoding
+      ps-cst:
+        repo: https://github.com/purescript-codegen/purescript-ps-cst.git
+        version: v1.2.0
+        dependencies:
+          - ansi
+          - console
+          - dodo-printer
+          - effect
+          - node-fs-aff
+          - node-path
+          - psci-support
+          - record
+          - strings
+      psa-utils:
+        repo: https://github.com/natefaubion/purescript-psa-utils.git
+        version: v8.0.0
+        dependencies:
+          - ansi
+          - argonaut-codecs
+          - argonaut-core
+          - arrays
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - maybe
+          - node-path
+          - ordered-collections
+          - prelude
+          - strings
+          - tuples
+          - unsafe-coerce
+      psc-ide:
+        repo: https://github.com/kRITZCREEK/purescript-psc-ide.git
+        version: v19.0.0
+        dependencies:
+          - aff
+          - argonaut
+          - arrays
+          - console
+          - maybe
+          - node-child-process
+          - node-fs
+          - parallel
+          - random
+      psci-support:
+        repo: https://github.com/purescript/purescript-psci-support.git
+        version: v6.0.0
+        dependencies:
+          - console
+          - effect
+          - prelude
+      qualified-do:
+        repo: https://github.com/artemisSystem/purescript-qualified-do.git
+        version: v2.2.0
+        dependencies:
+          - arrays
+          - control
+          - foldable-traversable
+          - parallel
+          - prelude
+          - unfoldable
+      quantities:
+        repo: https://github.com/sharkdp/purescript-quantities.git
+        version: v12.0.1
+        dependencies:
+          - decimals
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - newtype
+          - nonempty
+          - numbers
+          - pairs
+          - prelude
+          - tuples
+      quickcheck:
+        repo: https://github.com/purescript/purescript-quickcheck.git
+        version: v8.0.1
+        dependencies:
+          - arrays
+          - console
+          - control
+          - effect
+          - either
+          - enums
+          - exceptions
+          - foldable-traversable
+          - gen
+          - identity
+          - integers
+          - lazy
+          - lcg
+          - lists
+          - maybe
+          - newtype
+          - nonempty
+          - numbers
+          - partial
+          - prelude
+          - record
+          - st
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+          - unfoldable
+      quickcheck-combinators:
+        repo: https://github.com/athanclark/purescript-quickcheck-combinators.git
+        version: v0.1.3
+        dependencies:
+          - quickcheck
+          - typelevel
+      quickcheck-laws:
+        repo: https://github.com/purescript-contrib/purescript-quickcheck-laws.git
+        version: v7.0.0
+        dependencies:
+          - enums
+          - quickcheck
+      quickcheck-utf8:
+        repo: https://github.com/openchronology/purescript-quickcheck-utf8.git
+        version: v0.0.0
+        dependencies:
+          - quickcheck
+      quotient:
+        repo: https://github.com/rightfold/purescript-quotient.git
+        version: v3.0.0
+        dependencies:
+          - prelude
+          - quickcheck
+      random:
+        repo: https://github.com/purescript/purescript-random.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - integers
+      rationals:
+        repo: https://github.com/anttih/purescript-rationals.git
+        version: v5.0.0
+        dependencies:
+          - integers
+          - prelude
+      react:
+        repo: https://github.com/purescript-contrib/purescript-react.git
+        version: v10.0.1
+        dependencies:
+          - effect
+          - exceptions
+          - maybe
+          - nullable
+          - prelude
+          - typelevel-prelude
+          - unsafe-coerce
+      react-basic:
+        repo: https://github.com/lumihq/purescript-react-basic.git
+        version: v17.0.0
+        dependencies:
+          - effect
+          - prelude
+          - record
+      react-basic-dom:
+        repo: https://github.com/lumihq/purescript-react-basic-dom.git
+        version: v5.0.0
+        dependencies:
+          - effect
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - nullable
+          - prelude
+          - react-basic
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-file
+          - web-html
+      react-basic-hooks:
+        repo: https://github.com/megamaddu/purescript-react-basic-hooks.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - aff-promise
+          - bifunctors
+          - console
+          - control
+          - datetime
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - functions
+          - indexed-monad
+          - integers
+          - maybe
+          - newtype
+          - now
+          - nullable
+          - ordered-collections
+          - prelude
+          - react-basic
+          - refs
+          - tuples
+          - type-equality
+          - unsafe-coerce
+          - unsafe-reference
+          - web-html
+      react-dom:
+        repo: https://github.com/purescript-contrib/purescript-react-dom.git
+        version: v8.0.0
+        dependencies:
+          - effect
+          - react
+          - web-dom
+      read:
+        repo: https://github.com/truqu/purescript-read.git
+        version: v1.0.1
+        dependencies:
+          - maybe
+          - prelude
+          - strings
+      record:
+        repo: https://github.com/purescript/purescript-record.git
+        version: v4.0.0
+        dependencies:
+          - functions
+          - prelude
+          - unsafe-coerce
+      refined:
+        repo: https://github.com/danieljharvey/purescript-refined.git
+        version: v1.0.0
+        dependencies:
+          - argonaut
+          - effect
+          - prelude
+          - quickcheck
+          - typelevel
+      refs:
+        repo: https://github.com/purescript/purescript-refs.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - prelude
+      remotedata:
+        repo: https://github.com/krisajenkins/purescript-remotedata.git
+        version: v5.0.0
+        dependencies:
+          - bifunctors
+          - either
+          - profunctor-lenses
+      resource:
+        repo: https://github.com/joneshf/purescript-resource.git
+        version: v2.0.1
+        dependencies:
+          - aff
+          - console
+          - control
+          - effect
+          - newtype
+          - prelude
+          - psci-support
+          - refs
+      resourcet:
+        repo: https://github.com/robertdp/purescript-resourcet.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - effect
+          - foldable-traversable
+          - maybe
+          - ordered-collections
+          - parallel
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+      result:
+        repo: https://github.com/ad-si/purescript-result.git
+        version: v1.0.3
+        dependencies:
+          - either
+          - foldable-traversable
+          - prelude
+      return:
+        repo: https://github.com/ursi/purescript-return.git
+        version: v0.2.0
+        dependencies:
+          - foldable-traversable
+          - point-free
+          - prelude
+      ring-modules:
+        repo: https://github.com/f-o-a-m/purescript-ring-modules.git
+        version: v5.0.1
+        dependencies:
+          - prelude
+      routing:
+        repo: https://github.com/purescript-contrib/purescript-routing.git
+        version: v11.0.0
+        dependencies:
+          - aff
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - integers
+          - js-uri
+          - lists
+          - maybe
+          - numbers
+          - partial
+          - prelude
+          - semirings
+          - tuples
+          - validation
+          - web-html
+      routing-duplex:
+        repo: https://github.com/natefaubion/purescript-routing-duplex.git
+        version: v0.6.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - js-uri
+          - lazy
+          - numbers
+          - prelude
+          - profunctor
+          - record
+          - strings
+          - typelevel-prelude
+      run:
+        repo: https://github.com/natefaubion/purescript-run.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - free
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - tailrec
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - variant
+      safe-coerce:
+        repo: https://github.com/purescript/purescript-safe-coerce.git
+        version: v2.0.0
+        dependencies:
+          - unsafe-coerce
+      safely:
+        repo: https://github.com/paf31/purescript-safely.git
+        version: v4.0.1
+        dependencies:
+          - freet
+          - lists
+      selection-foldable:
+        repo: https://github.com/jamieyung/purescript-selection-foldable.git
+        version: v0.2.0
+        dependencies:
+          - filterable
+          - foldable-traversable
+          - maybe
+          - prelude
+      semirings:
+        repo: https://github.com/purescript/purescript-semirings.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - lists
+          - newtype
+          - prelude
+      signal:
+        repo: https://github.com/bodil/purescript-signal.git
+        version: v13.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - foldable-traversable
+          - maybe
+          - prelude
+      simple-emitter:
+        repo: https://github.com/oreshinya/purescript-simple-emitter.git
+        version: v2.0.0
+        dependencies:
+          - ordered-collections
+          - refs
+      sized-matrices:
+        repo: https://github.com/csicar/purescript-sized-matrices.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - distributive
+          - foldable-traversable
+          - maybe
+          - prelude
+          - sized-vectors
+          - strings
+          - typelevel
+          - unfoldable
+          - vectorfield
+      sized-vectors:
+        repo: https://github.com/bodil/purescript-sized-vectors.git
+        version: v5.0.2
+        dependencies:
+          - argonaut
+          - arrays
+          - distributive
+          - foldable-traversable
+          - maybe
+          - prelude
+          - quickcheck
+          - typelevel
+          - unfoldable
+      slug:
+        repo: https://github.com/thomashoneyman/purescript-slug.git
+        version: v3.0.1
+        dependencies:
+          - argonaut-codecs
+          - maybe
+          - prelude
+          - strings
+          - unicode
+      soundfonts:
+        repo: https://github.com/newlandsvalley/purescript-soundfonts.git
+        version: v4.1.0
+        dependencies:
+          - aff
+          - affjax
+          - affjax-web
+          - argonaut-core
+          - arraybuffer-types
+          - arrays
+          - b64
+          - bifunctors
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign-object
+          - http-methods
+          - integers
+          - lists
+          - maybe
+          - midi
+          - ordered-collections
+          - parallel
+          - partial
+          - prelude
+          - strings
+          - transformers
+          - tuples
+      sparse-matrices:
+        repo: https://github.com/Ebmtranceboy/purescript-sparse-matrices.git
+        version: v1.2.1
+        dependencies:
+          - console
+          - effect
+          - prelude
+          - sparse-polynomials
+      sparse-polynomials:
+        repo: https://github.com/Ebmtranceboy/purescript-sparse-polynomials.git
+        version: v1.0.5
+        dependencies:
+          - cartesian
+          - console
+          - effect
+          - ordered-collections
+          - prelude
+          - rationals
+          - tuples
+      spec:
+        repo: https://github.com/purescript-spec/purescript-spec.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - ansi
+          - avar
+          - console
+          - exceptions
+          - foldable-traversable
+          - fork
+          - now
+          - pipes
+          - prelude
+          - strings
+          - transformers
+      spec-discovery:
+        repo: https://github.com/purescript-spec/purescript-spec-discovery.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - aff-promise
+          - arrays
+          - console
+          - effect
+          - foldable-traversable
+          - node-fs
+          - prelude
+          - spec
+      spec-quickcheck:
+        repo: https://github.com/purescript-spec/purescript-spec-quickcheck.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - prelude
+          - quickcheck
+          - random
+          - spec
+      ssrs:
+        repo: https://github.com/PureFunctor/purescript-ssrs.git
+        version: v1.0.0
+        dependencies:
+          - dissect
+          - either
+          - fixed-points
+          - free
+          - lists
+          - prelude
+          - safe-coerce
+          - tailrec
+          - tuples
+          - variant
+      st:
+        repo: https://github.com/purescript/purescript-st.git
+        version: v6.0.0
+        dependencies:
+          - partial
+          - prelude
+          - tailrec
+          - unsafe-coerce
+      strictlypositiveint:
+        repo: https://github.com/jamieyung/purescript-strictlypositiveint.git
+        version: v1.0.1
+        dependencies:
+          - prelude
+      string-parsers:
+        repo: https://github.com/purescript-contrib/purescript-string-parsers.git
+        version: v8.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - prelude
+          - strings
+          - tailrec
+      strings:
+        repo: https://github.com/purescript/purescript-strings.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - enums
+          - foldable-traversable
+          - gen
+          - integers
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+          - unsafe-coerce
+      strings-extra:
+        repo: https://github.com/purescript-contrib/purescript-strings-extra.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - maybe
+          - prelude
+          - strings
+          - unicode
+      stringutils:
+        repo: https://github.com/menelaos/purescript-stringutils.git
+        version: v0.0.12
+        dependencies:
+          - arrays
+          - integers
+          - maybe
+          - partial
+          - prelude
+          - strings
+      substitute:
+        repo: https://github.com/ursi/purescript-substitute.git
+        version: v0.2.3
+        dependencies:
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - prelude
+          - return
+          - strings
+      supply:
+        repo: https://github.com/ajnsit/purescript-supply.git
+        version: v0.2.0
+        dependencies:
+          - console
+          - control
+          - effect
+          - lazy
+          - prelude
+          - refs
+          - tuples
+      tailrec:
+        repo: https://github.com/purescript/purescript-tailrec.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - effect
+          - either
+          - identity
+          - maybe
+          - partial
+          - prelude
+          - refs
+      test-unit:
+        repo: https://github.com/bodil/purescript-test-unit.git
+        version: v17.0.0
+        dependencies:
+          - aff
+          - avar
+          - effect
+          - either
+          - free
+          - js-timers
+          - lists
+          - prelude
+          - quickcheck
+          - strings
+      thermite:
+        repo: https://github.com/paf31/purescript-thermite.git
+        version: v6.3.1
+        dependencies:
+          - aff
+          - coroutines
+          - freet
+          - profunctor-lenses
+          - react
+      thermite-dom:
+        repo: https://github.com/athanclark/purescript-thermite-dom.git
+        version: v0.3.1
+        dependencies:
+          - react
+          - react-dom
+          - thermite
+          - web-html
+      these:
+        repo: https://github.com/purescript-contrib/purescript-these.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - gen
+          - lists
+          - quickcheck
+          - quickcheck-laws
+          - tuples
+      transformers:
+        repo: https://github.com/purescript/purescript-transformers.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - distributive
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - identity
+          - lazy
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      tree-rose:
+        repo: https://github.com/jordanmartinez/purescript-tree-rose.git
+        version: v4.0.2
+        dependencies:
+          - control
+          - foldable-traversable
+          - free
+          - lists
+          - maybe
+          - prelude
+          - tailrec
+      tuples:
+        repo: https://github.com/purescript/purescript-tuples.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - invariant
+          - prelude
+      two-or-more:
+        repo: https://github.com/i-am-the-slime/purescript-two-or-more.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - foldable-traversable
+          - maybe
+          - partial
+          - prelude
+          - psci-support
+          - tuples
+      type-equality:
+        repo: https://github.com/purescript/purescript-type-equality.git
+        version: v4.0.1
+        dependencies: []
+      typelevel:
+        repo: https://github.com/bodil/purescript-typelevel.git
+        version: v6.0.0
+        dependencies:
+          - partial
+          - prelude
+          - tuples
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-lists:
+        repo: https://github.com/PureFunctor/purescript-typelevel-lists.git
+        version: v2.1.0
+        dependencies:
+          - prelude
+          - tuples
+          - typelevel-peano
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-peano:
+        repo: https://github.com/csicar/purescript-typelevel-peano.git
+        version: v1.0.1
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - prelude
+          - psci-support
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-prelude:
+        repo: https://github.com/purescript/purescript-typelevel-prelude.git
+        version: v7.0.0
+        dependencies:
+          - prelude
+          - type-equality
+      typelevel-rows:
+        repo: https://github.com/jordanmartinez/purescript-typelevel-rows.git
+        version: v0.1.0
+        dependencies:
+          - prelude
+      uint:
+        repo: https://github.com/purescript-contrib/purescript-uint.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - enums
+          - gen
+          - maybe
+          - numbers
+          - prelude
+      uncurried-transformers:
+        repo: https://github.com/PureFunctor/purescript-uncurried-transformers.git
+        version: v1.1.0
+        dependencies:
+          - control
+          - effect
+          - either
+          - functions
+          - identity
+          - prelude
+          - safe-coerce
+          - tailrec
+          - transformers
+          - tuples
+      undefined-is-not-a-problem:
+        repo: https://github.com/paluh/purescript-undefined-is-not-a-problem.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - assert
+          - effect
+          - either
+          - foreign
+          - maybe
+          - newtype
+          - prelude
+          - random
+          - tuples
+          - type-equality
+          - unsafe-coerce
+      unfoldable:
+        repo: https://github.com/purescript/purescript-unfoldable.git
+        version: v6.0.0
+        dependencies:
+          - foldable-traversable
+          - maybe
+          - partial
+          - prelude
+          - tuples
+      unicode:
+        repo: https://github.com/purescript-contrib/purescript-unicode.git
+        version: v6.0.0
+        dependencies:
+          - foldable-traversable
+          - maybe
+          - strings
+      unlift:
+        repo: https://github.com/tweag/purescript-unlift.git
+        version: v1.0.1
+        dependencies:
+          - aff
+          - effect
+          - either
+          - freet
+          - identity
+          - lists
+          - maybe
+          - monad-control
+          - prelude
+          - st
+          - transformers
+          - tuples
+      unsafe-coerce:
+        repo: https://github.com/purescript/purescript-unsafe-coerce.git
+        version: v6.0.0
+        dependencies: []
+      unsafe-reference:
+        repo: https://github.com/purescript-contrib/purescript-unsafe-reference.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+      uri:
+        repo: https://github.com/purescript-contrib/purescript-uri.git
+        version: v9.0.0
+        dependencies:
+          - arrays
+          - integers
+          - js-uri
+          - numbers
+          - parsing
+          - prelude
+          - profunctor-lenses
+          - these
+          - transformers
+          - unfoldable
+      validation:
+        repo: https://github.com/purescript/purescript-validation.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - newtype
+          - prelude
+      variant:
+        repo: https://github.com/natefaubion/purescript-variant.git
+        version: v8.0.0
+        dependencies:
+          - enums
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - record
+          - tuples
+          - unsafe-coerce
+      vectorfield:
+        repo: https://github.com/csicar/purescript-vectorfield.git
+        version: v1.0.1
+        dependencies:
+          - console
+          - effect
+          - group
+          - prelude
+          - psci-support
+      versions:
+        repo: https://github.com/hdgarrood/purescript-versions.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - either
+          - foldable-traversable
+          - functions
+          - integers
+          - lists
+          - maybe
+          - orders
+          - parsing
+          - partial
+          - strings
+      web-clipboard:
+        repo: https://github.com/purescript-web/purescript-web-clipboard.git
+        version: v4.0.0
+        dependencies:
+          - web-html
+      web-cssom:
+        repo: https://github.com/purescript-web/purescript-web-cssom.git
+        version: v2.0.0
+        dependencies:
+          - web-dom
+          - web-html
+          - web-uievents
+      web-dom:
+        repo: https://github.com/purescript-web/purescript-web-dom.git
+        version: v6.0.0
+        dependencies:
+          - web-events
+      web-dom-parser:
+        repo: https://github.com/purescript-web/purescript-web-dom-parser.git
+        version: v8.0.0
+        dependencies:
+          - effect
+          - partial
+          - prelude
+          - web-dom
+      web-dom-xpath:
+        repo: https://github.com/purescript-web/purescript-web-dom-xpath.git
+        version: v3.0.0
+        dependencies:
+          - web-dom
+      web-encoding:
+        repo: https://github.com/purescript-web/purescript-web-encoding.git
+        version: v3.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - newtype
+          - prelude
+      web-events:
+        repo: https://github.com/purescript-web/purescript-web-events.git
+        version: v4.0.0
+        dependencies:
+          - datetime
+          - enums
+          - foreign
+          - nullable
+      web-fetch:
+        repo: https://github.com/purescript-web/purescript-web-fetch.git
+        version: v3.0.0
+        dependencies:
+          - effect
+          - foreign-object
+          - http-methods
+          - prelude
+          - record
+          - typelevel-prelude
+          - web-file
+          - web-promise
+          - web-streams
+      web-file:
+        repo: https://github.com/purescript-web/purescript-web-file.git
+        version: v4.0.0
+        dependencies:
+          - foreign
+          - media-types
+          - web-dom
+      web-html:
+        repo: https://github.com/purescript-web/purescript-web-html.git
+        version: v4.0.0
+        dependencies:
+          - js-date
+          - web-dom
+          - web-file
+          - web-storage
+      web-page-visibility:
+        repo: https://git.sr.ht/~toastal/purescript-web-page-visibility
+        version: v2.0.0
+        dependencies:
+          - effect
+          - enums
+          - exceptions
+          - maybe
+          - prelude
+          - strings
+          - web-events
+          - web-html
+      web-pointerevents:
+        repo: https://github.com/purescript-web/purescript-web-pointerevents.git
+        version: v1.0.0
+        dependencies:
+          - effect
+          - maybe
+          - prelude
+          - web-dom
+          - web-uievents
+      web-promise:
+        repo: https://github.com/purescript-web/purescript-web-promise.git
+        version: v3.0.0
+        dependencies:
+          - effect
+          - exceptions
+          - foldable-traversable
+          - functions
+          - maybe
+          - prelude
+      web-socket:
+        repo: https://github.com/purescript-web/purescript-web-socket.git
+        version: v4.0.0
+        dependencies:
+          - arraybuffer-types
+          - web-file
+      web-storage:
+        repo: https://github.com/purescript-web/purescript-web-storage.git
+        version: v5.0.0
+        dependencies:
+          - nullable
+          - web-events
+      web-streams:
+        repo: https://github.com/purescript-web/purescript-web-streams.git
+        version: v3.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - exceptions
+          - nullable
+          - prelude
+          - tuples
+          - web-promise
+      web-touchevents:
+        repo: https://github.com/purescript-web/purescript-web-touchevents.git
+        version: v4.0.0
+        dependencies:
+          - web-uievents
+      web-uievents:
+        repo: https://github.com/purescript-web/purescript-web-uievents.git
+        version: v4.0.0
+        dependencies:
+          - web-html
+      web-workers:
+        repo: https://github.com/gbagan/purescript-web-workers.git
+        version: v1.1.0
+        dependencies:
+          - effect
+          - foreign
+          - maybe
+          - prelude
+          - unsafe-coerce
+          - web-events
+      web-xhr:
+        repo: https://github.com/purescript-web/purescript-web-xhr.git
+        version: v5.0.0
+        dependencies:
+          - arraybuffer-types
+          - datetime
+          - http-methods
+          - web-dom
+          - web-file
+          - web-html
+      yoga-fetch:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-fetch.git
+        version: v1.0.1
+        dependencies:
+          - aff
+          - aff-promise
+          - arraybuffer-types
+          - effect
+          - foreign
+          - foreign-object
+          - newtype
+          - prelude
+          - typelevel-prelude
+          - unsafe-coerce
+      yoga-json:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-json.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - identity
+          - lists
+          - maybe
+          - nullable
+          - partial
+          - prelude
+          - record
+          - transformers
+          - typelevel-prelude
+          - variant
+      yoga-postgres:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-postgres.git
+        version: v6.0.0
+        dependencies:
+          - aff
+          - arrays
+          - datetime
+          - effect
+          - either
+          - enums
+          - foldable-traversable
+          - foreign
+          - integers
+          - maybe
+          - nullable
+          - prelude
+          - transformers
+          - unsafe-coerce
+  extra_packages: {}
+packages:
+  aff:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-aff.git
+    rev: 2d44d9f9d0d6a416a4103fba2fb39e5160f80e36
+    dependencies:
+      - datetime
+      - effect
+      - exceptions
+      - functions
+      - parallel
+      - transformers
+      - unsafe-coerce
+  arraybuffer-types:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
+    rev: 9b0b7a0f9ee034e039f3d3a2a9c3f74eb7c9264a
+    dependencies: []
+  arrays:
+    type: git
+    url: https://github.com/purescript/purescript-arrays.git
+    rev: d20bae2f76db6cf29b7b75e26e82b8a54c32295e
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - maybe
+      - nonempty
+      - partial
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  avar:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-avar.git
+    rev: d00f5784d9cc8f079babd62740f5c52b87e5caa5
+    dependencies:
+      - aff
+      - effect
+      - either
+      - exceptions
+      - functions
+      - maybe
+  bifunctors:
+    type: git
+    url: https://github.com/purescript/purescript-bifunctors.git
+    rev: 16ba2fb6dd7f05528ebd9e2f9ca3a068b325e5b3
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  catenable-lists:
+    type: git
+    url: https://github.com/purescript/purescript-catenable-lists.git
+    rev: 09abe1f4888bc00841ad2b59e56a9e7ce7ebd4ab
+    dependencies:
+      - control
+      - foldable-traversable
+      - lists
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  console:
+    type: git
+    url: https://github.com/purescript/purescript-console.git
+    rev: 3b83d7b792d03872afeea5e62b4f686ab0f09842
+    dependencies:
+      - effect
+      - prelude
+  const:
+    type: git
+    url: https://github.com/purescript/purescript-const.git
+    rev: ab9570cf2b6e67f7e441178211db1231cfd75c37
+    dependencies:
+      - invariant
+      - newtype
+      - prelude
+  contravariant:
+    type: git
+    url: https://github.com/purescript/purescript-contravariant.git
+    rev: 9ad3e105b8855bcc25f4e0893c784789d05a58de
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  control:
+    type: git
+    url: https://github.com/purescript/purescript-control.git
+    rev: a6033808790879a17b2729e73747a9ed3fb2264e
+    dependencies:
+      - newtype
+      - prelude
+  datetime:
+    type: git
+    url: https://github.com/purescript/purescript-datetime.git
+    rev: a6a0cf1b0324964ad1854bc3377ed8766ba90e6f
+    dependencies:
+      - bifunctors
+      - control
+      - either
+      - enums
+      - foldable-traversable
+      - functions
+      - gen
+      - integers
+      - lists
+      - maybe
+      - newtype
+      - numbers
+      - ordered-collections
+      - partial
+      - prelude
+      - tuples
+  distributive:
+    type: git
+    url: https://github.com/purescript/purescript-distributive.git
+    rev: 6005e513642e855ebf6f884d24a35c2803ca252a
+    dependencies:
+      - identity
+      - newtype
+      - prelude
+      - tuples
+      - type-equality
+  effect:
+    type: git
+    url: https://github.com/purescript/purescript-effect.git
+    rev: a192ddb923027d426d6ea3d8deb030c9aa7c7dda
+    dependencies:
+      - prelude
+  either:
+    type: git
+    url: https://github.com/purescript/purescript-either.git
+    rev: af655a04ed2fd694b6688af39ee20d7907ad0763
+    dependencies:
+      - control
+      - invariant
+      - maybe
+      - prelude
+  enums:
+    type: git
+    url: https://github.com/purescript/purescript-enums.git
+    rev: bae47961d401f9acf88da38f32e87403e5f0cf2f
+    dependencies:
+      - control
+      - either
+      - gen
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tuples
+      - unfoldable
+  exceptions:
+    type: git
+    url: https://github.com/purescript/purescript-exceptions.git
+    rev: afab3c07c820bb49b6c5be50049db46a964a6161
+    dependencies:
+      - effect
+      - either
+      - maybe
+      - prelude
+  exists:
+    type: git
+    url: https://github.com/purescript/purescript-exists.git
+    rev: f765b4ace7869c27b9c05949e18c843881f9173b
+    dependencies:
+      - unsafe-coerce
+  exitcodes:
+    type: git
+    url: https://github.com/Risto-Stevcev/purescript-exitcodes.git
+    rev: 8a9a93fd1776aba4a14cdc9a31094c9e05b05348
+    dependencies:
+      - enums
+  foldable-traversable:
+    type: git
+    url: https://github.com/purescript/purescript-foldable-traversable.git
+    rev: b3926f870532d287ea59e2d5cd3873b81ef2a93a
+    dependencies:
+      - bifunctors
+      - const
+      - control
+      - either
+      - functors
+      - identity
+      - maybe
+      - newtype
+      - orders
+      - prelude
+      - tuples
+  foreign:
+    type: git
+    url: https://github.com/purescript/purescript-foreign.git
+    rev: 2dd222d1ec7363fa0a0a7adb0d8eaf81bb7006dd
+    dependencies:
+      - either
+      - functions
+      - identity
+      - integers
+      - lists
+      - maybe
+      - prelude
+      - strings
+      - transformers
+  foreign-object:
+    type: git
+    url: https://github.com/purescript/purescript-foreign-object.git
+    rev: 28a635827a9a6c251df73f68874070d51fe9f756
+    dependencies:
+      - arrays
+      - foldable-traversable
+      - functions
+      - gen
+      - lists
+      - maybe
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - typelevel-prelude
+      - unfoldable
+  free:
+    type: git
+    url: https://github.com/purescript/purescript-free.git
+    rev: e2d8fa8023a864363857834e11393483bced5e38
+    dependencies:
+      - catenable-lists
+      - control
+      - distributive
+      - either
+      - exists
+      - foldable-traversable
+      - invariant
+      - lazy
+      - maybe
+      - prelude
+      - tailrec
+      - transformers
+      - tuples
+      - unsafe-coerce
+  functions:
+    type: git
+    url: https://github.com/purescript/purescript-functions.git
+    rev: f626f20580483977c5b27a01aac6471e28aff367
+    dependencies:
+      - prelude
+  functors:
+    type: git
+    url: https://github.com/purescript/purescript-functors.git
+    rev: 022ffd7a2a7ec12080314f3d217b400674a247b4
+    dependencies:
+      - bifunctors
+      - const
+      - contravariant
+      - control
+      - distributive
+      - either
+      - invariant
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - tuples
+      - unsafe-coerce
+  gen:
+    type: git
+    url: https://github.com/purescript/purescript-gen.git
+    rev: 9fbcc2a1261c32e30d79c5418edef4d96fe76931
+    dependencies:
+      - either
+      - foldable-traversable
+      - identity
+      - maybe
+      - newtype
+      - nonempty
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  identity:
+    type: git
+    url: https://github.com/purescript/purescript-identity.git
+    rev: ef6768f8a52ab0bc943a85f5761ba07c257f639f
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  integers:
+    type: git
+    url: https://github.com/purescript/purescript-integers.git
+    rev: 54d712b25c594833083d15dc9ff2418eb9c52822
+    dependencies:
+      - maybe
+      - numbers
+      - prelude
+  invariant:
+    type: git
+    url: https://github.com/purescript/purescript-invariant.git
+    rev: 1d2a196d51e90623adb88496c2cfd759c6736894
+    dependencies:
+      - control
+      - prelude
+  js-timers:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-js-timers.git
+    rev: 7cb728b3e6dc29f355143617e6e9ac770ecd9273
+    dependencies:
+      - effect
+  lazy:
+    type: git
+    url: https://github.com/purescript/purescript-lazy.git
+    rev: 48347841226b27af5205a1a8ec71e27a93ce86fd
+    dependencies:
+      - control
+      - foldable-traversable
+      - invariant
+      - prelude
+  lcg:
+    type: git
+    url: https://github.com/purescript/purescript-lcg.git
+    rev: 67c6c6483a563a59ae036d9dca0f1be2835326a5
+    dependencies:
+      - effect
+      - integers
+      - maybe
+      - partial
+      - prelude
+      - random
+  lists:
+    type: git
+    url: https://github.com/purescript/purescript-lists.git
+    rev: b113451e5b41cad87d669a3165f955c71cd863e2
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - lazy
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  maybe:
+    type: git
+    url: https://github.com/purescript/purescript-maybe.git
+    rev: c6f98ac1088766287106c5d9c8e30e7648d36786
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  newtype:
+    type: git
+    url: https://github.com/purescript/purescript-newtype.git
+    rev: 29d8e6dd77aec2c975c948364ec3faf26e14ee7b
+    dependencies:
+      - prelude
+      - safe-coerce
+  node-buffer:
+    type: git
+    url: https://github.com/purescript-node/purescript-node-buffer.git
+    rev: 7be7bd082b7d3e15de2ed5a626d43af746bdb35e
+    dependencies:
+      - arraybuffer-types
+      - effect
+      - maybe
+      - st
+      - unsafe-coerce
+  node-process:
+    type: git
+    url: https://github.com/purescript-node/purescript-node-process.git
+    rev: 9d126d9d4f898723e7cab69895770bbac0c3a0b8
+    dependencies:
+      - effect
+      - foreign-object
+      - maybe
+      - node-streams
+      - posix-types
+      - prelude
+      - unsafe-coerce
+  node-readline:
+    type: git
+    url: https://github.com/purescript-node/purescript-node-readline.git
+    rev: fbe80a949275f15643b80f9db7c01d5a6b4031ed
+    dependencies:
+      - effect
+      - foreign
+      - node-process
+      - node-streams
+      - options
+      - prelude
+  node-streams:
+    type: git
+    url: https://github.com/purescript-node/purescript-node-streams.git
+    rev: 8395652f9f347101fe042f58726edc592ae5086c
+    dependencies:
+      - effect
+      - either
+      - exceptions
+      - node-buffer
+      - nullable
+      - prelude
+  nonempty:
+    type: git
+    url: https://github.com/purescript/purescript-nonempty.git
+    rev: 28150ecc7419238b187abd609a92a645273348bb
+    dependencies:
+      - control
+      - foldable-traversable
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  nullable:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-nullable.git
+    rev: 3202744c6c65e8d1fbba7f4256a1c482078e7fb5
+    dependencies:
+      - effect
+      - functions
+      - maybe
+  numbers:
+    type: git
+    url: https://github.com/purescript/purescript-numbers.git
+    rev: 2a53528f18f9415334bae28e7bb3cf3be86342c2
+    dependencies:
+      - functions
+      - maybe
+  open-memoize:
+    type: git
+    url: https://github.com/purescript-open-community/purescript-open-memoize.git
+    rev: 20d5c14d3033d19044e2d49c11d02278bda72a54
+    dependencies:
+      - console
+      - effect
+      - either
+      - integers
+      - lazy
+      - lists
+      - maybe
+      - partial
+      - prelude
+      - psci-support
+      - strings
+      - tuples
+  options:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-options.git
+    rev: 93e4eb4610975cb7b3bb290273396707e7384c38
+    dependencies:
+      - contravariant
+      - foreign
+      - foreign-object
+      - maybe
+      - tuples
+  optparse:
+    type: git
+    url: https://github.com/f-o-a-m/purescript-optparse.git
+    rev: dbc4c385e6c436eed4299ae2c0bb2cc278cf2410
+    dependencies:
+      - aff
+      - arrays
+      - bifunctors
+      - console
+      - control
+      - effect
+      - either
+      - enums
+      - exists
+      - exitcodes
+      - foldable-traversable
+      - free
+      - gen
+      - integers
+      - lazy
+      - lists
+      - maybe
+      - newtype
+      - node-buffer
+      - node-process
+      - node-streams
+      - nonempty
+      - numbers
+      - open-memoize
+      - partial
+      - prelude
+      - quickcheck
+      - strings
+      - tailrec
+      - transformers
+      - tuples
+  ordered-collections:
+    type: git
+    url: https://github.com/purescript/purescript-ordered-collections.git
+    rev: 9826b7632d0d0a691173bde308a634195f42a419
+    dependencies:
+      - arrays
+      - foldable-traversable
+      - gen
+      - lists
+      - maybe
+      - partial
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+  orders:
+    type: git
+    url: https://github.com/purescript/purescript-orders.git
+    rev: f86db621ec5eef1274145f8b1fd8ebbfe0ed4a2c
+    dependencies:
+      - newtype
+      - prelude
+  parallel:
+    type: git
+    url: https://github.com/purescript/purescript-parallel.git
+    rev: 85290dca837771ac4870071008c933d315ef678f
+    dependencies:
+      - control
+      - effect
+      - either
+      - foldable-traversable
+      - functors
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - refs
+      - transformers
+  partial:
+    type: git
+    url: https://github.com/purescript/purescript-partial.git
+    rev: 0fa0646f5ea1ec5f0c46dcbd770c705a6c9ad3ec
+    dependencies: []
+  posix-types:
+    type: git
+    url: https://github.com/purescript-node/purescript-posix-types.git
+    rev: b79ff37f87846ca5caab2123cf84148e700d40d1
+    dependencies:
+      - maybe
+      - prelude
+  prelude:
+    type: git
+    url: https://github.com/purescript/purescript-prelude.git
+    rev: 32787f4399c92459c41602131a5858559eb868c5
+    dependencies: []
+  profunctor:
+    type: git
+    url: https://github.com/purescript/purescript-profunctor.git
+    rev: 0a966a14e7b0c827d44657dc1710cdc712d2e034
+    dependencies:
+      - control
+      - distributive
+      - either
+      - exists
+      - invariant
+      - newtype
+      - prelude
+      - tuples
+  psci-support:
+    type: git
+    url: https://github.com/purescript/purescript-psci-support.git
+    rev: 897cdb543548cb6078d69b6413b54841404eda72
+    dependencies:
+      - console
+      - effect
+      - prelude
+  quickcheck:
+    type: git
+    url: https://github.com/purescript/purescript-quickcheck.git
+    rev: bf5029f97e6c0d7552d3a08d2ab793a19e2c5e3d
+    dependencies:
+      - arrays
+      - console
+      - control
+      - effect
+      - either
+      - enums
+      - exceptions
+      - foldable-traversable
+      - gen
+      - identity
+      - integers
+      - lazy
+      - lcg
+      - lists
+      - maybe
+      - newtype
+      - nonempty
+      - numbers
+      - partial
+      - prelude
+      - record
+      - st
+      - strings
+      - tailrec
+      - transformers
+      - tuples
+      - unfoldable
+  random:
+    type: git
+    url: https://github.com/purescript/purescript-random.git
+    rev: 9540bc965a9596da02fefd9949418bb19c92533a
+    dependencies:
+      - effect
+      - integers
+  record:
+    type: git
+    url: https://github.com/purescript/purescript-record.git
+    rev: c89cd1ada6b636692571fc374196b1c39c4c9f70
+    dependencies:
+      - functions
+      - prelude
+      - unsafe-coerce
+  refs:
+    type: git
+    url: https://github.com/purescript/purescript-refs.git
+    rev: f8e6216da4cb9309fde1f20cd6f69ac3a3b7f9e8
+    dependencies:
+      - effect
+      - prelude
+  safe-coerce:
+    type: git
+    url: https://github.com/purescript/purescript-safe-coerce.git
+    rev: 7fa799ae80a38b8d948efcb52608e58e198b3da7
+    dependencies:
+      - unsafe-coerce
+  st:
+    type: git
+    url: https://github.com/purescript/purescript-st.git
+    rev: 2cc7ae1c3318a303378c4a9f3fa0f10ee7cc3589
+    dependencies:
+      - partial
+      - prelude
+      - tailrec
+      - unsafe-coerce
+  strings:
+    type: git
+    url: https://github.com/purescript/purescript-strings.git
+    rev: 4bc6954448d056f8aa7a659695a6ad60ad4fdf19
+    dependencies:
+      - arrays
+      - control
+      - either
+      - enums
+      - foldable-traversable
+      - gen
+      - integers
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  tailrec:
+    type: git
+    url: https://github.com/purescript/purescript-tailrec.git
+    rev: 5e2104aa734b31a17074cc805bf087d72b65afd1
+    dependencies:
+      - bifunctors
+      - effect
+      - either
+      - identity
+      - maybe
+      - partial
+      - prelude
+      - refs
+  test-unit:
+    type: git
+    url: https://github.com/bodil/purescript-test-unit.git
+    rev: 3112d7ebe06d467238058a6384dc75ffd960d335
+    dependencies:
+      - aff
+      - avar
+      - effect
+      - either
+      - free
+      - js-timers
+      - lists
+      - prelude
+      - quickcheck
+      - strings
+  transformers:
+    type: git
+    url: https://github.com/purescript/purescript-transformers.git
+    rev: be72ab52357d9a665cbf93d73ba1c07c4b0957ee
+    dependencies:
+      - control
+      - distributive
+      - effect
+      - either
+      - exceptions
+      - foldable-traversable
+      - identity
+      - lazy
+      - maybe
+      - newtype
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  tuples:
+    type: git
+    url: https://github.com/purescript/purescript-tuples.git
+    rev: 4f52da2729b448c8564369378f1232d8d2dc1d8b
+    dependencies:
+      - control
+      - invariant
+      - prelude
+  type-equality:
+    type: git
+    url: https://github.com/purescript/purescript-type-equality.git
+    rev: 0525b7d39e0fbd81b4209518139fb8ab02695774
+    dependencies: []
+  typelevel-prelude:
+    type: git
+    url: https://github.com/purescript/purescript-typelevel-prelude.git
+    rev: dca2fe3c8cfd5527d4fe70c4bedfda30148405bf
+    dependencies:
+      - prelude
+      - type-equality
+  unfoldable:
+    type: git
+    url: https://github.com/purescript/purescript-unfoldable.git
+    rev: 493dfe04ed590e20d8f69079df2f58486882748d
+    dependencies:
+      - foldable-traversable
+      - maybe
+      - partial
+      - prelude
+      - tuples
+  unsafe-coerce:
+    type: git
+    url: https://github.com/purescript/purescript-unsafe-coerce.git
+    rev: ab956f82e66e633f647fb3098e8ddd3ec58d689f
+    dependencies: []

--- a/exercises/chapter11/spago.yaml
+++ b/exercises/chapter11/spago.yaml
@@ -1,0 +1,25 @@
+package:
+  dependencies:
+    - arrays
+    - console
+    - control
+    - effect
+    - either
+    - foldable-traversable
+    - identity
+    - lists
+    - maybe
+    - newtype
+    - node-readline
+    - optparse
+    - ordered-collections
+    - prelude
+    - strings
+    - test-unit
+    - transformers
+    - tuples
+  name: my-project
+workspace:
+  extraPackages: {}
+  packageSet:
+    url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json

--- a/exercises/chapter11/spago.yaml
+++ b/exercises/chapter11/spago.yaml
@@ -22,4 +22,4 @@ package:
 workspace:
   extraPackages: {}
   packageSet:
-    url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
+    registry: 10.0.0

--- a/exercises/chapter12/spago.lock
+++ b/exercises/chapter12/spago.lock
@@ -1,0 +1,4039 @@
+workspace:
+  packages:
+    my-project:
+      path: ./
+      dependencies:
+        - arrays
+        - canvas
+        - console
+        - effect
+        - foldable-traversable
+        - integers
+        - maybe
+        - numbers
+        - partial
+        - prelude
+        - random
+        - refs
+        - web-dom
+        - web-events
+        - web-html
+      test_dependencies: []
+      build_plan:
+        - arraybuffer-types
+        - arrays
+        - bifunctors
+        - canvas
+        - console
+        - const
+        - contravariant
+        - control
+        - datetime
+        - distributive
+        - effect
+        - either
+        - enums
+        - exceptions
+        - exists
+        - foldable-traversable
+        - foreign
+        - functions
+        - functors
+        - gen
+        - identity
+        - integers
+        - invariant
+        - js-date
+        - lazy
+        - lists
+        - maybe
+        - media-types
+        - newtype
+        - nonempty
+        - now
+        - nullable
+        - numbers
+        - ordered-collections
+        - orders
+        - partial
+        - prelude
+        - profunctor
+        - random
+        - refs
+        - safe-coerce
+        - st
+        - strings
+        - tailrec
+        - transformers
+        - tuples
+        - type-equality
+        - unfoldable
+        - unsafe-coerce
+        - web-dom
+        - web-events
+        - web-file
+        - web-html
+        - web-storage
+  package_set:
+    address:
+      url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
+    compiler: ">=0.15.0 <0.16.0"
+    content:
+      ace:
+        repo: https://github.com/purescript-contrib/purescript-ace.git
+        version: v9.0.0
+        dependencies:
+          - arrays
+          - effect
+          - foreign
+          - nullable
+          - prelude
+          - web-html
+          - web-uievents
+      aff:
+        repo: https://github.com/purescript-contrib/purescript-aff.git
+        version: v7.0.0
+        dependencies:
+          - datetime
+          - effect
+          - exceptions
+          - functions
+          - parallel
+          - transformers
+          - unsafe-coerce
+      aff-bus:
+        repo: https://github.com/purescript-contrib/purescript-aff-bus.git
+        version: v6.0.0
+        dependencies:
+          - aff
+          - avar
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - lists
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+      aff-coroutines:
+        repo: https://github.com/purescript-contrib/purescript-aff-coroutines.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - avar
+          - coroutines
+          - effect
+      aff-promise:
+        repo: https://github.com/nwolverson/purescript-aff-promise.git
+        version: v4.0.0
+        dependencies:
+          - aff
+          - foreign
+      aff-retry:
+        repo: https://github.com/Unisay/purescript-aff-retry.git
+        version: v2.0.0
+        dependencies:
+          - aff
+          - arrays
+          - datetime
+          - effect
+          - either
+          - exceptions
+          - integers
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - random
+          - transformers
+      affjax:
+        repo: https://github.com/purescript-contrib/purescript-affjax.git
+        version: v13.0.0
+        dependencies:
+          - aff
+          - argonaut-core
+          - arraybuffer-types
+          - foreign
+          - form-urlencoded
+          - http-methods
+          - integers
+          - media-types
+          - nullable
+          - refs
+          - unsafe-coerce
+          - web-xhr
+      affjax-node:
+        repo: https://github.com/purescript-contrib/purescript-affjax-node.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - affjax
+          - either
+          - maybe
+          - prelude
+      affjax-web:
+        repo: https://github.com/purescript-contrib/purescript-affjax-web.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - affjax
+          - either
+          - maybe
+          - prelude
+      ansi:
+        repo: https://github.com/hdgarrood/purescript-ansi.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - lists
+          - strings
+      argonaut:
+        repo: https://github.com/purescript-contrib/purescript-argonaut.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - argonaut-traversals
+      argonaut-codecs:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-codecs.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-core
+          - arrays
+          - effect
+          - foreign-object
+          - identity
+          - integers
+          - maybe
+          - nonempty
+          - ordered-collections
+          - prelude
+          - record
+      argonaut-core:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-core.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - foreign-object
+          - functions
+          - gen
+          - maybe
+          - nonempty
+          - prelude
+          - strings
+          - tailrec
+      argonaut-generic:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-generic.git
+        version: v8.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - prelude
+          - record
+      argonaut-traversals:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-traversals.git
+        version: v10.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - profunctor-lenses
+      argparse-basic:
+        repo: https://github.com/natefaubion/purescript-argparse-basic.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - record
+          - strings
+          - tuples
+          - unfoldable
+      arraybuffer:
+        repo: https://github.com/purescript-contrib/purescript-arraybuffer.git
+        version: v13.0.0
+        dependencies:
+          - arraybuffer-types
+          - arrays
+          - effect
+          - float32
+          - functions
+          - gen
+          - maybe
+          - nullable
+          - prelude
+          - tailrec
+          - uint
+          - unfoldable
+      arraybuffer-builder:
+        repo: https://github.com/jamesdbrock/purescript-arraybuffer-builder.git
+        version: v3.0.1
+        dependencies:
+          - arraybuffer
+          - arraybuffer-types
+          - effect
+          - float32
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - transformers
+          - uint
+      arraybuffer-types:
+        repo: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
+        version: v3.0.2
+        dependencies: []
+      arrays:
+        repo: https://github.com/purescript/purescript-arrays.git
+        version: v7.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - foldable-traversable
+          - maybe
+          - nonempty
+          - partial
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - unfoldable
+          - unsafe-coerce
+      arrays-zipper:
+        repo: https://github.com/JordanMartinez/purescript-arrays-zipper.git
+        version: v2.0.1
+        dependencies:
+          - arrays
+          - control
+          - quickcheck
+      ask:
+        repo: https://github.com/Mateiadrielrafael/purescript-ask.git
+        version: v1.0.0
+        dependencies:
+          - unsafe-coerce
+      assert:
+        repo: https://github.com/purescript/purescript-assert.git
+        version: v6.0.0
+        dependencies:
+          - console
+          - effect
+          - prelude
+      avar:
+        repo: https://github.com/purescript-contrib/purescript-avar.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - exceptions
+          - functions
+          - maybe
+      b64:
+        repo: https://github.com/menelaos/purescript-b64.git
+        version: v0.0.8
+        dependencies:
+          - arraybuffer-types
+          - either
+          - encoding
+          - enums
+          - exceptions
+          - functions
+          - partial
+          - prelude
+          - strings
+      barlow-lens:
+        repo: https://github.com/sigma-andex/purescript-barlow-lens.git
+        version: v0.9.0
+        dependencies:
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - profunctor-lenses
+          - tuples
+          - typelevel-prelude
+      bifunctors:
+        repo: https://github.com/purescript/purescript-bifunctors.git
+        version: v6.0.0
+        dependencies:
+          - const
+          - either
+          - newtype
+          - prelude
+          - tuples
+      bigints:
+        repo: https://github.com/sharkdp/purescript-bigints.git
+        version: v7.0.1
+        dependencies:
+          - integers
+          - maybe
+          - strings
+      bower-json:
+        repo: https://github.com/klntsky/purescript-bower-json.git
+        version: v3.0.0
+        dependencies:
+          - argonaut-codecs
+          - arrays
+          - either
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - newtype
+          - prelude
+          - tuples
+      call-by-name:
+        repo: https://github.com/natefaubion/purescript-call-by-name.git
+        version: v4.0.1
+        dependencies:
+          - control
+          - either
+          - lazy
+          - maybe
+          - unsafe-coerce
+      canvas:
+        repo: https://github.com/purescript-web/purescript-canvas.git
+        version: v6.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - exceptions
+          - functions
+          - maybe
+      canvas-action:
+        repo: https://github.com/artemisSystem/purescript-canvas-action.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - arrays
+          - canvas
+          - colors
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - maybe
+          - numbers
+          - polymorphic-vectors
+          - prelude
+          - refs
+          - run
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-html
+      cartesian:
+        repo: https://github.com/Ebmtranceboy/purescript-cartesian.git
+        version: v1.0.6
+        dependencies:
+          - console
+          - effect
+          - integers
+          - psci-support
+      catenable-lists:
+        repo: https://github.com/purescript/purescript-catenable-lists.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - lists
+          - maybe
+          - prelude
+          - tuples
+          - unfoldable
+      channel:
+        repo: https://github.com/ConnorDillon/purescript-channel.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - assert
+          - avar
+          - console
+          - contravariant
+          - control
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - lazy
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      checked-exceptions:
+        repo: https://github.com/natefaubion/purescript-checked-exceptions.git
+        version: v3.1.1
+        dependencies:
+          - prelude
+          - transformers
+          - variant
+      codec:
+        repo: https://github.com/garyb/purescript-codec.git
+        version: v5.0.0
+        dependencies:
+          - profunctor
+          - transformers
+      codec-argonaut:
+        repo: https://github.com/garyb/purescript-codec-argonaut.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-core
+          - codec
+          - ordered-collections
+          - type-equality
+          - variant
+      colors:
+        repo: https://github.com/purescript-contrib/purescript-colors.git
+        version: v7.0.1
+        dependencies:
+          - arrays
+          - integers
+          - lists
+          - numbers
+          - partial
+          - strings
+      concurrent-queues:
+        repo: https://github.com/purescript-contrib/purescript-concurrent-queues.git
+        version: v3.0.0
+        dependencies:
+          - aff
+          - avar
+          - effect
+      console:
+        repo: https://github.com/purescript/purescript-console.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - prelude
+      const:
+        repo: https://github.com/purescript/purescript-const.git
+        version: v6.0.0
+        dependencies:
+          - invariant
+          - newtype
+          - prelude
+      contravariant:
+        repo: https://github.com/purescript/purescript-contravariant.git
+        version: v6.0.0
+        dependencies:
+          - const
+          - either
+          - newtype
+          - prelude
+          - tuples
+      control:
+        repo: https://github.com/purescript/purescript-control.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      convertable-options:
+        repo: https://github.com/natefaubion/purescript-convertable-options.git
+        version: v1.0.0
+        dependencies:
+          - console
+          - effect
+          - maybe
+          - record
+      coroutines:
+        repo: https://github.com/purescript-contrib/purescript-coroutines.git
+        version: v7.0.0
+        dependencies:
+          - freet
+          - parallel
+          - profunctor
+      css:
+        repo: https://github.com/purescript-contrib/purescript-css.git
+        version: v6.0.0
+        dependencies:
+          - colors
+          - console
+          - effect
+          - nonempty
+          - profunctor
+          - strings
+          - these
+          - transformers
+      datetime:
+        repo: https://github.com/purescript/purescript-datetime.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - either
+          - enums
+          - foldable-traversable
+          - functions
+          - gen
+          - integers
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - ordered-collections
+          - partial
+          - prelude
+          - tuples
+      datetime-parsing:
+        repo: https://github.com/flounders/purescript-datetime-parsing.git
+        version: v0.2.0
+        dependencies:
+          - arrays
+          - datetime
+          - either
+          - enums
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - numbers
+          - parsing
+          - prelude
+          - strings
+          - unicode
+      debug:
+        repo: https://github.com/garyb/purescript-debug.git
+        version: v6.0.0
+        dependencies:
+          - functions
+          - prelude
+      decimals:
+        repo: https://github.com/sharkdp/purescript-decimals.git
+        version: v7.0.0
+        dependencies:
+          - maybe
+      dissect:
+        repo: https://github.com/PureFunctor/purescript-dissect.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - foreign-object
+          - functors
+          - newtype
+          - partial
+          - prelude
+          - tailrec
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - variant
+      distributive:
+        repo: https://github.com/purescript/purescript-distributive.git
+        version: v6.0.0
+        dependencies:
+          - identity
+          - newtype
+          - prelude
+          - tuples
+          - type-equality
+      dodo-printer:
+        repo: https://github.com/natefaubion/purescript-dodo-printer.git
+        version: v2.2.0
+        dependencies:
+          - aff
+          - ansi
+          - avar
+          - console
+          - effect
+          - foldable-traversable
+          - lists
+          - maybe
+          - minibench
+          - node-child-process
+          - node-fs-aff
+          - node-process
+          - psci-support
+          - strings
+      dom-indexed:
+        repo: https://github.com/purescript-halogen/purescript-dom-indexed.git
+        version: v11.0.0
+        dependencies:
+          - media-types
+          - prelude
+          - web-clipboard
+          - web-pointerevents
+          - web-touchevents
+      droplet:
+        repo: https://github.com/easafe/purescript-droplet.git
+        version: v0.4.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - bigints
+          - datetime
+          - debug
+          - effect
+          - either
+          - enums
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - integers
+          - maybe
+          - newtype
+          - nullable
+          - ordered-collections
+          - partial
+          - prelude
+          - profunctor
+          - record
+          - spec
+          - strings
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+      dynamic-buffer:
+        repo: https://github.com/kritzcreek/purescript-dynamic-buffer.git
+        version: v3.0.1
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - refs
+      effect:
+        repo: https://github.com/purescript/purescript-effect.git
+        version: v4.0.0
+        dependencies:
+          - prelude
+      either:
+        repo: https://github.com/purescript/purescript-either.git
+        version: v6.1.0
+        dependencies:
+          - control
+          - invariant
+          - maybe
+          - prelude
+      elmish:
+        repo: https://github.com/collegevine/purescript-elmish.git
+        version: v0.8.1
+        dependencies:
+          - aff
+          - argonaut-core
+          - arrays
+          - bifunctors
+          - console
+          - debug
+          - effect
+          - either
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - functions
+          - integers
+          - js-date
+          - maybe
+          - nullable
+          - partial
+          - prelude
+          - refs
+          - typelevel-prelude
+          - undefined-is-not-a-problem
+          - unsafe-coerce
+          - web-dom
+          - web-html
+      elmish-enzyme:
+        repo: https://github.com/collegevine/purescript-elmish-enzyme.git
+        version: v0.1.1
+        dependencies:
+          - aff
+          - aff-promise
+          - arrays
+          - console
+          - debug
+          - effect
+          - elmish
+          - foldable-traversable
+          - foreign
+          - functions
+          - prelude
+          - transformers
+          - unsafe-coerce
+      elmish-hooks:
+        repo: https://github.com/collegevine/purescript-elmish-hooks.git
+        version: v0.8.2
+        dependencies:
+          - aff
+          - debug
+          - elmish
+          - maybe
+          - prelude
+          - tuples
+          - undefined-is-not-a-problem
+      elmish-html:
+        repo: https://github.com/collegevine/purescript-elmish-html.git
+        version: v0.7.1
+        dependencies:
+          - effect
+          - elmish
+          - foreign
+          - foreign-object
+          - prelude
+          - record
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-html
+      email-validate:
+        repo: https://github.com/cdepillabout/purescript-email-validate.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - string-parsers
+          - transformers
+      encoding:
+        repo: https://github.com/menelaos/purescript-encoding.git
+        version: v0.0.8
+        dependencies:
+          - arraybuffer-types
+          - either
+          - exceptions
+          - functions
+          - prelude
+      enums:
+        repo: https://github.com/purescript/purescript-enums.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - either
+          - gen
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tuples
+          - unfoldable
+      exceptions:
+        repo: https://github.com/purescript/purescript-exceptions.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - either
+          - maybe
+          - prelude
+      exists:
+        repo: https://github.com/purescript/purescript-exists.git
+        version: v6.0.0
+        dependencies:
+          - unsafe-coerce
+      exitcodes:
+        repo: https://github.com/Risto-Stevcev/purescript-exitcodes.git
+        version: v4.0.0
+        dependencies:
+          - enums
+      expect-inferred:
+        repo: https://github.com/justinwoo/purescript-expect-inferred.git
+        version: v3.0.0
+        dependencies:
+          - prelude
+          - typelevel-prelude
+      fast-vect:
+        repo: https://github.com/sigma-andex/purescript-fast-vect.git
+        version: v0.7.0
+        dependencies:
+          - arrays
+          - filterable
+          - foldable-traversable
+          - lists
+          - maybe
+          - ordered-collections
+          - prelude
+          - profunctor
+          - tuples
+          - unfoldable
+      filterable:
+        repo: https://github.com/purescript/purescript-filterable.git
+        version: v5.0.0
+        dependencies:
+          - arrays
+          - either
+          - foldable-traversable
+          - identity
+          - lists
+          - ordered-collections
+      fixed-points:
+        repo: https://github.com/purescript-contrib/purescript-fixed-points.git
+        version: v7.0.0
+        dependencies:
+          - exists
+          - newtype
+          - prelude
+          - transformers
+      fixed-precision:
+        repo: https://github.com/lumihq/purescript-fixed-precision.git
+        version: v5.0.0
+        dependencies:
+          - arrays
+          - bigints
+          - control
+          - integers
+          - maybe
+          - numbers
+          - partial
+          - prelude
+          - strings
+      flame:
+        repo: https://github.com/easafe/purescript-flame.git
+        version: v1.2.0
+        dependencies:
+          - aff
+          - argonaut-codecs
+          - argonaut-core
+          - argonaut-generic
+          - arrays
+          - bifunctors
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - maybe
+          - newtype
+          - nullable
+          - partial
+          - prelude
+          - random
+          - refs
+          - spec
+          - strings
+          - tuples
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-html
+          - web-uievents
+      float32:
+        repo: https://github.com/purescript-contrib/purescript-float32.git
+        version: v2.0.0
+        dependencies:
+          - gen
+          - maybe
+          - prelude
+      foldable-traversable:
+        repo: https://github.com/purescript/purescript-foldable-traversable.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - const
+          - control
+          - either
+          - functors
+          - identity
+          - maybe
+          - newtype
+          - orders
+          - prelude
+          - tuples
+      foreign:
+        repo: https://github.com/purescript/purescript-foreign.git
+        version: v7.0.0
+        dependencies:
+          - either
+          - functions
+          - identity
+          - integers
+          - lists
+          - maybe
+          - prelude
+          - strings
+          - transformers
+      foreign-object:
+        repo: https://github.com/purescript/purescript-foreign-object.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - functions
+          - gen
+          - lists
+          - maybe
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - typelevel-prelude
+          - unfoldable
+      foreign-readwrite:
+        repo: https://github.com/artemisSystem/purescript-foreign-readwrite.git
+        version: v3.0.0
+        dependencies:
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - record
+          - safe-coerce
+          - transformers
+          - unsafe-coerce
+      fork:
+        repo: https://github.com/purescript-contrib/purescript-fork.git
+        version: v6.0.0
+        dependencies:
+          - aff
+      form-urlencoded:
+        repo: https://github.com/purescript-contrib/purescript-form-urlencoded.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - js-uri
+          - maybe
+          - newtype
+          - prelude
+          - strings
+          - tuples
+      formatters:
+        repo: https://github.com/purescript-contrib/purescript-formatters.git
+        version: v7.0.0
+        dependencies:
+          - datetime
+          - fixed-points
+          - lists
+          - numbers
+          - parsing
+          - prelude
+          - transformers
+      free:
+        repo: https://github.com/purescript/purescript-free.git
+        version: v7.0.0
+        dependencies:
+          - catenable-lists
+          - control
+          - distributive
+          - either
+          - exists
+          - foldable-traversable
+          - invariant
+          - lazy
+          - maybe
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+      freeap:
+        repo: https://github.com/ethul/purescript-freeap.git
+        version: v7.0.0
+        dependencies:
+          - const
+          - exists
+          - gen
+          - lists
+      freet:
+        repo: https://github.com/purescript-contrib/purescript-freet.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - bifunctors
+          - effect
+          - either
+          - exists
+          - free
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      functions:
+        repo: https://github.com/purescript/purescript-functions.git
+        version: v6.0.0
+        dependencies:
+          - prelude
+      functors:
+        repo: https://github.com/purescript/purescript-functors.git
+        version: v5.0.0
+        dependencies:
+          - bifunctors
+          - const
+          - contravariant
+          - control
+          - distributive
+          - either
+          - invariant
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - tuples
+          - unsafe-coerce
+      fuzzy:
+        repo: https://github.com/citizennet/purescript-fuzzy.git
+        version: v0.4.0
+        dependencies:
+          - foldable-traversable
+          - foreign-object
+          - newtype
+          - ordered-collections
+          - prelude
+          - rationals
+          - strings
+          - tuples
+      gen:
+        repo: https://github.com/purescript/purescript-gen.git
+        version: v4.0.0
+        dependencies:
+          - either
+          - foldable-traversable
+          - identity
+          - maybe
+          - newtype
+          - nonempty
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      generate-values:
+        repo: https://github.com/jordanmartinez/purescript-generate-values.git
+        version: v1.0.1
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - enums
+          - foldable-traversable
+          - gen
+          - identity
+          - integers
+          - lcg
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - partial
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      geometry-plane:
+        repo: https://github.com/Ebmtranceboy/purescript-geometry-plane.git
+        version: v1.0.3
+        dependencies:
+          - console
+          - effect
+          - psci-support
+          - sparse-polynomials
+      github-actions-toolkit:
+        repo: https://github.com/purescript-contrib/purescript-github-actions-toolkit.git
+        version: v0.5.0
+        dependencies:
+          - aff
+          - aff-promise
+          - effect
+          - foreign-object
+          - node-buffer
+          - node-path
+          - node-streams
+          - nullable
+          - transformers
+      graphs:
+        repo: https://github.com/purescript/purescript-graphs.git
+        version: v8.0.0
+        dependencies:
+          - catenable-lists
+          - ordered-collections
+      group:
+        repo: https://github.com/morganthomas/purescript-group.git
+        version: v4.1.1
+        dependencies:
+          - lists
+      halogen:
+        repo: https://github.com/purescript-halogen/purescript-halogen.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - avar
+          - console
+          - const
+          - dom-indexed
+          - effect
+          - foreign
+          - fork
+          - free
+          - freeap
+          - halogen-subscriptions
+          - halogen-vdom
+          - media-types
+          - nullable
+          - ordered-collections
+          - parallel
+          - profunctor
+          - transformers
+          - unsafe-coerce
+          - unsafe-reference
+          - web-file
+          - web-uievents
+      halogen-css:
+        repo: https://github.com/purescript-halogen/purescript-halogen-css.git
+        version: v10.0.0
+        dependencies:
+          - css
+          - halogen
+      halogen-formless:
+        repo: https://github.com/thomashoneyman/purescript-halogen-formless.git
+        version: v4.0.0
+        dependencies:
+          - convertable-options
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - halogen
+          - heterogeneous
+          - maybe
+          - prelude
+          - record
+          - safe-coerce
+          - type-equality
+          - unsafe-coerce
+          - unsafe-reference
+          - variant
+          - web-events
+          - web-uievents
+      halogen-hooks:
+        repo: https://github.com/thomashoneyman/purescript-halogen-hooks.git
+        version: v0.6.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - effect
+          - exceptions
+          - foldable-traversable
+          - foreign-object
+          - free
+          - freeap
+          - halogen
+          - halogen-subscriptions
+          - maybe
+          - newtype
+          - ordered-collections
+          - parallel
+          - partial
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+          - unsafe-reference
+          - web-dom
+          - web-html
+      halogen-hooks-extra:
+        repo: https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git
+        version: v0.9.0
+        dependencies:
+          - halogen-hooks
+      halogen-store:
+        repo: https://github.com/thomashoneyman/purescript-halogen-store.git
+        version: v0.5.0
+        dependencies:
+          - aff
+          - distributive
+          - effect
+          - fork
+          - halogen
+          - halogen-hooks
+          - halogen-subscriptions
+          - maybe
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-reference
+      halogen-storybook:
+        repo: https://github.com/rnons/purescript-halogen-storybook.git
+        version: v2.0.0
+        dependencies:
+          - foreign-object
+          - halogen
+          - prelude
+          - routing
+      halogen-subscriptions:
+        repo: https://github.com/purescript-halogen/purescript-halogen-subscriptions.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - effect
+          - foldable-traversable
+          - functors
+          - refs
+          - safe-coerce
+          - unsafe-reference
+      halogen-svg-elems:
+        repo: https://github.com/JordanMartinez/purescript-halogen-svg-elems.git
+        version: v6.0.0
+        dependencies:
+          - halogen
+      halogen-vdom:
+        repo: https://github.com/purescript-halogen/purescript-halogen-vdom.git
+        version: v8.0.0
+        dependencies:
+          - bifunctors
+          - effect
+          - foreign
+          - foreign-object
+          - maybe
+          - prelude
+          - refs
+          - tuples
+          - unsafe-coerce
+          - web-html
+      halogen-vdom-string-renderer:
+        repo: https://github.com/purescript-halogen/purescript-halogen-vdom-string-renderer.git
+        version: v0.5.0
+        dependencies:
+          - foreign
+          - halogen-vdom
+          - ordered-collections
+          - prelude
+      heckin:
+        repo: https://github.com/maxdeviant/purescript-heckin.git
+        version: v2.0.1
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - maybe
+          - prelude
+          - strings
+          - transformers
+          - tuples
+          - unicode
+      heterogeneous:
+        repo: https://github.com/natefaubion/purescript-heterogeneous.git
+        version: v0.6.0
+        dependencies:
+          - either
+          - functors
+          - prelude
+          - record
+          - tuples
+          - variant
+      heterogeneous-extrablatt:
+        repo: https://github.com/sigma-andex/purescript-heterogeneous-extrablatt.git
+        version: v0.2.1
+        dependencies:
+          - heterogeneous
+          - prelude
+          - record
+      http-methods:
+        repo: https://github.com/purescript-contrib/purescript-http-methods.git
+        version: v6.0.0
+        dependencies:
+          - either
+          - prelude
+          - strings
+      httpure:
+        repo: https://github.com/citizennet/purescript-httpure.git
+        version: v0.15.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - js-uri
+          - maybe
+          - newtype
+          - node-buffer
+          - node-fs
+          - node-http
+          - node-streams
+          - options
+          - ordered-collections
+          - prelude
+          - refs
+          - strings
+          - tuples
+          - type-equality
+      httpurple:
+        repo: https://github.com/sigma-andex/purescript-httpurple.git
+        version: v1.3.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - js-uri
+          - justifill
+          - maybe
+          - newtype
+          - node-buffer
+          - node-fs
+          - node-http
+          - node-net
+          - node-process
+          - node-streams
+          - options
+          - ordered-collections
+          - posix-types
+          - prelude
+          - profunctor
+          - record
+          - refs
+          - routing-duplex
+          - strings
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+      httpurple-argonaut:
+        repo: https://github.com/sigma-andex/purescript-httpurple-argonaut.git
+        version: v1.0.1
+        dependencies:
+          - argonaut
+          - console
+          - effect
+          - either
+          - httpurple
+          - prelude
+      httpurple-yoga-json:
+        repo: https://github.com/sigma-andex/purescript-httpurple-yoga-json.git
+        version: v1.0.0
+        dependencies:
+          - console
+          - effect
+          - either
+          - foreign
+          - httpurple
+          - lists
+          - prelude
+          - yoga-json
+      identity:
+        repo: https://github.com/purescript/purescript-identity.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - invariant
+          - newtype
+          - prelude
+      indexed-monad:
+        repo: https://github.com/garyb/purescript-indexed-monad.git
+        version: v2.1.0
+        dependencies:
+          - control
+          - newtype
+      int64:
+        repo: https://github.com/purescript-contrib/purescript-int64.git
+        version: v2.0.0
+        dependencies:
+          - effect
+          - foreign
+          - functions
+          - integers
+          - maybe
+          - nullable
+          - prelude
+          - quickcheck
+      integers:
+        repo: https://github.com/purescript/purescript-integers.git
+        version: v6.0.0
+        dependencies:
+          - maybe
+          - numbers
+          - prelude
+      interpolate:
+        repo: https://github.com/jordanmartinez/purescript-interpolate.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+      invariant:
+        repo: https://github.com/purescript/purescript-invariant.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - prelude
+      js-date:
+        repo: https://github.com/purescript-contrib/purescript-js-date.git
+        version: v8.0.0
+        dependencies:
+          - datetime
+          - effect
+          - exceptions
+          - foreign
+          - integers
+          - now
+      js-fileio:
+        repo: https://github.com/newlandsvalley/purescript-js-fileio.git
+        version: v3.0.0
+        dependencies:
+          - aff
+          - effect
+          - prelude
+      js-timers:
+        repo: https://github.com/purescript-contrib/purescript-js-timers.git
+        version: v6.1.0
+        dependencies:
+          - effect
+      js-uri:
+        repo: https://github.com/purescript-contrib/purescript-js-uri.git
+        version: v3.0.0
+        dependencies:
+          - functions
+          - maybe
+      justifill:
+        repo: https://github.com/i-am-the-slime/purescript-justifill.git
+        version: v0.5.0
+        dependencies:
+          - maybe
+          - prelude
+          - record
+          - typelevel-prelude
+      jwt:
+        repo: https://github.com/menelaos/purescript-jwt.git
+        version: v0.0.9
+        dependencies:
+          - argonaut-core
+          - arrays
+          - b64
+          - either
+          - exceptions
+          - prelude
+          - profunctor-lenses
+          - strings
+      language-cst-parser:
+        repo: https://github.com/natefaubion/purescript-language-cst-parser.git
+        version: v0.12.0
+        dependencies:
+          - arrays
+          - const
+          - control
+          - either
+          - foldable-traversable
+          - free
+          - functions
+          - functors
+          - identity
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - ordered-collections
+          - partial
+          - prelude
+          - st
+          - strings
+          - transformers
+          - tuples
+          - typelevel-prelude
+          - unfoldable
+          - unsafe-coerce
+      lazy:
+        repo: https://github.com/purescript/purescript-lazy.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - invariant
+          - prelude
+      lcg:
+        repo: https://github.com/purescript/purescript-lcg.git
+        version: v4.0.0
+        dependencies:
+          - effect
+          - integers
+          - maybe
+          - partial
+          - prelude
+          - random
+      leibniz:
+        repo: https://github.com/paf31/purescript-leibniz.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+          - unsafe-coerce
+      linalg:
+        repo: https://github.com/gbagan/purescript-linalg.git
+        version: v5.1.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - functions
+          - maybe
+          - prelude
+          - tuples
+      lists:
+        repo: https://github.com/purescript/purescript-lists.git
+        version: v7.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - foldable-traversable
+          - lazy
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      logging:
+        repo: https://github.com/rightfold/purescript-logging.git
+        version: v3.0.0
+        dependencies:
+          - console
+          - contravariant
+          - effect
+          - either
+          - prelude
+          - transformers
+          - tuples
+      machines:
+        repo: https://github.com/purescript-contrib/purescript-machines.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - lists
+          - maybe
+          - prelude
+          - profunctor
+          - tuples
+          - unfoldable
+      matrices:
+        repo: https://github.com/kRITZCREEK/purescript-matrices.git
+        version: v5.0.1
+        dependencies:
+          - arrays
+          - strings
+      matryoshka:
+        repo: https://github.com/purescript-contrib/purescript-matryoshka.git
+        version: v1.0.0
+        dependencies:
+          - fixed-points
+          - free
+          - prelude
+          - profunctor
+          - transformers
+      maybe:
+        repo: https://github.com/purescript/purescript-maybe.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - invariant
+          - newtype
+          - prelude
+      media-types:
+        repo: https://github.com/purescript-contrib/purescript-media-types.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      metadata:
+        repo: https://github.com/purescript/purescript-metadata.git
+        version: v0.15.0
+        dependencies: []
+      midi:
+        repo: https://github.com/newlandsvalley/purescript-midi.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - ordered-collections
+          - prelude
+          - signal
+          - string-parsers
+          - strings
+          - tuples
+          - unfoldable
+      minibench:
+        repo: https://github.com/purescript/purescript-minibench.git
+        version: v4.0.0
+        dependencies:
+          - console
+          - effect
+          - integers
+          - numbers
+          - partial
+          - prelude
+          - refs
+      mmorph:
+        repo: https://github.com/Thimoteus/purescript-mmorph.git
+        version: v7.0.0
+        dependencies:
+          - free
+          - functors
+          - transformers
+      monad-control:
+        repo: https://github.com/athanclark/purescript-monad-control.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - freet
+          - identity
+          - lists
+      monad-logger:
+        repo: https://github.com/cprussin/purescript-monad-logger.git
+        version: v1.3.1
+        dependencies:
+          - aff
+          - ansi
+          - argonaut
+          - arrays
+          - console
+          - control
+          - effect
+          - foldable-traversable
+          - foreign-object
+          - integers
+          - js-date
+          - maybe
+          - newtype
+          - ordered-collections
+          - prelude
+          - strings
+          - transformers
+          - tuples
+      monad-loops:
+        repo: https://github.com/mlang/purescript-monad-loops.git
+        version: v0.5.0
+        dependencies:
+          - lists
+          - maybe
+          - prelude
+          - tailrec
+          - tuples
+      monad-unlift:
+        repo: https://github.com/athanclark/purescript-monad-unlift.git
+        version: v1.0.1
+        dependencies:
+          - monad-control
+      monoidal:
+        repo: https://github.com/mcneissue/purescript-monoidal.git
+        version: v0.16.0
+        dependencies:
+          - either
+          - profunctor
+          - these
+          - tuples
+      morello:
+        repo: https://github.com/sigma-andex/purescript-morello.git
+        version: v0.3.2
+        dependencies:
+          - arrays
+          - barlow-lens
+          - foldable-traversable
+          - heterogeneous
+          - heterogeneous-extrablatt
+          - newtype
+          - prelude
+          - profunctor
+          - profunctor-lenses
+          - record
+          - tuples
+          - typelevel-prelude
+          - validation
+      motsunabe:
+        repo: https://github.com/justinwoo/purescript-motsunabe.git
+        version: v2.0.0
+        dependencies:
+          - lists
+          - strings
+      nano-id:
+        repo: https://github.com/eikooc/nano-id.git
+        version: v1.1.0
+        dependencies:
+          - aff
+          - effect
+          - lists
+          - maybe
+          - prelude
+          - random
+          - spec
+          - strings
+          - stringutils
+      naturals:
+        repo: https://github.com/LiamGoodacre/purescript-naturals.git
+        version: v3.0.0
+        dependencies:
+          - enums
+          - maybe
+          - prelude
+      nested-functor:
+        repo: https://github.com/acple/purescript-nested-functor.git
+        version: v0.2.1
+        dependencies:
+          - prelude
+          - type-equality
+      newtype:
+        repo: https://github.com/purescript/purescript-newtype.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+          - safe-coerce
+      node-buffer:
+        repo: https://github.com/purescript-node/purescript-node-buffer.git
+        version: v8.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - maybe
+          - st
+          - unsafe-coerce
+      node-buffer-blob:
+        repo: https://github.com/purescript-node/purescript-node-buffer-blob.git
+        version: v1.0.0
+        dependencies:
+          - aff-promise
+          - arraybuffer-types
+          - arrays
+          - console
+          - effect
+          - maybe
+          - media-types
+          - newtype
+          - node-buffer
+          - nullable
+          - prelude
+          - web-streams
+      node-child-process:
+        repo: https://github.com/purescript-node/purescript-node-child-process.git
+        version: v9.0.0
+        dependencies:
+          - exceptions
+          - foreign
+          - foreign-object
+          - functions
+          - node-fs
+          - node-streams
+          - nullable
+          - posix-types
+          - unsafe-coerce
+      node-fs:
+        repo: https://github.com/purescript-node/purescript-node-fs.git
+        version: v8.0.0
+        dependencies:
+          - datetime
+          - effect
+          - either
+          - enums
+          - exceptions
+          - functions
+          - integers
+          - js-date
+          - maybe
+          - node-buffer
+          - node-path
+          - node-streams
+          - nullable
+          - partial
+          - prelude
+          - strings
+          - unsafe-coerce
+      node-fs-aff:
+        repo: https://github.com/purescript-node/purescript-node-fs-aff.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - either
+          - node-fs
+          - node-path
+      node-http:
+        repo: https://github.com/purescript-node/purescript-node-http.git
+        version: v8.0.0
+        dependencies:
+          - arraybuffer-types
+          - contravariant
+          - effect
+          - foreign
+          - foreign-object
+          - maybe
+          - node-buffer
+          - node-net
+          - node-streams
+          - node-url
+          - nullable
+          - options
+          - prelude
+          - unsafe-coerce
+      node-net:
+        repo: https://github.com/purescript-node/purescript-node-net.git
+        version: v4.0.0
+        dependencies:
+          - effect
+          - either
+          - exceptions
+          - foreign
+          - maybe
+          - node-buffer
+          - node-fs
+          - nullable
+          - options
+          - prelude
+          - transformers
+      node-path:
+        repo: https://github.com/purescript-node/purescript-node-path.git
+        version: v5.0.0
+        dependencies:
+          - effect
+      node-process:
+        repo: https://github.com/purescript-node/purescript-node-process.git
+        version: v10.0.0
+        dependencies:
+          - effect
+          - foreign-object
+          - maybe
+          - node-streams
+          - posix-types
+          - prelude
+          - unsafe-coerce
+      node-readline:
+        repo: https://github.com/purescript-node/purescript-node-readline.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - foreign
+          - node-process
+          - node-streams
+          - options
+          - prelude
+      node-streams:
+        repo: https://github.com/purescript-node/purescript-node-streams.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - either
+          - exceptions
+          - node-buffer
+          - nullable
+          - prelude
+      node-streams-aff:
+        repo: https://github.com/jamesdbrock/purescript-node-streams-aff.git
+        version: v2.0.0
+        dependencies:
+          - aff
+          - arrays
+          - effect
+          - either
+          - exceptions
+          - maybe
+          - node-buffer
+          - node-streams
+          - prelude
+          - st
+          - tuples
+      node-url:
+        repo: https://github.com/purescript-node/purescript-node-url.git
+        version: v6.0.0
+        dependencies:
+          - nullable
+      nonempty:
+        repo: https://github.com/purescript/purescript-nonempty.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - maybe
+          - prelude
+          - tuples
+          - unfoldable
+      now:
+        repo: https://github.com/purescript-contrib/purescript-now.git
+        version: v6.0.0
+        dependencies:
+          - datetime
+          - effect
+      npm-package-json:
+        repo: https://github.com/maxdeviant/purescript-npm-package-json.git
+        version: v2.0.0
+        dependencies:
+          - argonaut
+          - control
+          - either
+          - foreign-object
+          - maybe
+          - ordered-collections
+          - prelude
+      nullable:
+        repo: https://github.com/purescript-contrib/purescript-nullable.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - functions
+          - maybe
+      numbers:
+        repo: https://github.com/purescript/purescript-numbers.git
+        version: v9.0.0
+        dependencies:
+          - functions
+          - maybe
+      open-folds:
+        repo: https://github.com/purescript-open-community/purescript-open-folds.git
+        version: v6.3.0
+        dependencies:
+          - bifunctors
+          - console
+          - control
+          - distributive
+          - effect
+          - either
+          - foldable-traversable
+          - identity
+          - invariant
+          - maybe
+          - newtype
+          - ordered-collections
+          - prelude
+          - profunctor
+          - psci-support
+          - tuples
+      open-memoize:
+        repo: https://github.com/purescript-open-community/purescript-open-memoize.git
+        version: v6.1.0
+        dependencies:
+          - console
+          - effect
+          - either
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - psci-support
+          - strings
+          - tuples
+      open-pairing:
+        repo: https://github.com/purescript-open-community/purescript-open-pairing.git
+        version: v6.1.0
+        dependencies:
+          - console
+          - control
+          - effect
+          - either
+          - free
+          - functors
+          - identity
+          - newtype
+          - prelude
+          - psci-support
+          - transformers
+          - tuples
+      options:
+        repo: https://github.com/purescript-contrib/purescript-options.git
+        version: v7.0.0
+        dependencies:
+          - contravariant
+          - foreign
+          - foreign-object
+          - maybe
+          - tuples
+      optparse:
+        repo: https://github.com/f-o-a-m/purescript-optparse.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - control
+          - effect
+          - either
+          - enums
+          - exists
+          - exitcodes
+          - foldable-traversable
+          - free
+          - gen
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - newtype
+          - node-buffer
+          - node-process
+          - node-streams
+          - nonempty
+          - numbers
+          - open-memoize
+          - partial
+          - prelude
+          - quickcheck
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+      ordered-collections:
+        repo: https://github.com/purescript/purescript-ordered-collections.git
+        version: v3.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - gen
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - unfoldable
+      ordered-set:
+        repo: https://github.com/flip111/purescript-ordered-set.git
+        version: v0.4.0
+        dependencies:
+          - argonaut-codecs
+          - arrays
+          - partial
+          - prelude
+          - unfoldable
+      orders:
+        repo: https://github.com/purescript/purescript-orders.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      pairs:
+        repo: https://github.com/sharkdp/purescript-pairs.git
+        version: v9.0.0
+        dependencies:
+          - console
+          - distributive
+          - foldable-traversable
+          - quickcheck
+      parallel:
+        repo: https://github.com/purescript/purescript-parallel.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - functors
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - refs
+          - transformers
+      parsing:
+        repo: https://github.com/purescript-contrib/purescript-parsing.git
+        version: v9.1.0
+        dependencies:
+          - arrays
+          - either
+          - foldable-traversable
+          - identity
+          - integers
+          - lists
+          - maybe
+          - nullable
+          - prelude
+          - strings
+          - transformers
+          - unicode
+      parsing-dataview:
+        repo: https://github.com/jamesdbrock/purescript-parsing-dataview.git
+        version: v3.1.0
+        dependencies:
+          - arraybuffer
+          - arraybuffer-types
+          - effect
+          - float32
+          - maybe
+          - parsing
+          - prelude
+          - transformers
+          - tuples
+          - uint
+      partial:
+        repo: https://github.com/purescript/purescript-partial.git
+        version: v4.0.0
+        dependencies: []
+      pathy:
+        repo: https://github.com/purescript-contrib/purescript-pathy.git
+        version: v9.0.0
+        dependencies:
+          - console
+          - exceptions
+          - lists
+          - partial
+          - profunctor
+          - strings
+          - transformers
+          - typelevel-prelude
+          - unsafe-coerce
+      pha:
+        repo: https://github.com/gbagan/purescript-pha.git
+        version: v0.9.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - datetime
+          - effect
+          - foldable-traversable
+          - free
+          - integers
+          - maybe
+          - prelude
+          - profunctor-lenses
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+          - unsafe-reference
+          - web-dom
+          - web-events
+          - web-html
+          - web-pointerevents
+          - web-uievents
+      phaser:
+        repo: https://github.com/lfarroco/purescript-phaser.git
+        version: v0.6.0
+        dependencies:
+          - canvas
+          - console
+          - effect
+          - maybe
+          - nullable
+          - options
+          - prelude
+          - web-html
+      pipes:
+        repo: https://github.com/felixschl/purescript-pipes.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - lists
+          - mmorph
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      point-free:
+        repo: https://github.com/ursi/purescript-point-free.git
+        version: v1.0.0
+        dependencies:
+          - prelude
+      polymorphic-vectors:
+        repo: https://github.com/artemisSystem/purescript-polymorphic-vectors.git
+        version: v4.0.0
+        dependencies:
+          - distributive
+          - foldable-traversable
+          - numbers
+          - prelude
+          - record
+          - safe-coerce
+          - type-equality
+          - typelevel-prelude
+      posix-types:
+        repo: https://github.com/purescript-node/purescript-posix-types.git
+        version: v6.0.0
+        dependencies:
+          - maybe
+          - prelude
+      precise:
+        repo: https://github.com/purescript-contrib/purescript-precise.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - exceptions
+          - gen
+          - integers
+          - lists
+          - numbers
+          - prelude
+          - strings
+      precise-datetime:
+        repo: https://github.com/awakesecurity/purescript-precise-datetime.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - datetime
+          - decimals
+          - either
+          - enums
+          - foldable-traversable
+          - formatters
+          - integers
+          - js-date
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - strings
+          - tuples
+          - unicode
+      prelude:
+        repo: https://github.com/purescript/purescript-prelude.git
+        version: v6.0.0
+        dependencies: []
+      prettier-printer:
+        repo: https://github.com/paulyoung/purescript-prettier-printer.git
+        version: v3.0.0
+        dependencies:
+          - console
+          - lists
+          - prelude
+          - strings
+          - tuples
+      profunctor:
+        repo: https://github.com/purescript/purescript-profunctor.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - distributive
+          - either
+          - exists
+          - invariant
+          - newtype
+          - prelude
+          - tuples
+      profunctor-lenses:
+        repo: https://github.com/purescript-contrib/purescript-profunctor-lenses.git
+        version: v8.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - const
+          - control
+          - distributive
+          - either
+          - foldable-traversable
+          - foreign-object
+          - functors
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - ordered-collections
+          - partial
+          - prelude
+          - profunctor
+          - record
+          - transformers
+          - tuples
+      protobuf:
+        repo: https://github.com/xc-jp/purescript-protobuf.git
+        version: v4.0.0
+        dependencies:
+          - arraybuffer
+          - arraybuffer-builder
+          - arraybuffer-types
+          - arrays
+          - control
+          - effect
+          - either
+          - enums
+          - exceptions
+          - float32
+          - foldable-traversable
+          - functions
+          - int64
+          - maybe
+          - newtype
+          - parsing
+          - parsing-dataview
+          - prelude
+          - record
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+          - uint
+          - web-encoding
+      ps-cst:
+        repo: https://github.com/purescript-codegen/purescript-ps-cst.git
+        version: v1.2.0
+        dependencies:
+          - ansi
+          - console
+          - dodo-printer
+          - effect
+          - node-fs-aff
+          - node-path
+          - psci-support
+          - record
+          - strings
+      psa-utils:
+        repo: https://github.com/natefaubion/purescript-psa-utils.git
+        version: v8.0.0
+        dependencies:
+          - ansi
+          - argonaut-codecs
+          - argonaut-core
+          - arrays
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - maybe
+          - node-path
+          - ordered-collections
+          - prelude
+          - strings
+          - tuples
+          - unsafe-coerce
+      psc-ide:
+        repo: https://github.com/kRITZCREEK/purescript-psc-ide.git
+        version: v19.0.0
+        dependencies:
+          - aff
+          - argonaut
+          - arrays
+          - console
+          - maybe
+          - node-child-process
+          - node-fs
+          - parallel
+          - random
+      psci-support:
+        repo: https://github.com/purescript/purescript-psci-support.git
+        version: v6.0.0
+        dependencies:
+          - console
+          - effect
+          - prelude
+      qualified-do:
+        repo: https://github.com/artemisSystem/purescript-qualified-do.git
+        version: v2.2.0
+        dependencies:
+          - arrays
+          - control
+          - foldable-traversable
+          - parallel
+          - prelude
+          - unfoldable
+      quantities:
+        repo: https://github.com/sharkdp/purescript-quantities.git
+        version: v12.0.1
+        dependencies:
+          - decimals
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - newtype
+          - nonempty
+          - numbers
+          - pairs
+          - prelude
+          - tuples
+      quickcheck:
+        repo: https://github.com/purescript/purescript-quickcheck.git
+        version: v8.0.1
+        dependencies:
+          - arrays
+          - console
+          - control
+          - effect
+          - either
+          - enums
+          - exceptions
+          - foldable-traversable
+          - gen
+          - identity
+          - integers
+          - lazy
+          - lcg
+          - lists
+          - maybe
+          - newtype
+          - nonempty
+          - numbers
+          - partial
+          - prelude
+          - record
+          - st
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+          - unfoldable
+      quickcheck-combinators:
+        repo: https://github.com/athanclark/purescript-quickcheck-combinators.git
+        version: v0.1.3
+        dependencies:
+          - quickcheck
+          - typelevel
+      quickcheck-laws:
+        repo: https://github.com/purescript-contrib/purescript-quickcheck-laws.git
+        version: v7.0.0
+        dependencies:
+          - enums
+          - quickcheck
+      quickcheck-utf8:
+        repo: https://github.com/openchronology/purescript-quickcheck-utf8.git
+        version: v0.0.0
+        dependencies:
+          - quickcheck
+      quotient:
+        repo: https://github.com/rightfold/purescript-quotient.git
+        version: v3.0.0
+        dependencies:
+          - prelude
+          - quickcheck
+      random:
+        repo: https://github.com/purescript/purescript-random.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - integers
+      rationals:
+        repo: https://github.com/anttih/purescript-rationals.git
+        version: v5.0.0
+        dependencies:
+          - integers
+          - prelude
+      react:
+        repo: https://github.com/purescript-contrib/purescript-react.git
+        version: v10.0.1
+        dependencies:
+          - effect
+          - exceptions
+          - maybe
+          - nullable
+          - prelude
+          - typelevel-prelude
+          - unsafe-coerce
+      react-basic:
+        repo: https://github.com/lumihq/purescript-react-basic.git
+        version: v17.0.0
+        dependencies:
+          - effect
+          - prelude
+          - record
+      react-basic-dom:
+        repo: https://github.com/lumihq/purescript-react-basic-dom.git
+        version: v5.0.0
+        dependencies:
+          - effect
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - nullable
+          - prelude
+          - react-basic
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-file
+          - web-html
+      react-basic-hooks:
+        repo: https://github.com/megamaddu/purescript-react-basic-hooks.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - aff-promise
+          - bifunctors
+          - console
+          - control
+          - datetime
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - functions
+          - indexed-monad
+          - integers
+          - maybe
+          - newtype
+          - now
+          - nullable
+          - ordered-collections
+          - prelude
+          - react-basic
+          - refs
+          - tuples
+          - type-equality
+          - unsafe-coerce
+          - unsafe-reference
+          - web-html
+      react-dom:
+        repo: https://github.com/purescript-contrib/purescript-react-dom.git
+        version: v8.0.0
+        dependencies:
+          - effect
+          - react
+          - web-dom
+      read:
+        repo: https://github.com/truqu/purescript-read.git
+        version: v1.0.1
+        dependencies:
+          - maybe
+          - prelude
+          - strings
+      record:
+        repo: https://github.com/purescript/purescript-record.git
+        version: v4.0.0
+        dependencies:
+          - functions
+          - prelude
+          - unsafe-coerce
+      refined:
+        repo: https://github.com/danieljharvey/purescript-refined.git
+        version: v1.0.0
+        dependencies:
+          - argonaut
+          - effect
+          - prelude
+          - quickcheck
+          - typelevel
+      refs:
+        repo: https://github.com/purescript/purescript-refs.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - prelude
+      remotedata:
+        repo: https://github.com/krisajenkins/purescript-remotedata.git
+        version: v5.0.0
+        dependencies:
+          - bifunctors
+          - either
+          - profunctor-lenses
+      resource:
+        repo: https://github.com/joneshf/purescript-resource.git
+        version: v2.0.1
+        dependencies:
+          - aff
+          - console
+          - control
+          - effect
+          - newtype
+          - prelude
+          - psci-support
+          - refs
+      resourcet:
+        repo: https://github.com/robertdp/purescript-resourcet.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - effect
+          - foldable-traversable
+          - maybe
+          - ordered-collections
+          - parallel
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+      result:
+        repo: https://github.com/ad-si/purescript-result.git
+        version: v1.0.3
+        dependencies:
+          - either
+          - foldable-traversable
+          - prelude
+      return:
+        repo: https://github.com/ursi/purescript-return.git
+        version: v0.2.0
+        dependencies:
+          - foldable-traversable
+          - point-free
+          - prelude
+      ring-modules:
+        repo: https://github.com/f-o-a-m/purescript-ring-modules.git
+        version: v5.0.1
+        dependencies:
+          - prelude
+      routing:
+        repo: https://github.com/purescript-contrib/purescript-routing.git
+        version: v11.0.0
+        dependencies:
+          - aff
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - integers
+          - js-uri
+          - lists
+          - maybe
+          - numbers
+          - partial
+          - prelude
+          - semirings
+          - tuples
+          - validation
+          - web-html
+      routing-duplex:
+        repo: https://github.com/natefaubion/purescript-routing-duplex.git
+        version: v0.6.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - js-uri
+          - lazy
+          - numbers
+          - prelude
+          - profunctor
+          - record
+          - strings
+          - typelevel-prelude
+      run:
+        repo: https://github.com/natefaubion/purescript-run.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - free
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - tailrec
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - variant
+      safe-coerce:
+        repo: https://github.com/purescript/purescript-safe-coerce.git
+        version: v2.0.0
+        dependencies:
+          - unsafe-coerce
+      safely:
+        repo: https://github.com/paf31/purescript-safely.git
+        version: v4.0.1
+        dependencies:
+          - freet
+          - lists
+      selection-foldable:
+        repo: https://github.com/jamieyung/purescript-selection-foldable.git
+        version: v0.2.0
+        dependencies:
+          - filterable
+          - foldable-traversable
+          - maybe
+          - prelude
+      semirings:
+        repo: https://github.com/purescript/purescript-semirings.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - lists
+          - newtype
+          - prelude
+      signal:
+        repo: https://github.com/bodil/purescript-signal.git
+        version: v13.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - foldable-traversable
+          - maybe
+          - prelude
+      simple-emitter:
+        repo: https://github.com/oreshinya/purescript-simple-emitter.git
+        version: v2.0.0
+        dependencies:
+          - ordered-collections
+          - refs
+      sized-matrices:
+        repo: https://github.com/csicar/purescript-sized-matrices.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - distributive
+          - foldable-traversable
+          - maybe
+          - prelude
+          - sized-vectors
+          - strings
+          - typelevel
+          - unfoldable
+          - vectorfield
+      sized-vectors:
+        repo: https://github.com/bodil/purescript-sized-vectors.git
+        version: v5.0.2
+        dependencies:
+          - argonaut
+          - arrays
+          - distributive
+          - foldable-traversable
+          - maybe
+          - prelude
+          - quickcheck
+          - typelevel
+          - unfoldable
+      slug:
+        repo: https://github.com/thomashoneyman/purescript-slug.git
+        version: v3.0.1
+        dependencies:
+          - argonaut-codecs
+          - maybe
+          - prelude
+          - strings
+          - unicode
+      soundfonts:
+        repo: https://github.com/newlandsvalley/purescript-soundfonts.git
+        version: v4.1.0
+        dependencies:
+          - aff
+          - affjax
+          - affjax-web
+          - argonaut-core
+          - arraybuffer-types
+          - arrays
+          - b64
+          - bifunctors
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign-object
+          - http-methods
+          - integers
+          - lists
+          - maybe
+          - midi
+          - ordered-collections
+          - parallel
+          - partial
+          - prelude
+          - strings
+          - transformers
+          - tuples
+      sparse-matrices:
+        repo: https://github.com/Ebmtranceboy/purescript-sparse-matrices.git
+        version: v1.2.1
+        dependencies:
+          - console
+          - effect
+          - prelude
+          - sparse-polynomials
+      sparse-polynomials:
+        repo: https://github.com/Ebmtranceboy/purescript-sparse-polynomials.git
+        version: v1.0.5
+        dependencies:
+          - cartesian
+          - console
+          - effect
+          - ordered-collections
+          - prelude
+          - rationals
+          - tuples
+      spec:
+        repo: https://github.com/purescript-spec/purescript-spec.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - ansi
+          - avar
+          - console
+          - exceptions
+          - foldable-traversable
+          - fork
+          - now
+          - pipes
+          - prelude
+          - strings
+          - transformers
+      spec-discovery:
+        repo: https://github.com/purescript-spec/purescript-spec-discovery.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - aff-promise
+          - arrays
+          - console
+          - effect
+          - foldable-traversable
+          - node-fs
+          - prelude
+          - spec
+      spec-quickcheck:
+        repo: https://github.com/purescript-spec/purescript-spec-quickcheck.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - prelude
+          - quickcheck
+          - random
+          - spec
+      ssrs:
+        repo: https://github.com/PureFunctor/purescript-ssrs.git
+        version: v1.0.0
+        dependencies:
+          - dissect
+          - either
+          - fixed-points
+          - free
+          - lists
+          - prelude
+          - safe-coerce
+          - tailrec
+          - tuples
+          - variant
+      st:
+        repo: https://github.com/purescript/purescript-st.git
+        version: v6.0.0
+        dependencies:
+          - partial
+          - prelude
+          - tailrec
+          - unsafe-coerce
+      strictlypositiveint:
+        repo: https://github.com/jamieyung/purescript-strictlypositiveint.git
+        version: v1.0.1
+        dependencies:
+          - prelude
+      string-parsers:
+        repo: https://github.com/purescript-contrib/purescript-string-parsers.git
+        version: v8.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - prelude
+          - strings
+          - tailrec
+      strings:
+        repo: https://github.com/purescript/purescript-strings.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - enums
+          - foldable-traversable
+          - gen
+          - integers
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+          - unsafe-coerce
+      strings-extra:
+        repo: https://github.com/purescript-contrib/purescript-strings-extra.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - maybe
+          - prelude
+          - strings
+          - unicode
+      stringutils:
+        repo: https://github.com/menelaos/purescript-stringutils.git
+        version: v0.0.12
+        dependencies:
+          - arrays
+          - integers
+          - maybe
+          - partial
+          - prelude
+          - strings
+      substitute:
+        repo: https://github.com/ursi/purescript-substitute.git
+        version: v0.2.3
+        dependencies:
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - prelude
+          - return
+          - strings
+      supply:
+        repo: https://github.com/ajnsit/purescript-supply.git
+        version: v0.2.0
+        dependencies:
+          - console
+          - control
+          - effect
+          - lazy
+          - prelude
+          - refs
+          - tuples
+      tailrec:
+        repo: https://github.com/purescript/purescript-tailrec.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - effect
+          - either
+          - identity
+          - maybe
+          - partial
+          - prelude
+          - refs
+      test-unit:
+        repo: https://github.com/bodil/purescript-test-unit.git
+        version: v17.0.0
+        dependencies:
+          - aff
+          - avar
+          - effect
+          - either
+          - free
+          - js-timers
+          - lists
+          - prelude
+          - quickcheck
+          - strings
+      thermite:
+        repo: https://github.com/paf31/purescript-thermite.git
+        version: v6.3.1
+        dependencies:
+          - aff
+          - coroutines
+          - freet
+          - profunctor-lenses
+          - react
+      thermite-dom:
+        repo: https://github.com/athanclark/purescript-thermite-dom.git
+        version: v0.3.1
+        dependencies:
+          - react
+          - react-dom
+          - thermite
+          - web-html
+      these:
+        repo: https://github.com/purescript-contrib/purescript-these.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - gen
+          - lists
+          - quickcheck
+          - quickcheck-laws
+          - tuples
+      transformers:
+        repo: https://github.com/purescript/purescript-transformers.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - distributive
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - identity
+          - lazy
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      tree-rose:
+        repo: https://github.com/jordanmartinez/purescript-tree-rose.git
+        version: v4.0.2
+        dependencies:
+          - control
+          - foldable-traversable
+          - free
+          - lists
+          - maybe
+          - prelude
+          - tailrec
+      tuples:
+        repo: https://github.com/purescript/purescript-tuples.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - invariant
+          - prelude
+      two-or-more:
+        repo: https://github.com/i-am-the-slime/purescript-two-or-more.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - foldable-traversable
+          - maybe
+          - partial
+          - prelude
+          - psci-support
+          - tuples
+      type-equality:
+        repo: https://github.com/purescript/purescript-type-equality.git
+        version: v4.0.1
+        dependencies: []
+      typelevel:
+        repo: https://github.com/bodil/purescript-typelevel.git
+        version: v6.0.0
+        dependencies:
+          - partial
+          - prelude
+          - tuples
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-lists:
+        repo: https://github.com/PureFunctor/purescript-typelevel-lists.git
+        version: v2.1.0
+        dependencies:
+          - prelude
+          - tuples
+          - typelevel-peano
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-peano:
+        repo: https://github.com/csicar/purescript-typelevel-peano.git
+        version: v1.0.1
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - prelude
+          - psci-support
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-prelude:
+        repo: https://github.com/purescript/purescript-typelevel-prelude.git
+        version: v7.0.0
+        dependencies:
+          - prelude
+          - type-equality
+      typelevel-rows:
+        repo: https://github.com/jordanmartinez/purescript-typelevel-rows.git
+        version: v0.1.0
+        dependencies:
+          - prelude
+      uint:
+        repo: https://github.com/purescript-contrib/purescript-uint.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - enums
+          - gen
+          - maybe
+          - numbers
+          - prelude
+      uncurried-transformers:
+        repo: https://github.com/PureFunctor/purescript-uncurried-transformers.git
+        version: v1.1.0
+        dependencies:
+          - control
+          - effect
+          - either
+          - functions
+          - identity
+          - prelude
+          - safe-coerce
+          - tailrec
+          - transformers
+          - tuples
+      undefined-is-not-a-problem:
+        repo: https://github.com/paluh/purescript-undefined-is-not-a-problem.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - assert
+          - effect
+          - either
+          - foreign
+          - maybe
+          - newtype
+          - prelude
+          - random
+          - tuples
+          - type-equality
+          - unsafe-coerce
+      unfoldable:
+        repo: https://github.com/purescript/purescript-unfoldable.git
+        version: v6.0.0
+        dependencies:
+          - foldable-traversable
+          - maybe
+          - partial
+          - prelude
+          - tuples
+      unicode:
+        repo: https://github.com/purescript-contrib/purescript-unicode.git
+        version: v6.0.0
+        dependencies:
+          - foldable-traversable
+          - maybe
+          - strings
+      unlift:
+        repo: https://github.com/tweag/purescript-unlift.git
+        version: v1.0.1
+        dependencies:
+          - aff
+          - effect
+          - either
+          - freet
+          - identity
+          - lists
+          - maybe
+          - monad-control
+          - prelude
+          - st
+          - transformers
+          - tuples
+      unsafe-coerce:
+        repo: https://github.com/purescript/purescript-unsafe-coerce.git
+        version: v6.0.0
+        dependencies: []
+      unsafe-reference:
+        repo: https://github.com/purescript-contrib/purescript-unsafe-reference.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+      uri:
+        repo: https://github.com/purescript-contrib/purescript-uri.git
+        version: v9.0.0
+        dependencies:
+          - arrays
+          - integers
+          - js-uri
+          - numbers
+          - parsing
+          - prelude
+          - profunctor-lenses
+          - these
+          - transformers
+          - unfoldable
+      validation:
+        repo: https://github.com/purescript/purescript-validation.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - newtype
+          - prelude
+      variant:
+        repo: https://github.com/natefaubion/purescript-variant.git
+        version: v8.0.0
+        dependencies:
+          - enums
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - record
+          - tuples
+          - unsafe-coerce
+      vectorfield:
+        repo: https://github.com/csicar/purescript-vectorfield.git
+        version: v1.0.1
+        dependencies:
+          - console
+          - effect
+          - group
+          - prelude
+          - psci-support
+      versions:
+        repo: https://github.com/hdgarrood/purescript-versions.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - either
+          - foldable-traversable
+          - functions
+          - integers
+          - lists
+          - maybe
+          - orders
+          - parsing
+          - partial
+          - strings
+      web-clipboard:
+        repo: https://github.com/purescript-web/purescript-web-clipboard.git
+        version: v4.0.0
+        dependencies:
+          - web-html
+      web-cssom:
+        repo: https://github.com/purescript-web/purescript-web-cssom.git
+        version: v2.0.0
+        dependencies:
+          - web-dom
+          - web-html
+          - web-uievents
+      web-dom:
+        repo: https://github.com/purescript-web/purescript-web-dom.git
+        version: v6.0.0
+        dependencies:
+          - web-events
+      web-dom-parser:
+        repo: https://github.com/purescript-web/purescript-web-dom-parser.git
+        version: v8.0.0
+        dependencies:
+          - effect
+          - partial
+          - prelude
+          - web-dom
+      web-dom-xpath:
+        repo: https://github.com/purescript-web/purescript-web-dom-xpath.git
+        version: v3.0.0
+        dependencies:
+          - web-dom
+      web-encoding:
+        repo: https://github.com/purescript-web/purescript-web-encoding.git
+        version: v3.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - newtype
+          - prelude
+      web-events:
+        repo: https://github.com/purescript-web/purescript-web-events.git
+        version: v4.0.0
+        dependencies:
+          - datetime
+          - enums
+          - foreign
+          - nullable
+      web-fetch:
+        repo: https://github.com/purescript-web/purescript-web-fetch.git
+        version: v3.0.0
+        dependencies:
+          - effect
+          - foreign-object
+          - http-methods
+          - prelude
+          - record
+          - typelevel-prelude
+          - web-file
+          - web-promise
+          - web-streams
+      web-file:
+        repo: https://github.com/purescript-web/purescript-web-file.git
+        version: v4.0.0
+        dependencies:
+          - foreign
+          - media-types
+          - web-dom
+      web-html:
+        repo: https://github.com/purescript-web/purescript-web-html.git
+        version: v4.0.0
+        dependencies:
+          - js-date
+          - web-dom
+          - web-file
+          - web-storage
+      web-page-visibility:
+        repo: https://git.sr.ht/~toastal/purescript-web-page-visibility
+        version: v2.0.0
+        dependencies:
+          - effect
+          - enums
+          - exceptions
+          - maybe
+          - prelude
+          - strings
+          - web-events
+          - web-html
+      web-pointerevents:
+        repo: https://github.com/purescript-web/purescript-web-pointerevents.git
+        version: v1.0.0
+        dependencies:
+          - effect
+          - maybe
+          - prelude
+          - web-dom
+          - web-uievents
+      web-promise:
+        repo: https://github.com/purescript-web/purescript-web-promise.git
+        version: v3.0.0
+        dependencies:
+          - effect
+          - exceptions
+          - foldable-traversable
+          - functions
+          - maybe
+          - prelude
+      web-socket:
+        repo: https://github.com/purescript-web/purescript-web-socket.git
+        version: v4.0.0
+        dependencies:
+          - arraybuffer-types
+          - web-file
+      web-storage:
+        repo: https://github.com/purescript-web/purescript-web-storage.git
+        version: v5.0.0
+        dependencies:
+          - nullable
+          - web-events
+      web-streams:
+        repo: https://github.com/purescript-web/purescript-web-streams.git
+        version: v3.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - exceptions
+          - nullable
+          - prelude
+          - tuples
+          - web-promise
+      web-touchevents:
+        repo: https://github.com/purescript-web/purescript-web-touchevents.git
+        version: v4.0.0
+        dependencies:
+          - web-uievents
+      web-uievents:
+        repo: https://github.com/purescript-web/purescript-web-uievents.git
+        version: v4.0.0
+        dependencies:
+          - web-html
+      web-workers:
+        repo: https://github.com/gbagan/purescript-web-workers.git
+        version: v1.1.0
+        dependencies:
+          - effect
+          - foreign
+          - maybe
+          - prelude
+          - unsafe-coerce
+          - web-events
+      web-xhr:
+        repo: https://github.com/purescript-web/purescript-web-xhr.git
+        version: v5.0.0
+        dependencies:
+          - arraybuffer-types
+          - datetime
+          - http-methods
+          - web-dom
+          - web-file
+          - web-html
+      yoga-fetch:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-fetch.git
+        version: v1.0.1
+        dependencies:
+          - aff
+          - aff-promise
+          - arraybuffer-types
+          - effect
+          - foreign
+          - foreign-object
+          - newtype
+          - prelude
+          - typelevel-prelude
+          - unsafe-coerce
+      yoga-json:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-json.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - identity
+          - lists
+          - maybe
+          - nullable
+          - partial
+          - prelude
+          - record
+          - transformers
+          - typelevel-prelude
+          - variant
+      yoga-postgres:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-postgres.git
+        version: v6.0.0
+        dependencies:
+          - aff
+          - arrays
+          - datetime
+          - effect
+          - either
+          - enums
+          - foldable-traversable
+          - foreign
+          - integers
+          - maybe
+          - nullable
+          - prelude
+          - transformers
+          - unsafe-coerce
+  extra_packages: {}
+packages:
+  arraybuffer-types:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
+    rev: 9b0b7a0f9ee034e039f3d3a2a9c3f74eb7c9264a
+    dependencies: []
+  arrays:
+    type: git
+    url: https://github.com/purescript/purescript-arrays.git
+    rev: d20bae2f76db6cf29b7b75e26e82b8a54c32295e
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - maybe
+      - nonempty
+      - partial
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  bifunctors:
+    type: git
+    url: https://github.com/purescript/purescript-bifunctors.git
+    rev: 16ba2fb6dd7f05528ebd9e2f9ca3a068b325e5b3
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  canvas:
+    type: git
+    url: https://github.com/purescript-web/purescript-canvas.git
+    rev: bb640e46d64324678111262a8b5dddc13d7e61b6
+    dependencies:
+      - arraybuffer-types
+      - effect
+      - exceptions
+      - functions
+      - maybe
+  console:
+    type: git
+    url: https://github.com/purescript/purescript-console.git
+    rev: 3b83d7b792d03872afeea5e62b4f686ab0f09842
+    dependencies:
+      - effect
+      - prelude
+  const:
+    type: git
+    url: https://github.com/purescript/purescript-const.git
+    rev: ab9570cf2b6e67f7e441178211db1231cfd75c37
+    dependencies:
+      - invariant
+      - newtype
+      - prelude
+  contravariant:
+    type: git
+    url: https://github.com/purescript/purescript-contravariant.git
+    rev: 9ad3e105b8855bcc25f4e0893c784789d05a58de
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  control:
+    type: git
+    url: https://github.com/purescript/purescript-control.git
+    rev: a6033808790879a17b2729e73747a9ed3fb2264e
+    dependencies:
+      - newtype
+      - prelude
+  datetime:
+    type: git
+    url: https://github.com/purescript/purescript-datetime.git
+    rev: a6a0cf1b0324964ad1854bc3377ed8766ba90e6f
+    dependencies:
+      - bifunctors
+      - control
+      - either
+      - enums
+      - foldable-traversable
+      - functions
+      - gen
+      - integers
+      - lists
+      - maybe
+      - newtype
+      - numbers
+      - ordered-collections
+      - partial
+      - prelude
+      - tuples
+  distributive:
+    type: git
+    url: https://github.com/purescript/purescript-distributive.git
+    rev: 6005e513642e855ebf6f884d24a35c2803ca252a
+    dependencies:
+      - identity
+      - newtype
+      - prelude
+      - tuples
+      - type-equality
+  effect:
+    type: git
+    url: https://github.com/purescript/purescript-effect.git
+    rev: a192ddb923027d426d6ea3d8deb030c9aa7c7dda
+    dependencies:
+      - prelude
+  either:
+    type: git
+    url: https://github.com/purescript/purescript-either.git
+    rev: af655a04ed2fd694b6688af39ee20d7907ad0763
+    dependencies:
+      - control
+      - invariant
+      - maybe
+      - prelude
+  enums:
+    type: git
+    url: https://github.com/purescript/purescript-enums.git
+    rev: bae47961d401f9acf88da38f32e87403e5f0cf2f
+    dependencies:
+      - control
+      - either
+      - gen
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tuples
+      - unfoldable
+  exceptions:
+    type: git
+    url: https://github.com/purescript/purescript-exceptions.git
+    rev: afab3c07c820bb49b6c5be50049db46a964a6161
+    dependencies:
+      - effect
+      - either
+      - maybe
+      - prelude
+  exists:
+    type: git
+    url: https://github.com/purescript/purescript-exists.git
+    rev: f765b4ace7869c27b9c05949e18c843881f9173b
+    dependencies:
+      - unsafe-coerce
+  foldable-traversable:
+    type: git
+    url: https://github.com/purescript/purescript-foldable-traversable.git
+    rev: b3926f870532d287ea59e2d5cd3873b81ef2a93a
+    dependencies:
+      - bifunctors
+      - const
+      - control
+      - either
+      - functors
+      - identity
+      - maybe
+      - newtype
+      - orders
+      - prelude
+      - tuples
+  foreign:
+    type: git
+    url: https://github.com/purescript/purescript-foreign.git
+    rev: 2dd222d1ec7363fa0a0a7adb0d8eaf81bb7006dd
+    dependencies:
+      - either
+      - functions
+      - identity
+      - integers
+      - lists
+      - maybe
+      - prelude
+      - strings
+      - transformers
+  functions:
+    type: git
+    url: https://github.com/purescript/purescript-functions.git
+    rev: f626f20580483977c5b27a01aac6471e28aff367
+    dependencies:
+      - prelude
+  functors:
+    type: git
+    url: https://github.com/purescript/purescript-functors.git
+    rev: 022ffd7a2a7ec12080314f3d217b400674a247b4
+    dependencies:
+      - bifunctors
+      - const
+      - contravariant
+      - control
+      - distributive
+      - either
+      - invariant
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - tuples
+      - unsafe-coerce
+  gen:
+    type: git
+    url: https://github.com/purescript/purescript-gen.git
+    rev: 9fbcc2a1261c32e30d79c5418edef4d96fe76931
+    dependencies:
+      - either
+      - foldable-traversable
+      - identity
+      - maybe
+      - newtype
+      - nonempty
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  identity:
+    type: git
+    url: https://github.com/purescript/purescript-identity.git
+    rev: ef6768f8a52ab0bc943a85f5761ba07c257f639f
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  integers:
+    type: git
+    url: https://github.com/purescript/purescript-integers.git
+    rev: 54d712b25c594833083d15dc9ff2418eb9c52822
+    dependencies:
+      - maybe
+      - numbers
+      - prelude
+  invariant:
+    type: git
+    url: https://github.com/purescript/purescript-invariant.git
+    rev: 1d2a196d51e90623adb88496c2cfd759c6736894
+    dependencies:
+      - control
+      - prelude
+  js-date:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-js-date.git
+    rev: 1ea020316946cc4b87195bca9c54d0c16abaa490
+    dependencies:
+      - datetime
+      - effect
+      - exceptions
+      - foreign
+      - integers
+      - now
+  lazy:
+    type: git
+    url: https://github.com/purescript/purescript-lazy.git
+    rev: 48347841226b27af5205a1a8ec71e27a93ce86fd
+    dependencies:
+      - control
+      - foldable-traversable
+      - invariant
+      - prelude
+  lists:
+    type: git
+    url: https://github.com/purescript/purescript-lists.git
+    rev: b113451e5b41cad87d669a3165f955c71cd863e2
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - lazy
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  maybe:
+    type: git
+    url: https://github.com/purescript/purescript-maybe.git
+    rev: c6f98ac1088766287106c5d9c8e30e7648d36786
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  media-types:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-media-types.git
+    rev: af853de226592f319a953637069a943dd261cba3
+    dependencies:
+      - newtype
+      - prelude
+  newtype:
+    type: git
+    url: https://github.com/purescript/purescript-newtype.git
+    rev: 29d8e6dd77aec2c975c948364ec3faf26e14ee7b
+    dependencies:
+      - prelude
+      - safe-coerce
+  nonempty:
+    type: git
+    url: https://github.com/purescript/purescript-nonempty.git
+    rev: 28150ecc7419238b187abd609a92a645273348bb
+    dependencies:
+      - control
+      - foldable-traversable
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  now:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-now.git
+    rev: b5ffed2381e5fefc063f484e607e8499e79eaf32
+    dependencies:
+      - datetime
+      - effect
+  nullable:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-nullable.git
+    rev: 3202744c6c65e8d1fbba7f4256a1c482078e7fb5
+    dependencies:
+      - effect
+      - functions
+      - maybe
+  numbers:
+    type: git
+    url: https://github.com/purescript/purescript-numbers.git
+    rev: 2a53528f18f9415334bae28e7bb3cf3be86342c2
+    dependencies:
+      - functions
+      - maybe
+  ordered-collections:
+    type: git
+    url: https://github.com/purescript/purescript-ordered-collections.git
+    rev: 9826b7632d0d0a691173bde308a634195f42a419
+    dependencies:
+      - arrays
+      - foldable-traversable
+      - gen
+      - lists
+      - maybe
+      - partial
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+  orders:
+    type: git
+    url: https://github.com/purescript/purescript-orders.git
+    rev: f86db621ec5eef1274145f8b1fd8ebbfe0ed4a2c
+    dependencies:
+      - newtype
+      - prelude
+  partial:
+    type: git
+    url: https://github.com/purescript/purescript-partial.git
+    rev: 0fa0646f5ea1ec5f0c46dcbd770c705a6c9ad3ec
+    dependencies: []
+  prelude:
+    type: git
+    url: https://github.com/purescript/purescript-prelude.git
+    rev: 32787f4399c92459c41602131a5858559eb868c5
+    dependencies: []
+  profunctor:
+    type: git
+    url: https://github.com/purescript/purescript-profunctor.git
+    rev: 0a966a14e7b0c827d44657dc1710cdc712d2e034
+    dependencies:
+      - control
+      - distributive
+      - either
+      - exists
+      - invariant
+      - newtype
+      - prelude
+      - tuples
+  random:
+    type: git
+    url: https://github.com/purescript/purescript-random.git
+    rev: 9540bc965a9596da02fefd9949418bb19c92533a
+    dependencies:
+      - effect
+      - integers
+  refs:
+    type: git
+    url: https://github.com/purescript/purescript-refs.git
+    rev: f8e6216da4cb9309fde1f20cd6f69ac3a3b7f9e8
+    dependencies:
+      - effect
+      - prelude
+  safe-coerce:
+    type: git
+    url: https://github.com/purescript/purescript-safe-coerce.git
+    rev: 7fa799ae80a38b8d948efcb52608e58e198b3da7
+    dependencies:
+      - unsafe-coerce
+  st:
+    type: git
+    url: https://github.com/purescript/purescript-st.git
+    rev: 2cc7ae1c3318a303378c4a9f3fa0f10ee7cc3589
+    dependencies:
+      - partial
+      - prelude
+      - tailrec
+      - unsafe-coerce
+  strings:
+    type: git
+    url: https://github.com/purescript/purescript-strings.git
+    rev: 4bc6954448d056f8aa7a659695a6ad60ad4fdf19
+    dependencies:
+      - arrays
+      - control
+      - either
+      - enums
+      - foldable-traversable
+      - gen
+      - integers
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  tailrec:
+    type: git
+    url: https://github.com/purescript/purescript-tailrec.git
+    rev: 5e2104aa734b31a17074cc805bf087d72b65afd1
+    dependencies:
+      - bifunctors
+      - effect
+      - either
+      - identity
+      - maybe
+      - partial
+      - prelude
+      - refs
+  transformers:
+    type: git
+    url: https://github.com/purescript/purescript-transformers.git
+    rev: be72ab52357d9a665cbf93d73ba1c07c4b0957ee
+    dependencies:
+      - control
+      - distributive
+      - effect
+      - either
+      - exceptions
+      - foldable-traversable
+      - identity
+      - lazy
+      - maybe
+      - newtype
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  tuples:
+    type: git
+    url: https://github.com/purescript/purescript-tuples.git
+    rev: 4f52da2729b448c8564369378f1232d8d2dc1d8b
+    dependencies:
+      - control
+      - invariant
+      - prelude
+  type-equality:
+    type: git
+    url: https://github.com/purescript/purescript-type-equality.git
+    rev: 0525b7d39e0fbd81b4209518139fb8ab02695774
+    dependencies: []
+  unfoldable:
+    type: git
+    url: https://github.com/purescript/purescript-unfoldable.git
+    rev: 493dfe04ed590e20d8f69079df2f58486882748d
+    dependencies:
+      - foldable-traversable
+      - maybe
+      - partial
+      - prelude
+      - tuples
+  unsafe-coerce:
+    type: git
+    url: https://github.com/purescript/purescript-unsafe-coerce.git
+    rev: ab956f82e66e633f647fb3098e8ddd3ec58d689f
+    dependencies: []
+  web-dom:
+    type: git
+    url: https://github.com/purescript-web/purescript-web-dom.git
+    rev: 568a1ee158b29e6e739e7a9aaed3e35ca4c4305a
+    dependencies:
+      - web-events
+  web-events:
+    type: git
+    url: https://github.com/purescript-web/purescript-web-events.git
+    rev: 2124356117be7b764a2f3948032255ac4dab7051
+    dependencies:
+      - datetime
+      - enums
+      - foreign
+      - nullable
+  web-file:
+    type: git
+    url: https://github.com/purescript-web/purescript-web-file.git
+    rev: 023786ae62bbb8bf58156dd7f02011fa38221ef1
+    dependencies:
+      - foreign
+      - media-types
+      - web-dom
+  web-html:
+    type: git
+    url: https://github.com/purescript-web/purescript-web-html.git
+    rev: be189cf91b9a19cf493637423522e2fe4a0088cc
+    dependencies:
+      - js-date
+      - web-dom
+      - web-file
+      - web-storage
+  web-storage:
+    type: git
+    url: https://github.com/purescript-web/purescript-web-storage.git
+    rev: 6b74461e136755db70c271dc898d51776363d7e2
+    dependencies:
+      - nullable
+      - web-events

--- a/exercises/chapter12/spago.lock
+++ b/exercises/chapter12/spago.lock
@@ -76,3445 +76,445 @@ workspace:
         - web-storage
   package_set:
     address:
-      url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
-    compiler: ">=0.15.0 <0.16.0"
+      registry: 10.0.0
+    compiler: ">=0.15.4 <0.16.0"
     content:
-      ace:
-        repo: https://github.com/purescript-contrib/purescript-ace.git
-        version: v9.0.0
-        dependencies:
-          - arrays
-          - effect
-          - foreign
-          - nullable
-          - prelude
-          - web-html
-          - web-uievents
-      aff:
-        repo: https://github.com/purescript-contrib/purescript-aff.git
-        version: v7.0.0
-        dependencies:
-          - datetime
-          - effect
-          - exceptions
-          - functions
-          - parallel
-          - transformers
-          - unsafe-coerce
-      aff-bus:
-        repo: https://github.com/purescript-contrib/purescript-aff-bus.git
-        version: v6.0.0
-        dependencies:
-          - aff
-          - avar
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - lists
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-      aff-coroutines:
-        repo: https://github.com/purescript-contrib/purescript-aff-coroutines.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - avar
-          - coroutines
-          - effect
-      aff-promise:
-        repo: https://github.com/nwolverson/purescript-aff-promise.git
-        version: v4.0.0
-        dependencies:
-          - aff
-          - foreign
-      aff-retry:
-        repo: https://github.com/Unisay/purescript-aff-retry.git
-        version: v2.0.0
-        dependencies:
-          - aff
-          - arrays
-          - datetime
-          - effect
-          - either
-          - exceptions
-          - integers
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - random
-          - transformers
-      affjax:
-        repo: https://github.com/purescript-contrib/purescript-affjax.git
-        version: v13.0.0
-        dependencies:
-          - aff
-          - argonaut-core
-          - arraybuffer-types
-          - foreign
-          - form-urlencoded
-          - http-methods
-          - integers
-          - media-types
-          - nullable
-          - refs
-          - unsafe-coerce
-          - web-xhr
-      affjax-node:
-        repo: https://github.com/purescript-contrib/purescript-affjax-node.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - affjax
-          - either
-          - maybe
-          - prelude
-      affjax-web:
-        repo: https://github.com/purescript-contrib/purescript-affjax-web.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - affjax
-          - either
-          - maybe
-          - prelude
-      ansi:
-        repo: https://github.com/hdgarrood/purescript-ansi.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - lists
-          - strings
-      argonaut:
-        repo: https://github.com/purescript-contrib/purescript-argonaut.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - argonaut-traversals
-      argonaut-codecs:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-codecs.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-core
-          - arrays
-          - effect
-          - foreign-object
-          - identity
-          - integers
-          - maybe
-          - nonempty
-          - ordered-collections
-          - prelude
-          - record
-      argonaut-core:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-core.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - foreign-object
-          - functions
-          - gen
-          - maybe
-          - nonempty
-          - prelude
-          - strings
-          - tailrec
-      argonaut-generic:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-generic.git
-        version: v8.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - prelude
-          - record
-      argonaut-traversals:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-traversals.git
-        version: v10.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - profunctor-lenses
-      argparse-basic:
-        repo: https://github.com/natefaubion/purescript-argparse-basic.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - record
-          - strings
-          - tuples
-          - unfoldable
-      arraybuffer:
-        repo: https://github.com/purescript-contrib/purescript-arraybuffer.git
-        version: v13.0.0
-        dependencies:
-          - arraybuffer-types
-          - arrays
-          - effect
-          - float32
-          - functions
-          - gen
-          - maybe
-          - nullable
-          - prelude
-          - tailrec
-          - uint
-          - unfoldable
-      arraybuffer-builder:
-        repo: https://github.com/jamesdbrock/purescript-arraybuffer-builder.git
-        version: v3.0.1
-        dependencies:
-          - arraybuffer
-          - arraybuffer-types
-          - effect
-          - float32
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - transformers
-          - uint
-      arraybuffer-types:
-        repo: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
-        version: v3.0.2
-        dependencies: []
-      arrays:
-        repo: https://github.com/purescript/purescript-arrays.git
-        version: v7.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - foldable-traversable
-          - maybe
-          - nonempty
-          - partial
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - unfoldable
-          - unsafe-coerce
-      arrays-zipper:
-        repo: https://github.com/JordanMartinez/purescript-arrays-zipper.git
-        version: v2.0.1
-        dependencies:
-          - arrays
-          - control
-          - quickcheck
-      ask:
-        repo: https://github.com/Mateiadrielrafael/purescript-ask.git
-        version: v1.0.0
-        dependencies:
-          - unsafe-coerce
-      assert:
-        repo: https://github.com/purescript/purescript-assert.git
-        version: v6.0.0
-        dependencies:
-          - console
-          - effect
-          - prelude
-      avar:
-        repo: https://github.com/purescript-contrib/purescript-avar.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - exceptions
-          - functions
-          - maybe
-      b64:
-        repo: https://github.com/menelaos/purescript-b64.git
-        version: v0.0.8
-        dependencies:
-          - arraybuffer-types
-          - either
-          - encoding
-          - enums
-          - exceptions
-          - functions
-          - partial
-          - prelude
-          - strings
-      barlow-lens:
-        repo: https://github.com/sigma-andex/purescript-barlow-lens.git
-        version: v0.9.0
-        dependencies:
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - profunctor-lenses
-          - tuples
-          - typelevel-prelude
-      bifunctors:
-        repo: https://github.com/purescript/purescript-bifunctors.git
-        version: v6.0.0
-        dependencies:
-          - const
-          - either
-          - newtype
-          - prelude
-          - tuples
-      bigints:
-        repo: https://github.com/sharkdp/purescript-bigints.git
-        version: v7.0.1
-        dependencies:
-          - integers
-          - maybe
-          - strings
-      bower-json:
-        repo: https://github.com/klntsky/purescript-bower-json.git
-        version: v3.0.0
-        dependencies:
-          - argonaut-codecs
-          - arrays
-          - either
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - newtype
-          - prelude
-          - tuples
-      call-by-name:
-        repo: https://github.com/natefaubion/purescript-call-by-name.git
-        version: v4.0.1
-        dependencies:
-          - control
-          - either
-          - lazy
-          - maybe
-          - unsafe-coerce
-      canvas:
-        repo: https://github.com/purescript-web/purescript-canvas.git
-        version: v6.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - exceptions
-          - functions
-          - maybe
-      canvas-action:
-        repo: https://github.com/artemisSystem/purescript-canvas-action.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - arrays
-          - canvas
-          - colors
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - maybe
-          - numbers
-          - polymorphic-vectors
-          - prelude
-          - refs
-          - run
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-html
-      cartesian:
-        repo: https://github.com/Ebmtranceboy/purescript-cartesian.git
-        version: v1.0.6
-        dependencies:
-          - console
-          - effect
-          - integers
-          - psci-support
-      catenable-lists:
-        repo: https://github.com/purescript/purescript-catenable-lists.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - lists
-          - maybe
-          - prelude
-          - tuples
-          - unfoldable
-      channel:
-        repo: https://github.com/ConnorDillon/purescript-channel.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - assert
-          - avar
-          - console
-          - contravariant
-          - control
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - lazy
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      checked-exceptions:
-        repo: https://github.com/natefaubion/purescript-checked-exceptions.git
-        version: v3.1.1
-        dependencies:
-          - prelude
-          - transformers
-          - variant
-      codec:
-        repo: https://github.com/garyb/purescript-codec.git
-        version: v5.0.0
-        dependencies:
-          - profunctor
-          - transformers
-      codec-argonaut:
-        repo: https://github.com/garyb/purescript-codec-argonaut.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-core
-          - codec
-          - ordered-collections
-          - type-equality
-          - variant
-      colors:
-        repo: https://github.com/purescript-contrib/purescript-colors.git
-        version: v7.0.1
-        dependencies:
-          - arrays
-          - integers
-          - lists
-          - numbers
-          - partial
-          - strings
-      concurrent-queues:
-        repo: https://github.com/purescript-contrib/purescript-concurrent-queues.git
-        version: v3.0.0
-        dependencies:
-          - aff
-          - avar
-          - effect
-      console:
-        repo: https://github.com/purescript/purescript-console.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - prelude
-      const:
-        repo: https://github.com/purescript/purescript-const.git
-        version: v6.0.0
-        dependencies:
-          - invariant
-          - newtype
-          - prelude
-      contravariant:
-        repo: https://github.com/purescript/purescript-contravariant.git
-        version: v6.0.0
-        dependencies:
-          - const
-          - either
-          - newtype
-          - prelude
-          - tuples
-      control:
-        repo: https://github.com/purescript/purescript-control.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      convertable-options:
-        repo: https://github.com/natefaubion/purescript-convertable-options.git
-        version: v1.0.0
-        dependencies:
-          - console
-          - effect
-          - maybe
-          - record
-      coroutines:
-        repo: https://github.com/purescript-contrib/purescript-coroutines.git
-        version: v7.0.0
-        dependencies:
-          - freet
-          - parallel
-          - profunctor
-      css:
-        repo: https://github.com/purescript-contrib/purescript-css.git
-        version: v6.0.0
-        dependencies:
-          - colors
-          - console
-          - effect
-          - nonempty
-          - profunctor
-          - strings
-          - these
-          - transformers
-      datetime:
-        repo: https://github.com/purescript/purescript-datetime.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - either
-          - enums
-          - foldable-traversable
-          - functions
-          - gen
-          - integers
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - ordered-collections
-          - partial
-          - prelude
-          - tuples
-      datetime-parsing:
-        repo: https://github.com/flounders/purescript-datetime-parsing.git
-        version: v0.2.0
-        dependencies:
-          - arrays
-          - datetime
-          - either
-          - enums
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - numbers
-          - parsing
-          - prelude
-          - strings
-          - unicode
-      debug:
-        repo: https://github.com/garyb/purescript-debug.git
-        version: v6.0.0
-        dependencies:
-          - functions
-          - prelude
-      decimals:
-        repo: https://github.com/sharkdp/purescript-decimals.git
-        version: v7.0.0
-        dependencies:
-          - maybe
-      dissect:
-        repo: https://github.com/PureFunctor/purescript-dissect.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - foreign-object
-          - functors
-          - newtype
-          - partial
-          - prelude
-          - tailrec
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - variant
-      distributive:
-        repo: https://github.com/purescript/purescript-distributive.git
-        version: v6.0.0
-        dependencies:
-          - identity
-          - newtype
-          - prelude
-          - tuples
-          - type-equality
-      dodo-printer:
-        repo: https://github.com/natefaubion/purescript-dodo-printer.git
-        version: v2.2.0
-        dependencies:
-          - aff
-          - ansi
-          - avar
-          - console
-          - effect
-          - foldable-traversable
-          - lists
-          - maybe
-          - minibench
-          - node-child-process
-          - node-fs-aff
-          - node-process
-          - psci-support
-          - strings
-      dom-indexed:
-        repo: https://github.com/purescript-halogen/purescript-dom-indexed.git
-        version: v11.0.0
-        dependencies:
-          - media-types
-          - prelude
-          - web-clipboard
-          - web-pointerevents
-          - web-touchevents
-      droplet:
-        repo: https://github.com/easafe/purescript-droplet.git
-        version: v0.4.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - bigints
-          - datetime
-          - debug
-          - effect
-          - either
-          - enums
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - integers
-          - maybe
-          - newtype
-          - nullable
-          - ordered-collections
-          - partial
-          - prelude
-          - profunctor
-          - record
-          - spec
-          - strings
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-      dynamic-buffer:
-        repo: https://github.com/kritzcreek/purescript-dynamic-buffer.git
-        version: v3.0.1
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - refs
-      effect:
-        repo: https://github.com/purescript/purescript-effect.git
-        version: v4.0.0
-        dependencies:
-          - prelude
-      either:
-        repo: https://github.com/purescript/purescript-either.git
-        version: v6.1.0
-        dependencies:
-          - control
-          - invariant
-          - maybe
-          - prelude
-      elmish:
-        repo: https://github.com/collegevine/purescript-elmish.git
-        version: v0.8.1
-        dependencies:
-          - aff
-          - argonaut-core
-          - arrays
-          - bifunctors
-          - console
-          - debug
-          - effect
-          - either
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - functions
-          - integers
-          - js-date
-          - maybe
-          - nullable
-          - partial
-          - prelude
-          - refs
-          - typelevel-prelude
-          - undefined-is-not-a-problem
-          - unsafe-coerce
-          - web-dom
-          - web-html
-      elmish-enzyme:
-        repo: https://github.com/collegevine/purescript-elmish-enzyme.git
-        version: v0.1.1
-        dependencies:
-          - aff
-          - aff-promise
-          - arrays
-          - console
-          - debug
-          - effect
-          - elmish
-          - foldable-traversable
-          - foreign
-          - functions
-          - prelude
-          - transformers
-          - unsafe-coerce
-      elmish-hooks:
-        repo: https://github.com/collegevine/purescript-elmish-hooks.git
-        version: v0.8.2
-        dependencies:
-          - aff
-          - debug
-          - elmish
-          - maybe
-          - prelude
-          - tuples
-          - undefined-is-not-a-problem
-      elmish-html:
-        repo: https://github.com/collegevine/purescript-elmish-html.git
-        version: v0.7.1
-        dependencies:
-          - effect
-          - elmish
-          - foreign
-          - foreign-object
-          - prelude
-          - record
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-html
-      email-validate:
-        repo: https://github.com/cdepillabout/purescript-email-validate.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - string-parsers
-          - transformers
-      encoding:
-        repo: https://github.com/menelaos/purescript-encoding.git
-        version: v0.0.8
-        dependencies:
-          - arraybuffer-types
-          - either
-          - exceptions
-          - functions
-          - prelude
-      enums:
-        repo: https://github.com/purescript/purescript-enums.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - either
-          - gen
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tuples
-          - unfoldable
-      exceptions:
-        repo: https://github.com/purescript/purescript-exceptions.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - either
-          - maybe
-          - prelude
-      exists:
-        repo: https://github.com/purescript/purescript-exists.git
-        version: v6.0.0
-        dependencies:
-          - unsafe-coerce
-      exitcodes:
-        repo: https://github.com/Risto-Stevcev/purescript-exitcodes.git
-        version: v4.0.0
-        dependencies:
-          - enums
-      expect-inferred:
-        repo: https://github.com/justinwoo/purescript-expect-inferred.git
-        version: v3.0.0
-        dependencies:
-          - prelude
-          - typelevel-prelude
-      fast-vect:
-        repo: https://github.com/sigma-andex/purescript-fast-vect.git
-        version: v0.7.0
-        dependencies:
-          - arrays
-          - filterable
-          - foldable-traversable
-          - lists
-          - maybe
-          - ordered-collections
-          - prelude
-          - profunctor
-          - tuples
-          - unfoldable
-      filterable:
-        repo: https://github.com/purescript/purescript-filterable.git
-        version: v5.0.0
-        dependencies:
-          - arrays
-          - either
-          - foldable-traversable
-          - identity
-          - lists
-          - ordered-collections
-      fixed-points:
-        repo: https://github.com/purescript-contrib/purescript-fixed-points.git
-        version: v7.0.0
-        dependencies:
-          - exists
-          - newtype
-          - prelude
-          - transformers
-      fixed-precision:
-        repo: https://github.com/lumihq/purescript-fixed-precision.git
-        version: v5.0.0
-        dependencies:
-          - arrays
-          - bigints
-          - control
-          - integers
-          - maybe
-          - numbers
-          - partial
-          - prelude
-          - strings
-      flame:
-        repo: https://github.com/easafe/purescript-flame.git
-        version: v1.2.0
-        dependencies:
-          - aff
-          - argonaut-codecs
-          - argonaut-core
-          - argonaut-generic
-          - arrays
-          - bifunctors
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - maybe
-          - newtype
-          - nullable
-          - partial
-          - prelude
-          - random
-          - refs
-          - spec
-          - strings
-          - tuples
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-html
-          - web-uievents
-      float32:
-        repo: https://github.com/purescript-contrib/purescript-float32.git
-        version: v2.0.0
-        dependencies:
-          - gen
-          - maybe
-          - prelude
-      foldable-traversable:
-        repo: https://github.com/purescript/purescript-foldable-traversable.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - const
-          - control
-          - either
-          - functors
-          - identity
-          - maybe
-          - newtype
-          - orders
-          - prelude
-          - tuples
-      foreign:
-        repo: https://github.com/purescript/purescript-foreign.git
-        version: v7.0.0
-        dependencies:
-          - either
-          - functions
-          - identity
-          - integers
-          - lists
-          - maybe
-          - prelude
-          - strings
-          - transformers
-      foreign-object:
-        repo: https://github.com/purescript/purescript-foreign-object.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - functions
-          - gen
-          - lists
-          - maybe
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - typelevel-prelude
-          - unfoldable
-      foreign-readwrite:
-        repo: https://github.com/artemisSystem/purescript-foreign-readwrite.git
-        version: v3.0.0
-        dependencies:
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - record
-          - safe-coerce
-          - transformers
-          - unsafe-coerce
-      fork:
-        repo: https://github.com/purescript-contrib/purescript-fork.git
-        version: v6.0.0
-        dependencies:
-          - aff
-      form-urlencoded:
-        repo: https://github.com/purescript-contrib/purescript-form-urlencoded.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - js-uri
-          - maybe
-          - newtype
-          - prelude
-          - strings
-          - tuples
-      formatters:
-        repo: https://github.com/purescript-contrib/purescript-formatters.git
-        version: v7.0.0
-        dependencies:
-          - datetime
-          - fixed-points
-          - lists
-          - numbers
-          - parsing
-          - prelude
-          - transformers
-      free:
-        repo: https://github.com/purescript/purescript-free.git
-        version: v7.0.0
-        dependencies:
-          - catenable-lists
-          - control
-          - distributive
-          - either
-          - exists
-          - foldable-traversable
-          - invariant
-          - lazy
-          - maybe
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-      freeap:
-        repo: https://github.com/ethul/purescript-freeap.git
-        version: v7.0.0
-        dependencies:
-          - const
-          - exists
-          - gen
-          - lists
-      freet:
-        repo: https://github.com/purescript-contrib/purescript-freet.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - bifunctors
-          - effect
-          - either
-          - exists
-          - free
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      functions:
-        repo: https://github.com/purescript/purescript-functions.git
-        version: v6.0.0
-        dependencies:
-          - prelude
-      functors:
-        repo: https://github.com/purescript/purescript-functors.git
-        version: v5.0.0
-        dependencies:
-          - bifunctors
-          - const
-          - contravariant
-          - control
-          - distributive
-          - either
-          - invariant
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - tuples
-          - unsafe-coerce
-      fuzzy:
-        repo: https://github.com/citizennet/purescript-fuzzy.git
-        version: v0.4.0
-        dependencies:
-          - foldable-traversable
-          - foreign-object
-          - newtype
-          - ordered-collections
-          - prelude
-          - rationals
-          - strings
-          - tuples
-      gen:
-        repo: https://github.com/purescript/purescript-gen.git
-        version: v4.0.0
-        dependencies:
-          - either
-          - foldable-traversable
-          - identity
-          - maybe
-          - newtype
-          - nonempty
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      generate-values:
-        repo: https://github.com/jordanmartinez/purescript-generate-values.git
-        version: v1.0.1
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - enums
-          - foldable-traversable
-          - gen
-          - identity
-          - integers
-          - lcg
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - partial
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      geometry-plane:
-        repo: https://github.com/Ebmtranceboy/purescript-geometry-plane.git
-        version: v1.0.3
-        dependencies:
-          - console
-          - effect
-          - psci-support
-          - sparse-polynomials
-      github-actions-toolkit:
-        repo: https://github.com/purescript-contrib/purescript-github-actions-toolkit.git
-        version: v0.5.0
-        dependencies:
-          - aff
-          - aff-promise
-          - effect
-          - foreign-object
-          - node-buffer
-          - node-path
-          - node-streams
-          - nullable
-          - transformers
-      graphs:
-        repo: https://github.com/purescript/purescript-graphs.git
-        version: v8.0.0
-        dependencies:
-          - catenable-lists
-          - ordered-collections
-      group:
-        repo: https://github.com/morganthomas/purescript-group.git
-        version: v4.1.1
-        dependencies:
-          - lists
-      halogen:
-        repo: https://github.com/purescript-halogen/purescript-halogen.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - avar
-          - console
-          - const
-          - dom-indexed
-          - effect
-          - foreign
-          - fork
-          - free
-          - freeap
-          - halogen-subscriptions
-          - halogen-vdom
-          - media-types
-          - nullable
-          - ordered-collections
-          - parallel
-          - profunctor
-          - transformers
-          - unsafe-coerce
-          - unsafe-reference
-          - web-file
-          - web-uievents
-      halogen-css:
-        repo: https://github.com/purescript-halogen/purescript-halogen-css.git
-        version: v10.0.0
-        dependencies:
-          - css
-          - halogen
-      halogen-formless:
-        repo: https://github.com/thomashoneyman/purescript-halogen-formless.git
-        version: v4.0.0
-        dependencies:
-          - convertable-options
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - halogen
-          - heterogeneous
-          - maybe
-          - prelude
-          - record
-          - safe-coerce
-          - type-equality
-          - unsafe-coerce
-          - unsafe-reference
-          - variant
-          - web-events
-          - web-uievents
-      halogen-hooks:
-        repo: https://github.com/thomashoneyman/purescript-halogen-hooks.git
-        version: v0.6.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - effect
-          - exceptions
-          - foldable-traversable
-          - foreign-object
-          - free
-          - freeap
-          - halogen
-          - halogen-subscriptions
-          - maybe
-          - newtype
-          - ordered-collections
-          - parallel
-          - partial
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-          - unsafe-reference
-          - web-dom
-          - web-html
-      halogen-hooks-extra:
-        repo: https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git
-        version: v0.9.0
-        dependencies:
-          - halogen-hooks
-      halogen-store:
-        repo: https://github.com/thomashoneyman/purescript-halogen-store.git
-        version: v0.5.0
-        dependencies:
-          - aff
-          - distributive
-          - effect
-          - fork
-          - halogen
-          - halogen-hooks
-          - halogen-subscriptions
-          - maybe
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-reference
-      halogen-storybook:
-        repo: https://github.com/rnons/purescript-halogen-storybook.git
-        version: v2.0.0
-        dependencies:
-          - foreign-object
-          - halogen
-          - prelude
-          - routing
-      halogen-subscriptions:
-        repo: https://github.com/purescript-halogen/purescript-halogen-subscriptions.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - effect
-          - foldable-traversable
-          - functors
-          - refs
-          - safe-coerce
-          - unsafe-reference
-      halogen-svg-elems:
-        repo: https://github.com/JordanMartinez/purescript-halogen-svg-elems.git
-        version: v6.0.0
-        dependencies:
-          - halogen
-      halogen-vdom:
-        repo: https://github.com/purescript-halogen/purescript-halogen-vdom.git
-        version: v8.0.0
-        dependencies:
-          - bifunctors
-          - effect
-          - foreign
-          - foreign-object
-          - maybe
-          - prelude
-          - refs
-          - tuples
-          - unsafe-coerce
-          - web-html
-      halogen-vdom-string-renderer:
-        repo: https://github.com/purescript-halogen/purescript-halogen-vdom-string-renderer.git
-        version: v0.5.0
-        dependencies:
-          - foreign
-          - halogen-vdom
-          - ordered-collections
-          - prelude
-      heckin:
-        repo: https://github.com/maxdeviant/purescript-heckin.git
-        version: v2.0.1
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - maybe
-          - prelude
-          - strings
-          - transformers
-          - tuples
-          - unicode
-      heterogeneous:
-        repo: https://github.com/natefaubion/purescript-heterogeneous.git
-        version: v0.6.0
-        dependencies:
-          - either
-          - functors
-          - prelude
-          - record
-          - tuples
-          - variant
-      heterogeneous-extrablatt:
-        repo: https://github.com/sigma-andex/purescript-heterogeneous-extrablatt.git
-        version: v0.2.1
-        dependencies:
-          - heterogeneous
-          - prelude
-          - record
-      http-methods:
-        repo: https://github.com/purescript-contrib/purescript-http-methods.git
-        version: v6.0.0
-        dependencies:
-          - either
-          - prelude
-          - strings
-      httpure:
-        repo: https://github.com/citizennet/purescript-httpure.git
-        version: v0.15.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - js-uri
-          - maybe
-          - newtype
-          - node-buffer
-          - node-fs
-          - node-http
-          - node-streams
-          - options
-          - ordered-collections
-          - prelude
-          - refs
-          - strings
-          - tuples
-          - type-equality
-      httpurple:
-        repo: https://github.com/sigma-andex/purescript-httpurple.git
-        version: v1.3.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - js-uri
-          - justifill
-          - maybe
-          - newtype
-          - node-buffer
-          - node-fs
-          - node-http
-          - node-net
-          - node-process
-          - node-streams
-          - options
-          - ordered-collections
-          - posix-types
-          - prelude
-          - profunctor
-          - record
-          - refs
-          - routing-duplex
-          - strings
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-      httpurple-argonaut:
-        repo: https://github.com/sigma-andex/purescript-httpurple-argonaut.git
-        version: v1.0.1
-        dependencies:
-          - argonaut
-          - console
-          - effect
-          - either
-          - httpurple
-          - prelude
-      httpurple-yoga-json:
-        repo: https://github.com/sigma-andex/purescript-httpurple-yoga-json.git
-        version: v1.0.0
-        dependencies:
-          - console
-          - effect
-          - either
-          - foreign
-          - httpurple
-          - lists
-          - prelude
-          - yoga-json
-      identity:
-        repo: https://github.com/purescript/purescript-identity.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - invariant
-          - newtype
-          - prelude
-      indexed-monad:
-        repo: https://github.com/garyb/purescript-indexed-monad.git
-        version: v2.1.0
-        dependencies:
-          - control
-          - newtype
-      int64:
-        repo: https://github.com/purescript-contrib/purescript-int64.git
-        version: v2.0.0
-        dependencies:
-          - effect
-          - foreign
-          - functions
-          - integers
-          - maybe
-          - nullable
-          - prelude
-          - quickcheck
-      integers:
-        repo: https://github.com/purescript/purescript-integers.git
-        version: v6.0.0
-        dependencies:
-          - maybe
-          - numbers
-          - prelude
-      interpolate:
-        repo: https://github.com/jordanmartinez/purescript-interpolate.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-      invariant:
-        repo: https://github.com/purescript/purescript-invariant.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - prelude
-      js-date:
-        repo: https://github.com/purescript-contrib/purescript-js-date.git
-        version: v8.0.0
-        dependencies:
-          - datetime
-          - effect
-          - exceptions
-          - foreign
-          - integers
-          - now
-      js-fileio:
-        repo: https://github.com/newlandsvalley/purescript-js-fileio.git
-        version: v3.0.0
-        dependencies:
-          - aff
-          - effect
-          - prelude
-      js-timers:
-        repo: https://github.com/purescript-contrib/purescript-js-timers.git
-        version: v6.1.0
-        dependencies:
-          - effect
-      js-uri:
-        repo: https://github.com/purescript-contrib/purescript-js-uri.git
-        version: v3.0.0
-        dependencies:
-          - functions
-          - maybe
-      justifill:
-        repo: https://github.com/i-am-the-slime/purescript-justifill.git
-        version: v0.5.0
-        dependencies:
-          - maybe
-          - prelude
-          - record
-          - typelevel-prelude
-      jwt:
-        repo: https://github.com/menelaos/purescript-jwt.git
-        version: v0.0.9
-        dependencies:
-          - argonaut-core
-          - arrays
-          - b64
-          - either
-          - exceptions
-          - prelude
-          - profunctor-lenses
-          - strings
-      language-cst-parser:
-        repo: https://github.com/natefaubion/purescript-language-cst-parser.git
-        version: v0.12.0
-        dependencies:
-          - arrays
-          - const
-          - control
-          - either
-          - foldable-traversable
-          - free
-          - functions
-          - functors
-          - identity
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - ordered-collections
-          - partial
-          - prelude
-          - st
-          - strings
-          - transformers
-          - tuples
-          - typelevel-prelude
-          - unfoldable
-          - unsafe-coerce
-      lazy:
-        repo: https://github.com/purescript/purescript-lazy.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - invariant
-          - prelude
-      lcg:
-        repo: https://github.com/purescript/purescript-lcg.git
-        version: v4.0.0
-        dependencies:
-          - effect
-          - integers
-          - maybe
-          - partial
-          - prelude
-          - random
-      leibniz:
-        repo: https://github.com/paf31/purescript-leibniz.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-          - unsafe-coerce
-      linalg:
-        repo: https://github.com/gbagan/purescript-linalg.git
-        version: v5.1.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - functions
-          - maybe
-          - prelude
-          - tuples
-      lists:
-        repo: https://github.com/purescript/purescript-lists.git
-        version: v7.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - foldable-traversable
-          - lazy
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      logging:
-        repo: https://github.com/rightfold/purescript-logging.git
-        version: v3.0.0
-        dependencies:
-          - console
-          - contravariant
-          - effect
-          - either
-          - prelude
-          - transformers
-          - tuples
-      machines:
-        repo: https://github.com/purescript-contrib/purescript-machines.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - lists
-          - maybe
-          - prelude
-          - profunctor
-          - tuples
-          - unfoldable
-      matrices:
-        repo: https://github.com/kRITZCREEK/purescript-matrices.git
-        version: v5.0.1
-        dependencies:
-          - arrays
-          - strings
-      matryoshka:
-        repo: https://github.com/purescript-contrib/purescript-matryoshka.git
-        version: v1.0.0
-        dependencies:
-          - fixed-points
-          - free
-          - prelude
-          - profunctor
-          - transformers
-      maybe:
-        repo: https://github.com/purescript/purescript-maybe.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - invariant
-          - newtype
-          - prelude
-      media-types:
-        repo: https://github.com/purescript-contrib/purescript-media-types.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      metadata:
-        repo: https://github.com/purescript/purescript-metadata.git
-        version: v0.15.0
-        dependencies: []
-      midi:
-        repo: https://github.com/newlandsvalley/purescript-midi.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - ordered-collections
-          - prelude
-          - signal
-          - string-parsers
-          - strings
-          - tuples
-          - unfoldable
-      minibench:
-        repo: https://github.com/purescript/purescript-minibench.git
-        version: v4.0.0
-        dependencies:
-          - console
-          - effect
-          - integers
-          - numbers
-          - partial
-          - prelude
-          - refs
-      mmorph:
-        repo: https://github.com/Thimoteus/purescript-mmorph.git
-        version: v7.0.0
-        dependencies:
-          - free
-          - functors
-          - transformers
-      monad-control:
-        repo: https://github.com/athanclark/purescript-monad-control.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - freet
-          - identity
-          - lists
-      monad-logger:
-        repo: https://github.com/cprussin/purescript-monad-logger.git
-        version: v1.3.1
-        dependencies:
-          - aff
-          - ansi
-          - argonaut
-          - arrays
-          - console
-          - control
-          - effect
-          - foldable-traversable
-          - foreign-object
-          - integers
-          - js-date
-          - maybe
-          - newtype
-          - ordered-collections
-          - prelude
-          - strings
-          - transformers
-          - tuples
-      monad-loops:
-        repo: https://github.com/mlang/purescript-monad-loops.git
-        version: v0.5.0
-        dependencies:
-          - lists
-          - maybe
-          - prelude
-          - tailrec
-          - tuples
-      monad-unlift:
-        repo: https://github.com/athanclark/purescript-monad-unlift.git
-        version: v1.0.1
-        dependencies:
-          - monad-control
-      monoidal:
-        repo: https://github.com/mcneissue/purescript-monoidal.git
-        version: v0.16.0
-        dependencies:
-          - either
-          - profunctor
-          - these
-          - tuples
-      morello:
-        repo: https://github.com/sigma-andex/purescript-morello.git
-        version: v0.3.2
-        dependencies:
-          - arrays
-          - barlow-lens
-          - foldable-traversable
-          - heterogeneous
-          - heterogeneous-extrablatt
-          - newtype
-          - prelude
-          - profunctor
-          - profunctor-lenses
-          - record
-          - tuples
-          - typelevel-prelude
-          - validation
-      motsunabe:
-        repo: https://github.com/justinwoo/purescript-motsunabe.git
-        version: v2.0.0
-        dependencies:
-          - lists
-          - strings
-      nano-id:
-        repo: https://github.com/eikooc/nano-id.git
-        version: v1.1.0
-        dependencies:
-          - aff
-          - effect
-          - lists
-          - maybe
-          - prelude
-          - random
-          - spec
-          - strings
-          - stringutils
-      naturals:
-        repo: https://github.com/LiamGoodacre/purescript-naturals.git
-        version: v3.0.0
-        dependencies:
-          - enums
-          - maybe
-          - prelude
-      nested-functor:
-        repo: https://github.com/acple/purescript-nested-functor.git
-        version: v0.2.1
-        dependencies:
-          - prelude
-          - type-equality
-      newtype:
-        repo: https://github.com/purescript/purescript-newtype.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-          - safe-coerce
-      node-buffer:
-        repo: https://github.com/purescript-node/purescript-node-buffer.git
-        version: v8.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - maybe
-          - st
-          - unsafe-coerce
-      node-buffer-blob:
-        repo: https://github.com/purescript-node/purescript-node-buffer-blob.git
-        version: v1.0.0
-        dependencies:
-          - aff-promise
-          - arraybuffer-types
-          - arrays
-          - console
-          - effect
-          - maybe
-          - media-types
-          - newtype
-          - node-buffer
-          - nullable
-          - prelude
-          - web-streams
-      node-child-process:
-        repo: https://github.com/purescript-node/purescript-node-child-process.git
-        version: v9.0.0
-        dependencies:
-          - exceptions
-          - foreign
-          - foreign-object
-          - functions
-          - node-fs
-          - node-streams
-          - nullable
-          - posix-types
-          - unsafe-coerce
-      node-fs:
-        repo: https://github.com/purescript-node/purescript-node-fs.git
-        version: v8.0.0
-        dependencies:
-          - datetime
-          - effect
-          - either
-          - enums
-          - exceptions
-          - functions
-          - integers
-          - js-date
-          - maybe
-          - node-buffer
-          - node-path
-          - node-streams
-          - nullable
-          - partial
-          - prelude
-          - strings
-          - unsafe-coerce
-      node-fs-aff:
-        repo: https://github.com/purescript-node/purescript-node-fs-aff.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - either
-          - node-fs
-          - node-path
-      node-http:
-        repo: https://github.com/purescript-node/purescript-node-http.git
-        version: v8.0.0
-        dependencies:
-          - arraybuffer-types
-          - contravariant
-          - effect
-          - foreign
-          - foreign-object
-          - maybe
-          - node-buffer
-          - node-net
-          - node-streams
-          - node-url
-          - nullable
-          - options
-          - prelude
-          - unsafe-coerce
-      node-net:
-        repo: https://github.com/purescript-node/purescript-node-net.git
-        version: v4.0.0
-        dependencies:
-          - effect
-          - either
-          - exceptions
-          - foreign
-          - maybe
-          - node-buffer
-          - node-fs
-          - nullable
-          - options
-          - prelude
-          - transformers
-      node-path:
-        repo: https://github.com/purescript-node/purescript-node-path.git
-        version: v5.0.0
-        dependencies:
-          - effect
-      node-process:
-        repo: https://github.com/purescript-node/purescript-node-process.git
-        version: v10.0.0
-        dependencies:
-          - effect
-          - foreign-object
-          - maybe
-          - node-streams
-          - posix-types
-          - prelude
-          - unsafe-coerce
-      node-readline:
-        repo: https://github.com/purescript-node/purescript-node-readline.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - foreign
-          - node-process
-          - node-streams
-          - options
-          - prelude
-      node-streams:
-        repo: https://github.com/purescript-node/purescript-node-streams.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - either
-          - exceptions
-          - node-buffer
-          - nullable
-          - prelude
-      node-streams-aff:
-        repo: https://github.com/jamesdbrock/purescript-node-streams-aff.git
-        version: v2.0.0
-        dependencies:
-          - aff
-          - arrays
-          - effect
-          - either
-          - exceptions
-          - maybe
-          - node-buffer
-          - node-streams
-          - prelude
-          - st
-          - tuples
-      node-url:
-        repo: https://github.com/purescript-node/purescript-node-url.git
-        version: v6.0.0
-        dependencies:
-          - nullable
-      nonempty:
-        repo: https://github.com/purescript/purescript-nonempty.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - maybe
-          - prelude
-          - tuples
-          - unfoldable
-      now:
-        repo: https://github.com/purescript-contrib/purescript-now.git
-        version: v6.0.0
-        dependencies:
-          - datetime
-          - effect
-      npm-package-json:
-        repo: https://github.com/maxdeviant/purescript-npm-package-json.git
-        version: v2.0.0
-        dependencies:
-          - argonaut
-          - control
-          - either
-          - foreign-object
-          - maybe
-          - ordered-collections
-          - prelude
-      nullable:
-        repo: https://github.com/purescript-contrib/purescript-nullable.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - functions
-          - maybe
-      numbers:
-        repo: https://github.com/purescript/purescript-numbers.git
-        version: v9.0.0
-        dependencies:
-          - functions
-          - maybe
-      open-folds:
-        repo: https://github.com/purescript-open-community/purescript-open-folds.git
-        version: v6.3.0
-        dependencies:
-          - bifunctors
-          - console
-          - control
-          - distributive
-          - effect
-          - either
-          - foldable-traversable
-          - identity
-          - invariant
-          - maybe
-          - newtype
-          - ordered-collections
-          - prelude
-          - profunctor
-          - psci-support
-          - tuples
-      open-memoize:
-        repo: https://github.com/purescript-open-community/purescript-open-memoize.git
-        version: v6.1.0
-        dependencies:
-          - console
-          - effect
-          - either
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - psci-support
-          - strings
-          - tuples
-      open-pairing:
-        repo: https://github.com/purescript-open-community/purescript-open-pairing.git
-        version: v6.1.0
-        dependencies:
-          - console
-          - control
-          - effect
-          - either
-          - free
-          - functors
-          - identity
-          - newtype
-          - prelude
-          - psci-support
-          - transformers
-          - tuples
-      options:
-        repo: https://github.com/purescript-contrib/purescript-options.git
-        version: v7.0.0
-        dependencies:
-          - contravariant
-          - foreign
-          - foreign-object
-          - maybe
-          - tuples
-      optparse:
-        repo: https://github.com/f-o-a-m/purescript-optparse.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - control
-          - effect
-          - either
-          - enums
-          - exists
-          - exitcodes
-          - foldable-traversable
-          - free
-          - gen
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - newtype
-          - node-buffer
-          - node-process
-          - node-streams
-          - nonempty
-          - numbers
-          - open-memoize
-          - partial
-          - prelude
-          - quickcheck
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-      ordered-collections:
-        repo: https://github.com/purescript/purescript-ordered-collections.git
-        version: v3.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - gen
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - unfoldable
-      ordered-set:
-        repo: https://github.com/flip111/purescript-ordered-set.git
-        version: v0.4.0
-        dependencies:
-          - argonaut-codecs
-          - arrays
-          - partial
-          - prelude
-          - unfoldable
-      orders:
-        repo: https://github.com/purescript/purescript-orders.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      pairs:
-        repo: https://github.com/sharkdp/purescript-pairs.git
-        version: v9.0.0
-        dependencies:
-          - console
-          - distributive
-          - foldable-traversable
-          - quickcheck
-      parallel:
-        repo: https://github.com/purescript/purescript-parallel.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - functors
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - refs
-          - transformers
-      parsing:
-        repo: https://github.com/purescript-contrib/purescript-parsing.git
-        version: v9.1.0
-        dependencies:
-          - arrays
-          - either
-          - foldable-traversable
-          - identity
-          - integers
-          - lists
-          - maybe
-          - nullable
-          - prelude
-          - strings
-          - transformers
-          - unicode
-      parsing-dataview:
-        repo: https://github.com/jamesdbrock/purescript-parsing-dataview.git
-        version: v3.1.0
-        dependencies:
-          - arraybuffer
-          - arraybuffer-types
-          - effect
-          - float32
-          - maybe
-          - parsing
-          - prelude
-          - transformers
-          - tuples
-          - uint
-      partial:
-        repo: https://github.com/purescript/purescript-partial.git
-        version: v4.0.0
-        dependencies: []
-      pathy:
-        repo: https://github.com/purescript-contrib/purescript-pathy.git
-        version: v9.0.0
-        dependencies:
-          - console
-          - exceptions
-          - lists
-          - partial
-          - profunctor
-          - strings
-          - transformers
-          - typelevel-prelude
-          - unsafe-coerce
-      pha:
-        repo: https://github.com/gbagan/purescript-pha.git
-        version: v0.9.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - datetime
-          - effect
-          - foldable-traversable
-          - free
-          - integers
-          - maybe
-          - prelude
-          - profunctor-lenses
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-          - unsafe-reference
-          - web-dom
-          - web-events
-          - web-html
-          - web-pointerevents
-          - web-uievents
-      phaser:
-        repo: https://github.com/lfarroco/purescript-phaser.git
-        version: v0.6.0
-        dependencies:
-          - canvas
-          - console
-          - effect
-          - maybe
-          - nullable
-          - options
-          - prelude
-          - web-html
-      pipes:
-        repo: https://github.com/felixschl/purescript-pipes.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - lists
-          - mmorph
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      point-free:
-        repo: https://github.com/ursi/purescript-point-free.git
-        version: v1.0.0
-        dependencies:
-          - prelude
-      polymorphic-vectors:
-        repo: https://github.com/artemisSystem/purescript-polymorphic-vectors.git
-        version: v4.0.0
-        dependencies:
-          - distributive
-          - foldable-traversable
-          - numbers
-          - prelude
-          - record
-          - safe-coerce
-          - type-equality
-          - typelevel-prelude
-      posix-types:
-        repo: https://github.com/purescript-node/purescript-posix-types.git
-        version: v6.0.0
-        dependencies:
-          - maybe
-          - prelude
-      precise:
-        repo: https://github.com/purescript-contrib/purescript-precise.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - exceptions
-          - gen
-          - integers
-          - lists
-          - numbers
-          - prelude
-          - strings
-      precise-datetime:
-        repo: https://github.com/awakesecurity/purescript-precise-datetime.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - datetime
-          - decimals
-          - either
-          - enums
-          - foldable-traversable
-          - formatters
-          - integers
-          - js-date
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - strings
-          - tuples
-          - unicode
-      prelude:
-        repo: https://github.com/purescript/purescript-prelude.git
-        version: v6.0.0
-        dependencies: []
-      prettier-printer:
-        repo: https://github.com/paulyoung/purescript-prettier-printer.git
-        version: v3.0.0
-        dependencies:
-          - console
-          - lists
-          - prelude
-          - strings
-          - tuples
-      profunctor:
-        repo: https://github.com/purescript/purescript-profunctor.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - distributive
-          - either
-          - exists
-          - invariant
-          - newtype
-          - prelude
-          - tuples
-      profunctor-lenses:
-        repo: https://github.com/purescript-contrib/purescript-profunctor-lenses.git
-        version: v8.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - const
-          - control
-          - distributive
-          - either
-          - foldable-traversable
-          - foreign-object
-          - functors
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - ordered-collections
-          - partial
-          - prelude
-          - profunctor
-          - record
-          - transformers
-          - tuples
-      protobuf:
-        repo: https://github.com/xc-jp/purescript-protobuf.git
-        version: v4.0.0
-        dependencies:
-          - arraybuffer
-          - arraybuffer-builder
-          - arraybuffer-types
-          - arrays
-          - control
-          - effect
-          - either
-          - enums
-          - exceptions
-          - float32
-          - foldable-traversable
-          - functions
-          - int64
-          - maybe
-          - newtype
-          - parsing
-          - parsing-dataview
-          - prelude
-          - record
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-          - uint
-          - web-encoding
-      ps-cst:
-        repo: https://github.com/purescript-codegen/purescript-ps-cst.git
-        version: v1.2.0
-        dependencies:
-          - ansi
-          - console
-          - dodo-printer
-          - effect
-          - node-fs-aff
-          - node-path
-          - psci-support
-          - record
-          - strings
-      psa-utils:
-        repo: https://github.com/natefaubion/purescript-psa-utils.git
-        version: v8.0.0
-        dependencies:
-          - ansi
-          - argonaut-codecs
-          - argonaut-core
-          - arrays
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - maybe
-          - node-path
-          - ordered-collections
-          - prelude
-          - strings
-          - tuples
-          - unsafe-coerce
-      psc-ide:
-        repo: https://github.com/kRITZCREEK/purescript-psc-ide.git
-        version: v19.0.0
-        dependencies:
-          - aff
-          - argonaut
-          - arrays
-          - console
-          - maybe
-          - node-child-process
-          - node-fs
-          - parallel
-          - random
-      psci-support:
-        repo: https://github.com/purescript/purescript-psci-support.git
-        version: v6.0.0
-        dependencies:
-          - console
-          - effect
-          - prelude
-      qualified-do:
-        repo: https://github.com/artemisSystem/purescript-qualified-do.git
-        version: v2.2.0
-        dependencies:
-          - arrays
-          - control
-          - foldable-traversable
-          - parallel
-          - prelude
-          - unfoldable
-      quantities:
-        repo: https://github.com/sharkdp/purescript-quantities.git
-        version: v12.0.1
-        dependencies:
-          - decimals
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - newtype
-          - nonempty
-          - numbers
-          - pairs
-          - prelude
-          - tuples
-      quickcheck:
-        repo: https://github.com/purescript/purescript-quickcheck.git
-        version: v8.0.1
-        dependencies:
-          - arrays
-          - console
-          - control
-          - effect
-          - either
-          - enums
-          - exceptions
-          - foldable-traversable
-          - gen
-          - identity
-          - integers
-          - lazy
-          - lcg
-          - lists
-          - maybe
-          - newtype
-          - nonempty
-          - numbers
-          - partial
-          - prelude
-          - record
-          - st
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-          - unfoldable
-      quickcheck-combinators:
-        repo: https://github.com/athanclark/purescript-quickcheck-combinators.git
-        version: v0.1.3
-        dependencies:
-          - quickcheck
-          - typelevel
-      quickcheck-laws:
-        repo: https://github.com/purescript-contrib/purescript-quickcheck-laws.git
-        version: v7.0.0
-        dependencies:
-          - enums
-          - quickcheck
-      quickcheck-utf8:
-        repo: https://github.com/openchronology/purescript-quickcheck-utf8.git
-        version: v0.0.0
-        dependencies:
-          - quickcheck
-      quotient:
-        repo: https://github.com/rightfold/purescript-quotient.git
-        version: v3.0.0
-        dependencies:
-          - prelude
-          - quickcheck
-      random:
-        repo: https://github.com/purescript/purescript-random.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - integers
-      rationals:
-        repo: https://github.com/anttih/purescript-rationals.git
-        version: v5.0.0
-        dependencies:
-          - integers
-          - prelude
-      react:
-        repo: https://github.com/purescript-contrib/purescript-react.git
-        version: v10.0.1
-        dependencies:
-          - effect
-          - exceptions
-          - maybe
-          - nullable
-          - prelude
-          - typelevel-prelude
-          - unsafe-coerce
-      react-basic:
-        repo: https://github.com/lumihq/purescript-react-basic.git
-        version: v17.0.0
-        dependencies:
-          - effect
-          - prelude
-          - record
-      react-basic-dom:
-        repo: https://github.com/lumihq/purescript-react-basic-dom.git
-        version: v5.0.0
-        dependencies:
-          - effect
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - nullable
-          - prelude
-          - react-basic
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-file
-          - web-html
-      react-basic-hooks:
-        repo: https://github.com/megamaddu/purescript-react-basic-hooks.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - aff-promise
-          - bifunctors
-          - console
-          - control
-          - datetime
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - functions
-          - indexed-monad
-          - integers
-          - maybe
-          - newtype
-          - now
-          - nullable
-          - ordered-collections
-          - prelude
-          - react-basic
-          - refs
-          - tuples
-          - type-equality
-          - unsafe-coerce
-          - unsafe-reference
-          - web-html
-      react-dom:
-        repo: https://github.com/purescript-contrib/purescript-react-dom.git
-        version: v8.0.0
-        dependencies:
-          - effect
-          - react
-          - web-dom
-      read:
-        repo: https://github.com/truqu/purescript-read.git
-        version: v1.0.1
-        dependencies:
-          - maybe
-          - prelude
-          - strings
-      record:
-        repo: https://github.com/purescript/purescript-record.git
-        version: v4.0.0
-        dependencies:
-          - functions
-          - prelude
-          - unsafe-coerce
-      refined:
-        repo: https://github.com/danieljharvey/purescript-refined.git
-        version: v1.0.0
-        dependencies:
-          - argonaut
-          - effect
-          - prelude
-          - quickcheck
-          - typelevel
-      refs:
-        repo: https://github.com/purescript/purescript-refs.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - prelude
-      remotedata:
-        repo: https://github.com/krisajenkins/purescript-remotedata.git
-        version: v5.0.0
-        dependencies:
-          - bifunctors
-          - either
-          - profunctor-lenses
-      resource:
-        repo: https://github.com/joneshf/purescript-resource.git
-        version: v2.0.1
-        dependencies:
-          - aff
-          - console
-          - control
-          - effect
-          - newtype
-          - prelude
-          - psci-support
-          - refs
-      resourcet:
-        repo: https://github.com/robertdp/purescript-resourcet.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - effect
-          - foldable-traversable
-          - maybe
-          - ordered-collections
-          - parallel
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-      result:
-        repo: https://github.com/ad-si/purescript-result.git
-        version: v1.0.3
-        dependencies:
-          - either
-          - foldable-traversable
-          - prelude
-      return:
-        repo: https://github.com/ursi/purescript-return.git
-        version: v0.2.0
-        dependencies:
-          - foldable-traversable
-          - point-free
-          - prelude
-      ring-modules:
-        repo: https://github.com/f-o-a-m/purescript-ring-modules.git
-        version: v5.0.1
-        dependencies:
-          - prelude
-      routing:
-        repo: https://github.com/purescript-contrib/purescript-routing.git
-        version: v11.0.0
-        dependencies:
-          - aff
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - integers
-          - js-uri
-          - lists
-          - maybe
-          - numbers
-          - partial
-          - prelude
-          - semirings
-          - tuples
-          - validation
-          - web-html
-      routing-duplex:
-        repo: https://github.com/natefaubion/purescript-routing-duplex.git
-        version: v0.6.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - js-uri
-          - lazy
-          - numbers
-          - prelude
-          - profunctor
-          - record
-          - strings
-          - typelevel-prelude
-      run:
-        repo: https://github.com/natefaubion/purescript-run.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - free
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - tailrec
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - variant
-      safe-coerce:
-        repo: https://github.com/purescript/purescript-safe-coerce.git
-        version: v2.0.0
-        dependencies:
-          - unsafe-coerce
-      safely:
-        repo: https://github.com/paf31/purescript-safely.git
-        version: v4.0.1
-        dependencies:
-          - freet
-          - lists
-      selection-foldable:
-        repo: https://github.com/jamieyung/purescript-selection-foldable.git
-        version: v0.2.0
-        dependencies:
-          - filterable
-          - foldable-traversable
-          - maybe
-          - prelude
-      semirings:
-        repo: https://github.com/purescript/purescript-semirings.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - lists
-          - newtype
-          - prelude
-      signal:
-        repo: https://github.com/bodil/purescript-signal.git
-        version: v13.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - foldable-traversable
-          - maybe
-          - prelude
-      simple-emitter:
-        repo: https://github.com/oreshinya/purescript-simple-emitter.git
-        version: v2.0.0
-        dependencies:
-          - ordered-collections
-          - refs
-      sized-matrices:
-        repo: https://github.com/csicar/purescript-sized-matrices.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - distributive
-          - foldable-traversable
-          - maybe
-          - prelude
-          - sized-vectors
-          - strings
-          - typelevel
-          - unfoldable
-          - vectorfield
-      sized-vectors:
-        repo: https://github.com/bodil/purescript-sized-vectors.git
-        version: v5.0.2
-        dependencies:
-          - argonaut
-          - arrays
-          - distributive
-          - foldable-traversable
-          - maybe
-          - prelude
-          - quickcheck
-          - typelevel
-          - unfoldable
-      slug:
-        repo: https://github.com/thomashoneyman/purescript-slug.git
-        version: v3.0.1
-        dependencies:
-          - argonaut-codecs
-          - maybe
-          - prelude
-          - strings
-          - unicode
-      soundfonts:
-        repo: https://github.com/newlandsvalley/purescript-soundfonts.git
-        version: v4.1.0
-        dependencies:
-          - aff
-          - affjax
-          - affjax-web
-          - argonaut-core
-          - arraybuffer-types
-          - arrays
-          - b64
-          - bifunctors
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign-object
-          - http-methods
-          - integers
-          - lists
-          - maybe
-          - midi
-          - ordered-collections
-          - parallel
-          - partial
-          - prelude
-          - strings
-          - transformers
-          - tuples
-      sparse-matrices:
-        repo: https://github.com/Ebmtranceboy/purescript-sparse-matrices.git
-        version: v1.2.1
-        dependencies:
-          - console
-          - effect
-          - prelude
-          - sparse-polynomials
-      sparse-polynomials:
-        repo: https://github.com/Ebmtranceboy/purescript-sparse-polynomials.git
-        version: v1.0.5
-        dependencies:
-          - cartesian
-          - console
-          - effect
-          - ordered-collections
-          - prelude
-          - rationals
-          - tuples
-      spec:
-        repo: https://github.com/purescript-spec/purescript-spec.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - ansi
-          - avar
-          - console
-          - exceptions
-          - foldable-traversable
-          - fork
-          - now
-          - pipes
-          - prelude
-          - strings
-          - transformers
-      spec-discovery:
-        repo: https://github.com/purescript-spec/purescript-spec-discovery.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - aff-promise
-          - arrays
-          - console
-          - effect
-          - foldable-traversable
-          - node-fs
-          - prelude
-          - spec
-      spec-quickcheck:
-        repo: https://github.com/purescript-spec/purescript-spec-quickcheck.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - prelude
-          - quickcheck
-          - random
-          - spec
-      ssrs:
-        repo: https://github.com/PureFunctor/purescript-ssrs.git
-        version: v1.0.0
-        dependencies:
-          - dissect
-          - either
-          - fixed-points
-          - free
-          - lists
-          - prelude
-          - safe-coerce
-          - tailrec
-          - tuples
-          - variant
-      st:
-        repo: https://github.com/purescript/purescript-st.git
-        version: v6.0.0
-        dependencies:
-          - partial
-          - prelude
-          - tailrec
-          - unsafe-coerce
-      strictlypositiveint:
-        repo: https://github.com/jamieyung/purescript-strictlypositiveint.git
-        version: v1.0.1
-        dependencies:
-          - prelude
-      string-parsers:
-        repo: https://github.com/purescript-contrib/purescript-string-parsers.git
-        version: v8.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - prelude
-          - strings
-          - tailrec
-      strings:
-        repo: https://github.com/purescript/purescript-strings.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - enums
-          - foldable-traversable
-          - gen
-          - integers
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-          - unsafe-coerce
-      strings-extra:
-        repo: https://github.com/purescript-contrib/purescript-strings-extra.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - maybe
-          - prelude
-          - strings
-          - unicode
-      stringutils:
-        repo: https://github.com/menelaos/purescript-stringutils.git
-        version: v0.0.12
-        dependencies:
-          - arrays
-          - integers
-          - maybe
-          - partial
-          - prelude
-          - strings
-      substitute:
-        repo: https://github.com/ursi/purescript-substitute.git
-        version: v0.2.3
-        dependencies:
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - prelude
-          - return
-          - strings
-      supply:
-        repo: https://github.com/ajnsit/purescript-supply.git
-        version: v0.2.0
-        dependencies:
-          - console
-          - control
-          - effect
-          - lazy
-          - prelude
-          - refs
-          - tuples
-      tailrec:
-        repo: https://github.com/purescript/purescript-tailrec.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - effect
-          - either
-          - identity
-          - maybe
-          - partial
-          - prelude
-          - refs
-      test-unit:
-        repo: https://github.com/bodil/purescript-test-unit.git
-        version: v17.0.0
-        dependencies:
-          - aff
-          - avar
-          - effect
-          - either
-          - free
-          - js-timers
-          - lists
-          - prelude
-          - quickcheck
-          - strings
-      thermite:
-        repo: https://github.com/paf31/purescript-thermite.git
-        version: v6.3.1
-        dependencies:
-          - aff
-          - coroutines
-          - freet
-          - profunctor-lenses
-          - react
-      thermite-dom:
-        repo: https://github.com/athanclark/purescript-thermite-dom.git
-        version: v0.3.1
-        dependencies:
-          - react
-          - react-dom
-          - thermite
-          - web-html
-      these:
-        repo: https://github.com/purescript-contrib/purescript-these.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - gen
-          - lists
-          - quickcheck
-          - quickcheck-laws
-          - tuples
-      transformers:
-        repo: https://github.com/purescript/purescript-transformers.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - distributive
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - identity
-          - lazy
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      tree-rose:
-        repo: https://github.com/jordanmartinez/purescript-tree-rose.git
-        version: v4.0.2
-        dependencies:
-          - control
-          - foldable-traversable
-          - free
-          - lists
-          - maybe
-          - prelude
-          - tailrec
-      tuples:
-        repo: https://github.com/purescript/purescript-tuples.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - invariant
-          - prelude
-      two-or-more:
-        repo: https://github.com/i-am-the-slime/purescript-two-or-more.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - foldable-traversable
-          - maybe
-          - partial
-          - prelude
-          - psci-support
-          - tuples
-      type-equality:
-        repo: https://github.com/purescript/purescript-type-equality.git
-        version: v4.0.1
-        dependencies: []
-      typelevel:
-        repo: https://github.com/bodil/purescript-typelevel.git
-        version: v6.0.0
-        dependencies:
-          - partial
-          - prelude
-          - tuples
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-lists:
-        repo: https://github.com/PureFunctor/purescript-typelevel-lists.git
-        version: v2.1.0
-        dependencies:
-          - prelude
-          - tuples
-          - typelevel-peano
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-peano:
-        repo: https://github.com/csicar/purescript-typelevel-peano.git
-        version: v1.0.1
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - prelude
-          - psci-support
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-prelude:
-        repo: https://github.com/purescript/purescript-typelevel-prelude.git
-        version: v7.0.0
-        dependencies:
-          - prelude
-          - type-equality
-      typelevel-rows:
-        repo: https://github.com/jordanmartinez/purescript-typelevel-rows.git
-        version: v0.1.0
-        dependencies:
-          - prelude
-      uint:
-        repo: https://github.com/purescript-contrib/purescript-uint.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - enums
-          - gen
-          - maybe
-          - numbers
-          - prelude
-      uncurried-transformers:
-        repo: https://github.com/PureFunctor/purescript-uncurried-transformers.git
-        version: v1.1.0
-        dependencies:
-          - control
-          - effect
-          - either
-          - functions
-          - identity
-          - prelude
-          - safe-coerce
-          - tailrec
-          - transformers
-          - tuples
-      undefined-is-not-a-problem:
-        repo: https://github.com/paluh/purescript-undefined-is-not-a-problem.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - assert
-          - effect
-          - either
-          - foreign
-          - maybe
-          - newtype
-          - prelude
-          - random
-          - tuples
-          - type-equality
-          - unsafe-coerce
-      unfoldable:
-        repo: https://github.com/purescript/purescript-unfoldable.git
-        version: v6.0.0
-        dependencies:
-          - foldable-traversable
-          - maybe
-          - partial
-          - prelude
-          - tuples
-      unicode:
-        repo: https://github.com/purescript-contrib/purescript-unicode.git
-        version: v6.0.0
-        dependencies:
-          - foldable-traversable
-          - maybe
-          - strings
-      unlift:
-        repo: https://github.com/tweag/purescript-unlift.git
-        version: v1.0.1
-        dependencies:
-          - aff
-          - effect
-          - either
-          - freet
-          - identity
-          - lists
-          - maybe
-          - monad-control
-          - prelude
-          - st
-          - transformers
-          - tuples
-      unsafe-coerce:
-        repo: https://github.com/purescript/purescript-unsafe-coerce.git
-        version: v6.0.0
-        dependencies: []
-      unsafe-reference:
-        repo: https://github.com/purescript-contrib/purescript-unsafe-reference.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-      uri:
-        repo: https://github.com/purescript-contrib/purescript-uri.git
-        version: v9.0.0
-        dependencies:
-          - arrays
-          - integers
-          - js-uri
-          - numbers
-          - parsing
-          - prelude
-          - profunctor-lenses
-          - these
-          - transformers
-          - unfoldable
-      validation:
-        repo: https://github.com/purescript/purescript-validation.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - newtype
-          - prelude
-      variant:
-        repo: https://github.com/natefaubion/purescript-variant.git
-        version: v8.0.0
-        dependencies:
-          - enums
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - record
-          - tuples
-          - unsafe-coerce
-      vectorfield:
-        repo: https://github.com/csicar/purescript-vectorfield.git
-        version: v1.0.1
-        dependencies:
-          - console
-          - effect
-          - group
-          - prelude
-          - psci-support
-      versions:
-        repo: https://github.com/hdgarrood/purescript-versions.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - either
-          - foldable-traversable
-          - functions
-          - integers
-          - lists
-          - maybe
-          - orders
-          - parsing
-          - partial
-          - strings
-      web-clipboard:
-        repo: https://github.com/purescript-web/purescript-web-clipboard.git
-        version: v4.0.0
-        dependencies:
-          - web-html
-      web-cssom:
-        repo: https://github.com/purescript-web/purescript-web-cssom.git
-        version: v2.0.0
-        dependencies:
-          - web-dom
-          - web-html
-          - web-uievents
-      web-dom:
-        repo: https://github.com/purescript-web/purescript-web-dom.git
-        version: v6.0.0
-        dependencies:
-          - web-events
-      web-dom-parser:
-        repo: https://github.com/purescript-web/purescript-web-dom-parser.git
-        version: v8.0.0
-        dependencies:
-          - effect
-          - partial
-          - prelude
-          - web-dom
-      web-dom-xpath:
-        repo: https://github.com/purescript-web/purescript-web-dom-xpath.git
-        version: v3.0.0
-        dependencies:
-          - web-dom
-      web-encoding:
-        repo: https://github.com/purescript-web/purescript-web-encoding.git
-        version: v3.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - newtype
-          - prelude
-      web-events:
-        repo: https://github.com/purescript-web/purescript-web-events.git
-        version: v4.0.0
-        dependencies:
-          - datetime
-          - enums
-          - foreign
-          - nullable
-      web-fetch:
-        repo: https://github.com/purescript-web/purescript-web-fetch.git
-        version: v3.0.0
-        dependencies:
-          - effect
-          - foreign-object
-          - http-methods
-          - prelude
-          - record
-          - typelevel-prelude
-          - web-file
-          - web-promise
-          - web-streams
-      web-file:
-        repo: https://github.com/purescript-web/purescript-web-file.git
-        version: v4.0.0
-        dependencies:
-          - foreign
-          - media-types
-          - web-dom
-      web-html:
-        repo: https://github.com/purescript-web/purescript-web-html.git
-        version: v4.0.0
-        dependencies:
-          - js-date
-          - web-dom
-          - web-file
-          - web-storage
-      web-page-visibility:
-        repo: https://git.sr.ht/~toastal/purescript-web-page-visibility
-        version: v2.0.0
-        dependencies:
-          - effect
-          - enums
-          - exceptions
-          - maybe
-          - prelude
-          - strings
-          - web-events
-          - web-html
-      web-pointerevents:
-        repo: https://github.com/purescript-web/purescript-web-pointerevents.git
-        version: v1.0.0
-        dependencies:
-          - effect
-          - maybe
-          - prelude
-          - web-dom
-          - web-uievents
-      web-promise:
-        repo: https://github.com/purescript-web/purescript-web-promise.git
-        version: v3.0.0
-        dependencies:
-          - effect
-          - exceptions
-          - foldable-traversable
-          - functions
-          - maybe
-          - prelude
-      web-socket:
-        repo: https://github.com/purescript-web/purescript-web-socket.git
-        version: v4.0.0
-        dependencies:
-          - arraybuffer-types
-          - web-file
-      web-storage:
-        repo: https://github.com/purescript-web/purescript-web-storage.git
-        version: v5.0.0
-        dependencies:
-          - nullable
-          - web-events
-      web-streams:
-        repo: https://github.com/purescript-web/purescript-web-streams.git
-        version: v3.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - exceptions
-          - nullable
-          - prelude
-          - tuples
-          - web-promise
-      web-touchevents:
-        repo: https://github.com/purescript-web/purescript-web-touchevents.git
-        version: v4.0.0
-        dependencies:
-          - web-uievents
-      web-uievents:
-        repo: https://github.com/purescript-web/purescript-web-uievents.git
-        version: v4.0.0
-        dependencies:
-          - web-html
-      web-workers:
-        repo: https://github.com/gbagan/purescript-web-workers.git
-        version: v1.1.0
-        dependencies:
-          - effect
-          - foreign
-          - maybe
-          - prelude
-          - unsafe-coerce
-          - web-events
-      web-xhr:
-        repo: https://github.com/purescript-web/purescript-web-xhr.git
-        version: v5.0.0
-        dependencies:
-          - arraybuffer-types
-          - datetime
-          - http-methods
-          - web-dom
-          - web-file
-          - web-html
-      yoga-fetch:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-fetch.git
-        version: v1.0.1
-        dependencies:
-          - aff
-          - aff-promise
-          - arraybuffer-types
-          - effect
-          - foreign
-          - foreign-object
-          - newtype
-          - prelude
-          - typelevel-prelude
-          - unsafe-coerce
-      yoga-json:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-json.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - identity
-          - lists
-          - maybe
-          - nullable
-          - partial
-          - prelude
-          - record
-          - transformers
-          - typelevel-prelude
-          - variant
-      yoga-postgres:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-postgres.git
-        version: v6.0.0
-        dependencies:
-          - aff
-          - arrays
-          - datetime
-          - effect
-          - either
-          - enums
-          - foldable-traversable
-          - foreign
-          - integers
-          - maybe
-          - nullable
-          - prelude
-          - transformers
-          - unsafe-coerce
+      abc-parser: 2.0.0
+      ace: 9.0.0
+      aff: 7.1.0
+      aff-bus: 6.0.0
+      aff-coroutines: 9.0.0
+      aff-promise: 4.0.0
+      aff-retry: 2.0.0
+      affjax: 13.0.0
+      affjax-node: 1.0.0
+      affjax-web: 1.0.0
+      ansi: 7.0.0
+      argonaut: 9.0.0
+      argonaut-aeson-generic: 0.4.1
+      argonaut-codecs: 9.1.0
+      argonaut-core: 7.0.0
+      argonaut-generic: 8.0.0
+      argonaut-traversals: 10.0.0
+      argparse-basic: 2.0.0
+      array-builder: 0.1.2
+      arraybuffer: 13.1.1
+      arraybuffer-builder: 3.1.0
+      arraybuffer-types: 3.0.2
+      arrays: 7.1.0
+      arrays-zipper: 2.0.1
+      ask: 1.0.0
+      assert: 6.0.0
+      avar: 5.0.0
+      b64: 0.0.8
+      barbies: 1.0.1
+      barlow-lens: 0.9.0
+      basic-auth: 3.0.1
+      bifunctors: 6.0.0
+      bigints: 7.0.1
+      bolson: 0.3.1
+      bower-json: 3.0.0
+      bucketchain: 1.0.1
+      bucketchain-basic-auth: 1.0.1
+      bucketchain-conditional: 1.0.1
+      bucketchain-cors: 1.0.1
+      bucketchain-csrf: 1.0.1
+      bucketchain-header-utils: 1.0.1
+      bucketchain-health: 1.0.1
+      bucketchain-history-api-fallback: 1.0.1
+      bucketchain-logger: 1.0.1
+      bucketchain-secure: 1.0.1
+      bucketchain-simple-api: 5.0.1
+      bucketchain-sslify: 1.0.1
+      bucketchain-static: 1.0.1
+      call-by-name: 4.0.1
+      canvas: 6.0.0
+      canvas-action: 9.0.0
+      cartesian: 1.0.6
+      catenable-lists: 7.0.0
+      channel: 1.0.0
+      checked-exceptions: 3.1.1
+      classless: 0.1.1
+      classless-arbitrary: 0.1.1
+      classless-decode-json: 0.1.1
+      classless-encode-json: 0.1.3
+      classnames: 2.0.0
+      codec: 6.0.0
+      codec-argonaut: 10.0.0
+      colors: 7.0.1
+      concur-core: 0.5.0
+      concur-react: 0.5.0
+      concurrent-queues: 3.0.0
+      console: 6.0.0
+      const: 6.0.0
+      contravariant: 6.0.0
+      control: 6.0.0
+      convertable-options: 1.0.0
+      coroutines: 7.0.0
+      crypto: 5.0.1
+      css: 6.0.0
+      datetime: 6.1.0
+      datetime-parsing: 0.2.0
+      debug: 6.0.2
+      decimals: 7.1.0
+      default-values: 1.0.1
+      deku: 0.9.9
+      deno: 0.0.5
+      dissect: 1.0.0
+      distributive: 6.0.0
+      dodo-printer: 2.2.1
+      dom-filereader: 7.0.0
+      dom-indexed: 11.0.0
+      dotenv: 3.0.0
+      droplet: 0.5.0
+      dynamic-buffer: 3.0.1
+      echarts-simple: 0.0.1
+      effect: 4.0.0
+      either: 6.1.0
+      elmish: 0.8.3
+      elmish-enzyme: 0.1.1
+      elmish-hooks: 0.9.1
+      elmish-html: 0.7.2
+      elmish-testing-library: 0.3.1
+      email-validate: 7.0.0
+      encoding: 0.0.8
+      enums: 6.0.1
+      error: 2.0.0
+      exceptions: 6.0.0
+      exists: 6.0.0
+      exitcodes: 4.0.0
+      expect-inferred: 3.0.0
+      fahrtwind: 2.0.0
+      fallback: 0.1.0
+      fast-vect: 1.1.0
+      fetch: 1.1.4
+      fetch-argonaut: 1.0.0
+      fetch-core: 4.0.4
+      fetch-yoga-json: 1.1.0
+      filterable: 5.0.0
+      fixed-points: 7.0.0
+      fixed-precision: 5.0.0
+      flame: 1.2.0
+      float32: 2.0.0
+      foldable-traversable: 6.0.0
+      foreign: 7.0.0
+      foreign-object: 4.1.0
+      foreign-readwrite: 3.4.0
+      fork: 6.0.0
+      form-urlencoded: 7.0.0
+      formatters: 7.0.0
+      framer-motion: 1.0.1
+      free: 7.0.0
+      freeap: 7.0.0
+      freer-free: 0.0.1
+      freet: 7.0.0
+      functions: 6.0.0
+      functor1: 3.0.0
+      functors: 5.0.0
+      fuzzy: 0.4.0
+      gen: 4.0.0
+      generate-values: 1.0.1
+      generic-router: 0.0.1
+      geometry-plane: 1.0.3
+      github-actions-toolkit: 0.5.0
+      grain: 3.0.0
+      grain-router: 3.0.0
+      grain-virtualized: 3.0.0
+      graphql-client: 9.3.2
+      graphs: 8.1.0
+      group: 4.1.1
+      halogen: 7.0.0
+      halogen-bootstrap5: 2.1.0
+      halogen-css: 10.0.0
+      halogen-echarts-simple: 0.0.4
+      halogen-formless: 4.0.2
+      halogen-hooks: 0.6.3
+      halogen-hooks-extra: 0.9.0
+      halogen-store: 0.5.4
+      halogen-storybook: 2.0.0
+      halogen-subscriptions: 2.0.0
+      halogen-svg-elems: 7.0.0
+      halogen-vdom: 8.0.0
+      halogen-vdom-string-renderer: 0.5.0
+      heckin: 2.0.1
+      heterogeneous: 0.6.0
+      homogeneous: 0.4.0
+      http-methods: 6.0.0
+      httpure: 0.16.0
+      httpurple: 3.0.1
+      httpurple-argonaut: 1.0.1
+      httpurple-yoga-json: 1.0.0
+      humdrum: 0.0.1
+      hyrule: 2.3.5
+      identity: 6.0.0
+      identy: 4.0.1
+      indexed-monad: 2.1.0
+      int64: 3.0.0
+      integers: 6.0.0
+      interpolate: 5.0.2
+      invariant: 6.0.0
+      jarilo: 1.0.1
+      jelly: 0.9.1
+      jelly-hooks: 0.3.1
+      jelly-router: 0.2.2
+      jelly-signal: 0.3.0
+      jest: 1.0.0
+      js-bigints: 1.2.0
+      js-date: 8.0.0
+      js-fileio: 3.0.0
+      js-promise: 1.0.0
+      js-promise-aff: 1.0.0
+      js-timers: 6.1.0
+      js-uri: 3.1.0
+      justifill: 0.5.0
+      jwt: 0.0.9
+      language-cst-parser: 0.12.1
+      lazy: 6.0.0
+      lazy-joe: 1.0.0
+      lcg: 4.0.0
+      leibniz: 5.0.0
+      linalg: 5.1.0
+      lists: 7.0.0
+      literals: 1.0.2
+      logging: 3.0.0
+      logging-journald: 0.4.0
+      machines: 7.0.0
+      marionette: 1.0.0
+      marionette-commander: 0.1.1
+      marionette-react-basic-hooks: 0.1.1
+      matrices: 5.0.1
+      matryoshka: 1.0.0
+      maybe: 6.0.0
+      mdast-util-from-markdown: 0.2.1
+      media-types: 6.0.0
+      midi: 4.0.0
+      milkis: 9.0.0
+      minibench: 4.0.1
+      mmorph: 7.0.0
+      monad-control: 5.0.0
+      monad-logger: 1.3.1
+      monad-loops: 0.5.0
+      monad-unlift: 1.0.1
+      monoid-extras: 0.0.1
+      monoidal: 0.16.0
+      morello: 0.4.0
+      mote: 3.0.0
+      motsunabe: 2.0.0
+      mysql: 6.0.1
+      n3: 0.1.0
+      nano-id: 1.1.0
+      naturals: 3.0.0
+      nested-functor: 0.2.1
+      newtype: 5.0.0
+      nextui: 0.1.0
+      node-buffer: 8.0.0
+      node-buffer-blob: 1.0.0
+      node-child-process: 9.0.0
+      node-fs: 8.1.1
+      node-fs-aff: 9.1.0
+      node-http: 8.0.0
+      node-net: 4.0.0
+      node-path: 5.0.0
+      node-process: 10.0.0
+      node-readline: 7.0.0
+      node-sqlite3: 8.0.0
+      node-streams: 7.0.0
+      node-streams-aff: 4.0.1
+      node-url: 6.0.0
+      nodemailer: 4.0.1
+      nonempty: 7.0.0
+      now: 6.0.0
+      npm-package-json: 2.0.0
+      nullable: 6.0.0
+      numbers: 9.0.0
+      object-maps: 0.1.1
+      ocarina: 1.5.2
+      open-folds: 6.3.0
+      open-memoize: 6.1.0
+      open-pairing: 6.1.0
+      options: 7.0.0
+      optparse: 5.0.0
+      ordered-collections: 3.0.0
+      ordered-set: 0.4.0
+      orders: 6.0.0
+      pairs: 9.0.0
+      parallel: 6.0.0
+      parsing: 10.2.0
+      parsing-dataview: 3.2.4
+      partial: 4.0.0
+      pathy: 9.0.0
+      pha: 0.9.0
+      phaser: 0.6.0
+      pipes: 8.0.0
+      pirates-charm: 0.0.1
+      point-free: 1.0.0
+      pointed-list: 0.5.1
+      polymorphic-vectors: 4.0.0
+      posix-types: 6.0.0
+      precise: 6.0.0
+      precise-datetime: 7.0.0
+      prelude: 6.0.1
+      prettier-printer: 3.0.0
+      profunctor: 6.0.0
+      profunctor-lenses: 8.0.0
+      protobuf: 4.2.0
+      ps-cst: 1.2.0
+      psa-utils: 8.0.0
+      psc-ide: 19.0.0
+      psci-support: 6.0.0
+      qualified-do: 2.2.0
+      quantities: 12.1.0
+      quickcheck: 8.0.1
+      quickcheck-combinators: 0.1.3
+      quickcheck-laws: 7.0.0
+      quickcheck-utf8: 0.0.0
+      random: 6.0.0
+      rationals: 5.0.1
+      rdf: 0.1.0
+      react: 10.0.1
+      react-aria: 0.2.0
+      react-basic: 17.0.0
+      react-basic-classic: 3.0.0
+      react-basic-dnd: 10.1.0
+      react-basic-dom: 6.0.0
+      react-basic-emotion: 7.1.0
+      react-basic-hooks: 8.1.2
+      react-basic-storybook: 2.0.0
+      react-dom: 8.0.0
+      react-halo: 3.0.0
+      react-icons: 1.0.8
+      react-testing-library: 4.0.1
+      react-virtuoso: 1.0.0
+      read: 1.0.1
+      record: 4.0.0
+      record-extra: 5.0.1
+      record-studio: 1.0.4
+      refs: 6.0.0
+      remotedata: 5.0.0
+      resource: 2.0.1
+      resourcet: 1.0.0
+      result: 1.0.3
+      return: 0.2.0
+      ring-modules: 5.0.1
+      rito: 0.3.2
+      routing: 11.0.0
+      routing-duplex: 0.7.0
+      run: 5.0.0
+      safe-coerce: 2.0.0
+      safely: 4.0.1
+      school-of-music: 1.3.0
+      selection-foldable: 0.2.0
+      semirings: 7.0.0
+      signal: 13.0.0
+      simple-emitter: 3.0.1
+      simple-i18n: 2.0.1
+      simple-json: 9.0.0
+      simple-jwt: 4.0.1
+      simple-ulid: 3.0.0
+      sized-matrices: 1.0.0
+      sized-vectors: 5.0.2
+      slug: 3.0.8
+      small-ffi: 4.0.1
+      soundfonts: 4.1.0
+      sparse-matrices: 1.2.1
+      sparse-polynomials: 1.0.5
+      spec: 7.2.0
+      spec-discovery: 8.0.1
+      spec-quickcheck: 5.0.0
+      splitmix: 2.1.0
+      ssrs: 1.0.0
+      st: 6.2.0
+      strictlypositiveint: 1.0.1
+      string-parsers: 8.0.0
+      strings: 6.0.1
+      strings-extra: 4.0.0
+      stringutils: 0.0.12
+      substitute: 0.2.3
+      sunde: 3.0.0
+      supply: 0.2.0
+      svg-parser: 3.0.0
+      systemd-journald: 0.3.0
+      tagged: 4.0.2
+      tailrec: 6.1.0
+      tecton: 0.1.6
+      tecton-halogen: 0.1.3
+      test-unit: 17.0.0
+      thermite: 6.3.1
+      thermite-dom: 0.3.1
+      these: 6.0.0
+      toppokki: 4.0.0
+      transformers: 6.0.0
+      tree-rose: 4.0.2
+      tuples: 7.0.0
+      two-or-more: 1.0.0
+      type-equality: 4.0.1
+      typelevel: 6.0.0
+      typelevel-lists: 2.1.0
+      typelevel-peano: 1.0.1
+      typelevel-prelude: 7.0.0
+      typelevel-rows: 0.1.0
+      uint: 7.0.0
+      ulid: 3.0.1
+      uncurried-transformers: 1.1.0
+      undefined: 2.0.0
+      undefined-is-not-a-problem: 1.1.0
+      unfoldable: 6.0.0
+      unicode: 6.0.0
+      unlift: 1.0.1
+      unordered-collections: 3.0.1
+      unsafe-coerce: 6.0.0
+      unsafe-reference: 5.0.0
+      untagged-to-tagged: 0.1.4
+      untagged-union: 1.0.0
+      uri: 9.0.0
+      uuid: 9.0.0
+      uuidv4: 1.0.0
+      validation: 6.0.0
+      variant: 8.0.0
+      vectorfield: 1.0.1
+      vectors: 2.1.0
+      versions: 7.0.0
+      visx: 0.0.2
+      web-clipboard: 5.0.0
+      web-cssom: 2.0.0
+      web-dom: 6.0.0
+      web-dom-parser: 8.0.0
+      web-dom-xpath: 3.0.0
+      web-encoding: 3.0.0
+      web-events: 4.0.0
+      web-fetch: 3.0.0
+      web-file: 4.0.0
+      web-html: 4.1.0
+      web-pointerevents: 1.0.0
+      web-proletarian: 1.0.0
+      web-promise: 3.1.0
+      web-resize-observer: 2.0.0
+      web-router: 1.0.0
+      web-socket: 4.0.0
+      web-storage: 5.0.0
+      web-streams: 3.0.0
+      web-touchevents: 4.0.0
+      web-uievents: 4.0.0
+      web-url: 2.0.0
+      web-workers: 1.1.0
+      web-xhr: 5.0.0
+      which: 2.0.0
+      yoga-fetch: 1.0.1
+      yoga-json: 4.0.1
+      yoga-om: 0.1.0
+      yoga-postgres: 6.0.0
+      yoga-tree: 1.0.0
   extra_packages: {}
 packages:
   arraybuffer-types:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
-    rev: 9b0b7a0f9ee034e039f3d3a2a9c3f74eb7c9264a
+    type: registry
+    version: 3.0.2
+    integrity: sha256-mQKokysYVkooS4uXbO+yovmV/s8b138Ws3zQvOwIHRA=
     dependencies: []
   arrays:
-    type: git
-    url: https://github.com/purescript/purescript-arrays.git
-    rev: d20bae2f76db6cf29b7b75e26e82b8a54c32295e
+    type: registry
+    version: 7.1.0
+    integrity: sha256-Rvb3AVLal0ZLpmpABgOPIUeYHa4M+c5GwcUP5rQ2trA=
     dependencies:
       - bifunctors
       - control
@@ -3523,15 +523,16 @@ packages:
       - nonempty
       - partial
       - prelude
+      - safe-coerce
       - st
       - tailrec
       - tuples
       - unfoldable
       - unsafe-coerce
   bifunctors:
-    type: git
-    url: https://github.com/purescript/purescript-bifunctors.git
-    rev: 16ba2fb6dd7f05528ebd9e2f9ca3a068b325e5b3
+    type: registry
+    version: 6.0.0
+    integrity: sha256-/gZwC9YhNxZNQpnHa5BIYerCGM2jeX9ukZiEvYxm5Nw=
     dependencies:
       - const
       - either
@@ -3539,9 +540,9 @@ packages:
       - prelude
       - tuples
   canvas:
-    type: git
-    url: https://github.com/purescript-web/purescript-canvas.git
-    rev: bb640e46d64324678111262a8b5dddc13d7e61b6
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Y4L0bTJu4budLhb24ImGUb3s0qvcgja2lPhRDhHRlys=
     dependencies:
       - arraybuffer-types
       - effect
@@ -3549,24 +550,24 @@ packages:
       - functions
       - maybe
   console:
-    type: git
-    url: https://github.com/purescript/purescript-console.git
-    rev: 3b83d7b792d03872afeea5e62b4f686ab0f09842
+    type: registry
+    version: 6.0.0
+    integrity: sha256-gJpJ53fCDAL8BiCiJXH0HNAJ9K3gJtLo8GDaCK6hA5U=
     dependencies:
       - effect
       - prelude
   const:
-    type: git
-    url: https://github.com/purescript/purescript-const.git
-    rev: ab9570cf2b6e67f7e441178211db1231cfd75c37
+    type: registry
+    version: 6.0.0
+    integrity: sha256-tNrxDW8D8H4jdHE2HiPzpLy08zkzJMmGHdRqt5BQuTc=
     dependencies:
       - invariant
       - newtype
       - prelude
   contravariant:
-    type: git
-    url: https://github.com/purescript/purescript-contravariant.git
-    rev: 9ad3e105b8855bcc25f4e0893c784789d05a58de
+    type: registry
+    version: 6.0.0
+    integrity: sha256-TP+ooAp3vvmdjfQsQJSichF5B4BPDHp3wAJoWchip6c=
     dependencies:
       - const
       - either
@@ -3574,16 +575,16 @@ packages:
       - prelude
       - tuples
   control:
-    type: git
-    url: https://github.com/purescript/purescript-control.git
-    rev: a6033808790879a17b2729e73747a9ed3fb2264e
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sH7Pg9E96JCPF9PIA6oQ8+BjTyO/BH1ZuE/bOcyj4Jk=
     dependencies:
       - newtype
       - prelude
   datetime:
-    type: git
-    url: https://github.com/purescript/purescript-datetime.git
-    rev: a6a0cf1b0324964ad1854bc3377ed8766ba90e6f
+    type: registry
+    version: 6.1.0
+    integrity: sha256-g/5X5BBegQWLpI9IWD+sY6mcaYpzzlW5lz5NBzaMtyI=
     dependencies:
       - bifunctors
       - control
@@ -3602,9 +603,9 @@ packages:
       - prelude
       - tuples
   distributive:
-    type: git
-    url: https://github.com/purescript/purescript-distributive.git
-    rev: 6005e513642e855ebf6f884d24a35c2803ca252a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-HTDdmEnzigMl+02SJB88j+gAXDx9VKsbvR4MJGDPbOQ=
     dependencies:
       - identity
       - newtype
@@ -3612,24 +613,24 @@ packages:
       - tuples
       - type-equality
   effect:
-    type: git
-    url: https://github.com/purescript/purescript-effect.git
-    rev: a192ddb923027d426d6ea3d8deb030c9aa7c7dda
+    type: registry
+    version: 4.0.0
+    integrity: sha256-eBtZu+HZcMa5HilvI6kaDyVX3ji8p0W9MGKy2K4T6+M=
     dependencies:
       - prelude
   either:
-    type: git
-    url: https://github.com/purescript/purescript-either.git
-    rev: af655a04ed2fd694b6688af39ee20d7907ad0763
+    type: registry
+    version: 6.1.0
+    integrity: sha256-6hgTPisnMWVwQivOu2PKYcH8uqjEOOqDyaDQVUchTpY=
     dependencies:
       - control
       - invariant
       - maybe
       - prelude
   enums:
-    type: git
-    url: https://github.com/purescript/purescript-enums.git
-    rev: bae47961d401f9acf88da38f32e87403e5f0cf2f
+    type: registry
+    version: 6.0.1
+    integrity: sha256-HWaD73JFLorc4A6trKIRUeDMdzE+GpkJaEOM1nTNkC8=
     dependencies:
       - control
       - either
@@ -3642,24 +643,24 @@ packages:
       - tuples
       - unfoldable
   exceptions:
-    type: git
-    url: https://github.com/purescript/purescript-exceptions.git
-    rev: afab3c07c820bb49b6c5be50049db46a964a6161
+    type: registry
+    version: 6.0.0
+    integrity: sha256-y/xTAEIZIARCE+50/u1di0ncebJ+CIwNOLswyOWzMTw=
     dependencies:
       - effect
       - either
       - maybe
       - prelude
   exists:
-    type: git
-    url: https://github.com/purescript/purescript-exists.git
-    rev: f765b4ace7869c27b9c05949e18c843881f9173b
+    type: registry
+    version: 6.0.0
+    integrity: sha256-A0JQHpTfo1dNOj9U5/Fd3xndlRSE0g2IQWOGor2yXn8=
     dependencies:
       - unsafe-coerce
   foldable-traversable:
-    type: git
-    url: https://github.com/purescript/purescript-foldable-traversable.git
-    rev: b3926f870532d287ea59e2d5cd3873b81ef2a93a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-fLeqRYM4jUrZD5H4WqcwUgzU7XfYkzO4zhgtNc3jcWM=
     dependencies:
       - bifunctors
       - const
@@ -3673,9 +674,9 @@ packages:
       - prelude
       - tuples
   foreign:
-    type: git
-    url: https://github.com/purescript/purescript-foreign.git
-    rev: 2dd222d1ec7363fa0a0a7adb0d8eaf81bb7006dd
+    type: registry
+    version: 7.0.0
+    integrity: sha256-1ORiqoS3HW+qfwSZAppHPWy4/6AQysxZ2t29jcdUMNA=
     dependencies:
       - either
       - functions
@@ -3687,15 +688,15 @@ packages:
       - strings
       - transformers
   functions:
-    type: git
-    url: https://github.com/purescript/purescript-functions.git
-    rev: f626f20580483977c5b27a01aac6471e28aff367
+    type: registry
+    version: 6.0.0
+    integrity: sha256-adMyJNEnhGde2unHHAP79gPtlNjNqzgLB8arEOn9hLI=
     dependencies:
       - prelude
   functors:
-    type: git
-    url: https://github.com/purescript/purescript-functors.git
-    rev: 022ffd7a2a7ec12080314f3d217b400674a247b4
+    type: registry
+    version: 5.0.0
+    integrity: sha256-zfPWWYisbD84MqwpJSZFlvM6v86McM68ob8p9s27ywU=
     dependencies:
       - bifunctors
       - const
@@ -3711,9 +712,9 @@ packages:
       - tuples
       - unsafe-coerce
   gen:
-    type: git
-    url: https://github.com/purescript/purescript-gen.git
-    rev: 9fbcc2a1261c32e30d79c5418edef4d96fe76931
+    type: registry
+    version: 4.0.0
+    integrity: sha256-f7yzAXWwr+xnaqEOcvyO3ezKdoes8+WXWdXIHDBCAPI=
     dependencies:
       - either
       - foldable-traversable
@@ -3726,33 +727,33 @@ packages:
       - tuples
       - unfoldable
   identity:
-    type: git
-    url: https://github.com/purescript/purescript-identity.git
-    rev: ef6768f8a52ab0bc943a85f5761ba07c257f639f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-4wY0XZbAksjY6UAg99WkuKyJlQlWAfTi2ssadH0wVMY=
     dependencies:
       - control
       - invariant
       - newtype
       - prelude
   integers:
-    type: git
-    url: https://github.com/purescript/purescript-integers.git
-    rev: 54d712b25c594833083d15dc9ff2418eb9c52822
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sf+sK26R1hzwl3NhXR7WAu9zCDjQnfoXwcyGoseX158=
     dependencies:
       - maybe
       - numbers
       - prelude
   invariant:
-    type: git
-    url: https://github.com/purescript/purescript-invariant.git
-    rev: 1d2a196d51e90623adb88496c2cfd759c6736894
+    type: registry
+    version: 6.0.0
+    integrity: sha256-RGWWyYrz0Hs1KjPDA+87Kia67ZFBhfJ5lMGOMCEFoLo=
     dependencies:
       - control
       - prelude
   js-date:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-js-date.git
-    rev: 1ea020316946cc4b87195bca9c54d0c16abaa490
+    type: registry
+    version: 8.0.0
+    integrity: sha256-6TVF4DWg5JL+jRAsoMssYw8rgOVALMUHT1CuNZt8NRo=
     dependencies:
       - datetime
       - effect
@@ -3761,18 +762,18 @@ packages:
       - integers
       - now
   lazy:
-    type: git
-    url: https://github.com/purescript/purescript-lazy.git
-    rev: 48347841226b27af5205a1a8ec71e27a93ce86fd
+    type: registry
+    version: 6.0.0
+    integrity: sha256-lMsfFOnlqfe4KzRRiW8ot5ge6HtcU3Eyh2XkXcP5IgU=
     dependencies:
       - control
       - foldable-traversable
       - invariant
       - prelude
   lists:
-    type: git
-    url: https://github.com/purescript/purescript-lists.git
-    rev: b113451e5b41cad87d669a3165f955c71cd863e2
+    type: registry
+    version: 7.0.0
+    integrity: sha256-EKF15qYqucuXP2lT/xPxhqy58f0FFT6KHdIB/yBOayI=
     dependencies:
       - bifunctors
       - control
@@ -3787,32 +788,32 @@ packages:
       - tuples
       - unfoldable
   maybe:
-    type: git
-    url: https://github.com/purescript/purescript-maybe.git
-    rev: c6f98ac1088766287106c5d9c8e30e7648d36786
+    type: registry
+    version: 6.0.0
+    integrity: sha256-5cCIb0wPwbat2PRkQhUeZO0jcAmf8jCt2qE0wbC3v2Q=
     dependencies:
       - control
       - invariant
       - newtype
       - prelude
   media-types:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-media-types.git
-    rev: af853de226592f319a953637069a943dd261cba3
+    type: registry
+    version: 6.0.0
+    integrity: sha256-n/4FoGBasbVSYscGVRSyBunQ6CZbL3jsYL+Lp01mc9k=
     dependencies:
       - newtype
       - prelude
   newtype:
-    type: git
-    url: https://github.com/purescript/purescript-newtype.git
-    rev: 29d8e6dd77aec2c975c948364ec3faf26e14ee7b
+    type: registry
+    version: 5.0.0
+    integrity: sha256-gdrQu8oGe9eZE6L3wOI8ql/igOg+zEGB5ITh2g+uttw=
     dependencies:
       - prelude
       - safe-coerce
   nonempty:
-    type: git
-    url: https://github.com/purescript/purescript-nonempty.git
-    rev: 28150ecc7419238b187abd609a92a645273348bb
+    type: registry
+    version: 7.0.0
+    integrity: sha256-54ablJZUHGvvlTJzi3oXyPCuvY6zsrWJuH/dMJ/MFLs=
     dependencies:
       - control
       - foldable-traversable
@@ -3821,31 +822,31 @@ packages:
       - tuples
       - unfoldable
   now:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-now.git
-    rev: b5ffed2381e5fefc063f484e607e8499e79eaf32
+    type: registry
+    version: 6.0.0
+    integrity: sha256-xZ7x37ZMREfs6GCDw/h+FaKHV/3sPWmtqBZRGTxybQY=
     dependencies:
       - datetime
       - effect
   nullable:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-nullable.git
-    rev: 3202744c6c65e8d1fbba7f4256a1c482078e7fb5
+    type: registry
+    version: 6.0.0
+    integrity: sha256-yiGBVl3AD+Guy4kNWWeN+zl1gCiJK+oeIFtZtPCw4+o=
     dependencies:
       - effect
       - functions
       - maybe
   numbers:
-    type: git
-    url: https://github.com/purescript/purescript-numbers.git
-    rev: 2a53528f18f9415334bae28e7bb3cf3be86342c2
+    type: registry
+    version: 9.0.0
+    integrity: sha256-fDKXExFxMRFgy+v+kbjVbGBIOOQkWGnmm0vtnE3zWRE=
     dependencies:
       - functions
       - maybe
   ordered-collections:
-    type: git
-    url: https://github.com/purescript/purescript-ordered-collections.git
-    rev: 9826b7632d0d0a691173bde308a634195f42a419
+    type: registry
+    version: 3.0.0
+    integrity: sha256-R9WddNBRPkY37gw8XkDCLX2vJ5eI9qdaWDdCp61r2+M=
     dependencies:
       - arrays
       - foldable-traversable
@@ -3859,26 +860,26 @@ packages:
       - tuples
       - unfoldable
   orders:
-    type: git
-    url: https://github.com/purescript/purescript-orders.git
-    rev: f86db621ec5eef1274145f8b1fd8ebbfe0ed4a2c
+    type: registry
+    version: 6.0.0
+    integrity: sha256-nBA0g3/ai0euH8q9pSbGqk53W2q6agm/dECZTHcoink=
     dependencies:
       - newtype
       - prelude
   partial:
-    type: git
-    url: https://github.com/purescript/purescript-partial.git
-    rev: 0fa0646f5ea1ec5f0c46dcbd770c705a6c9ad3ec
+    type: registry
+    version: 4.0.0
+    integrity: sha256-fwXerld6Xw1VkReh8yeQsdtLVrjfGiVuC5bA1Wyo/J4=
     dependencies: []
   prelude:
-    type: git
-    url: https://github.com/purescript/purescript-prelude.git
-    rev: 32787f4399c92459c41602131a5858559eb868c5
+    type: registry
+    version: 6.0.1
+    integrity: sha256-o8p6SLYmVPqzXZhQFd2hGAWEwBoXl1swxLG/scpJ0V0=
     dependencies: []
   profunctor:
-    type: git
-    url: https://github.com/purescript/purescript-profunctor.git
-    rev: 0a966a14e7b0c827d44657dc1710cdc712d2e034
+    type: registry
+    version: 6.0.0
+    integrity: sha256-99NzxFgTr4CGlCSRYG1kShL+JhYbihhHtbOk1/0R5zI=
     dependencies:
       - control
       - distributive
@@ -3889,38 +890,38 @@ packages:
       - prelude
       - tuples
   random:
-    type: git
-    url: https://github.com/purescript/purescript-random.git
-    rev: 9540bc965a9596da02fefd9949418bb19c92533a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-CJ611a35MPCE7XQMp0rdC6MCn76znlhisiCRgboAG+Q=
     dependencies:
       - effect
       - integers
   refs:
-    type: git
-    url: https://github.com/purescript/purescript-refs.git
-    rev: f8e6216da4cb9309fde1f20cd6f69ac3a3b7f9e8
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Vgwne7jIbD3ZMoLNNETLT8Litw6lIYo3MfYNdtYWj9s=
     dependencies:
       - effect
       - prelude
   safe-coerce:
-    type: git
-    url: https://github.com/purescript/purescript-safe-coerce.git
-    rev: 7fa799ae80a38b8d948efcb52608e58e198b3da7
+    type: registry
+    version: 2.0.0
+    integrity: sha256-a1ibQkiUcbODbLE/WAq7Ttbbh9ex+x33VCQ7GngKudU=
     dependencies:
       - unsafe-coerce
   st:
-    type: git
-    url: https://github.com/purescript/purescript-st.git
-    rev: 2cc7ae1c3318a303378c4a9f3fa0f10ee7cc3589
+    type: registry
+    version: 6.2.0
+    integrity: sha256-z9X0WsOUlPwNx9GlCC+YccCyz8MejC8Wb0C4+9fiBRY=
     dependencies:
       - partial
       - prelude
       - tailrec
       - unsafe-coerce
   strings:
-    type: git
-    url: https://github.com/purescript/purescript-strings.git
-    rev: 4bc6954448d056f8aa7a659695a6ad60ad4fdf19
+    type: registry
+    version: 6.0.1
+    integrity: sha256-WssD3DbX4OPzxSdjvRMX0yvc9+pS7n5gyPv5I2Trb7k=
     dependencies:
       - arrays
       - control
@@ -3939,9 +940,9 @@ packages:
       - unfoldable
       - unsafe-coerce
   tailrec:
-    type: git
-    url: https://github.com/purescript/purescript-tailrec.git
-    rev: 5e2104aa734b31a17074cc805bf087d72b65afd1
+    type: registry
+    version: 6.1.0
+    integrity: sha256-Xx19ECVDRrDWpz9D2GxQHHV89vd61dnXxQm0IcYQHGk=
     dependencies:
       - bifunctors
       - effect
@@ -3952,9 +953,9 @@ packages:
       - prelude
       - refs
   transformers:
-    type: git
-    url: https://github.com/purescript/purescript-transformers.git
-    rev: be72ab52357d9a665cbf93d73ba1c07c4b0957ee
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Pzw40HjthX77tdPAYzjx43LK3X5Bb7ZspYAp27wksFA=
     dependencies:
       - control
       - distributive
@@ -3971,22 +972,22 @@ packages:
       - tuples
       - unfoldable
   tuples:
-    type: git
-    url: https://github.com/purescript/purescript-tuples.git
-    rev: 4f52da2729b448c8564369378f1232d8d2dc1d8b
+    type: registry
+    version: 7.0.0
+    integrity: sha256-1rXgTomes9105BjgXqIw0FL6Fz1lqqUTLWOumhWec1M=
     dependencies:
       - control
       - invariant
       - prelude
   type-equality:
-    type: git
-    url: https://github.com/purescript/purescript-type-equality.git
-    rev: 0525b7d39e0fbd81b4209518139fb8ab02695774
+    type: registry
+    version: 4.0.1
+    integrity: sha256-Hs9D6Y71zFi/b+qu5NSbuadUQXe5iv5iWx0226vOHUw=
     dependencies: []
   unfoldable:
-    type: git
-    url: https://github.com/purescript/purescript-unfoldable.git
-    rev: 493dfe04ed590e20d8f69079df2f58486882748d
+    type: registry
+    version: 6.0.0
+    integrity: sha256-JtikvJdktRap7vr/K4ITlxUX1QexpnqBq0G/InLr6eg=
     dependencies:
       - foldable-traversable
       - maybe
@@ -3994,46 +995,46 @@ packages:
       - prelude
       - tuples
   unsafe-coerce:
-    type: git
-    url: https://github.com/purescript/purescript-unsafe-coerce.git
-    rev: ab956f82e66e633f647fb3098e8ddd3ec58d689f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-IqIYW4Vkevn8sI+6aUwRGvd87tVL36BBeOr0cGAE7t0=
     dependencies: []
   web-dom:
-    type: git
-    url: https://github.com/purescript-web/purescript-web-dom.git
-    rev: 568a1ee158b29e6e739e7a9aaed3e35ca4c4305a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-1kSKWFDI4LupdmpjK01b1MMxDFW7jvatEgPgVmCmSBQ=
     dependencies:
       - web-events
   web-events:
-    type: git
-    url: https://github.com/purescript-web/purescript-web-events.git
-    rev: 2124356117be7b764a2f3948032255ac4dab7051
+    type: registry
+    version: 4.0.0
+    integrity: sha256-YDt8b6u1tzGtnWyNRodne57iO8FNSGPaTCVzBUyUn4k=
     dependencies:
       - datetime
       - enums
       - foreign
       - nullable
   web-file:
-    type: git
-    url: https://github.com/purescript-web/purescript-web-file.git
-    rev: 023786ae62bbb8bf58156dd7f02011fa38221ef1
+    type: registry
+    version: 4.0.0
+    integrity: sha256-1h5jPBkvjY71jLEdwVadXCx86/2inNoMBO//Rd3eCSU=
     dependencies:
       - foreign
       - media-types
       - web-dom
   web-html:
-    type: git
-    url: https://github.com/purescript-web/purescript-web-html.git
-    rev: be189cf91b9a19cf493637423522e2fe4a0088cc
+    type: registry
+    version: 4.1.0
+    integrity: sha256-ByqS/h1/yG+hjCOnOQp7L1QpIWzQENNKB1kaHtpEhlE=
     dependencies:
       - js-date
       - web-dom
       - web-file
       - web-storage
   web-storage:
-    type: git
-    url: https://github.com/purescript-web/purescript-web-storage.git
-    rev: 6b74461e136755db70c271dc898d51776363d7e2
+    type: registry
+    version: 5.0.0
+    integrity: sha256-q+6lxcnfWxus0/nDeFVtF1V+tLehZvvXQ0cduYPLksY=
     dependencies:
       - nullable
       - web-events

--- a/exercises/chapter12/spago.yaml
+++ b/exercises/chapter12/spago.yaml
@@ -1,0 +1,22 @@
+package:
+  dependencies:
+    - arrays
+    - canvas
+    - console
+    - effect
+    - foldable-traversable
+    - integers
+    - maybe
+    - numbers
+    - partial
+    - prelude
+    - random
+    - refs
+    - web-dom
+    - web-events
+    - web-html
+  name: my-project
+workspace:
+  extraPackages: {}
+  packageSet:
+    url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json

--- a/exercises/chapter12/spago.yaml
+++ b/exercises/chapter12/spago.yaml
@@ -19,4 +19,4 @@ package:
 workspace:
   extraPackages: {}
   packageSet:
-    url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
+    registry: 10.0.0

--- a/exercises/chapter13/spago.lock
+++ b/exercises/chapter13/spago.lock
@@ -1,0 +1,3934 @@
+workspace:
+  packages:
+    my-project:
+      path: ./
+      dependencies:
+        - arrays
+        - console
+        - effect
+        - foldable-traversable
+        - functions
+        - lists
+        - prelude
+        - quickcheck
+      test_dependencies: []
+      build_plan:
+        - arrays
+        - bifunctors
+        - console
+        - const
+        - contravariant
+        - control
+        - distributive
+        - effect
+        - either
+        - enums
+        - exceptions
+        - exists
+        - foldable-traversable
+        - functions
+        - functors
+        - gen
+        - identity
+        - integers
+        - invariant
+        - lazy
+        - lcg
+        - lists
+        - maybe
+        - newtype
+        - nonempty
+        - numbers
+        - orders
+        - partial
+        - prelude
+        - profunctor
+        - quickcheck
+        - random
+        - record
+        - refs
+        - safe-coerce
+        - st
+        - strings
+        - tailrec
+        - transformers
+        - tuples
+        - type-equality
+        - unfoldable
+        - unsafe-coerce
+  package_set:
+    address:
+      url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
+    compiler: ">=0.15.0 <0.16.0"
+    content:
+      ace:
+        repo: https://github.com/purescript-contrib/purescript-ace.git
+        version: v9.0.0
+        dependencies:
+          - arrays
+          - effect
+          - foreign
+          - nullable
+          - prelude
+          - web-html
+          - web-uievents
+      aff:
+        repo: https://github.com/purescript-contrib/purescript-aff.git
+        version: v7.0.0
+        dependencies:
+          - datetime
+          - effect
+          - exceptions
+          - functions
+          - parallel
+          - transformers
+          - unsafe-coerce
+      aff-bus:
+        repo: https://github.com/purescript-contrib/purescript-aff-bus.git
+        version: v6.0.0
+        dependencies:
+          - aff
+          - avar
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - lists
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+      aff-coroutines:
+        repo: https://github.com/purescript-contrib/purescript-aff-coroutines.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - avar
+          - coroutines
+          - effect
+      aff-promise:
+        repo: https://github.com/nwolverson/purescript-aff-promise.git
+        version: v4.0.0
+        dependencies:
+          - aff
+          - foreign
+      aff-retry:
+        repo: https://github.com/Unisay/purescript-aff-retry.git
+        version: v2.0.0
+        dependencies:
+          - aff
+          - arrays
+          - datetime
+          - effect
+          - either
+          - exceptions
+          - integers
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - random
+          - transformers
+      affjax:
+        repo: https://github.com/purescript-contrib/purescript-affjax.git
+        version: v13.0.0
+        dependencies:
+          - aff
+          - argonaut-core
+          - arraybuffer-types
+          - foreign
+          - form-urlencoded
+          - http-methods
+          - integers
+          - media-types
+          - nullable
+          - refs
+          - unsafe-coerce
+          - web-xhr
+      affjax-node:
+        repo: https://github.com/purescript-contrib/purescript-affjax-node.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - affjax
+          - either
+          - maybe
+          - prelude
+      affjax-web:
+        repo: https://github.com/purescript-contrib/purescript-affjax-web.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - affjax
+          - either
+          - maybe
+          - prelude
+      ansi:
+        repo: https://github.com/hdgarrood/purescript-ansi.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - lists
+          - strings
+      argonaut:
+        repo: https://github.com/purescript-contrib/purescript-argonaut.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - argonaut-traversals
+      argonaut-codecs:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-codecs.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-core
+          - arrays
+          - effect
+          - foreign-object
+          - identity
+          - integers
+          - maybe
+          - nonempty
+          - ordered-collections
+          - prelude
+          - record
+      argonaut-core:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-core.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - foreign-object
+          - functions
+          - gen
+          - maybe
+          - nonempty
+          - prelude
+          - strings
+          - tailrec
+      argonaut-generic:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-generic.git
+        version: v8.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - prelude
+          - record
+      argonaut-traversals:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-traversals.git
+        version: v10.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - profunctor-lenses
+      argparse-basic:
+        repo: https://github.com/natefaubion/purescript-argparse-basic.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - record
+          - strings
+          - tuples
+          - unfoldable
+      arraybuffer:
+        repo: https://github.com/purescript-contrib/purescript-arraybuffer.git
+        version: v13.0.0
+        dependencies:
+          - arraybuffer-types
+          - arrays
+          - effect
+          - float32
+          - functions
+          - gen
+          - maybe
+          - nullable
+          - prelude
+          - tailrec
+          - uint
+          - unfoldable
+      arraybuffer-builder:
+        repo: https://github.com/jamesdbrock/purescript-arraybuffer-builder.git
+        version: v3.0.1
+        dependencies:
+          - arraybuffer
+          - arraybuffer-types
+          - effect
+          - float32
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - transformers
+          - uint
+      arraybuffer-types:
+        repo: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
+        version: v3.0.2
+        dependencies: []
+      arrays:
+        repo: https://github.com/purescript/purescript-arrays.git
+        version: v7.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - foldable-traversable
+          - maybe
+          - nonempty
+          - partial
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - unfoldable
+          - unsafe-coerce
+      arrays-zipper:
+        repo: https://github.com/JordanMartinez/purescript-arrays-zipper.git
+        version: v2.0.1
+        dependencies:
+          - arrays
+          - control
+          - quickcheck
+      ask:
+        repo: https://github.com/Mateiadrielrafael/purescript-ask.git
+        version: v1.0.0
+        dependencies:
+          - unsafe-coerce
+      assert:
+        repo: https://github.com/purescript/purescript-assert.git
+        version: v6.0.0
+        dependencies:
+          - console
+          - effect
+          - prelude
+      avar:
+        repo: https://github.com/purescript-contrib/purescript-avar.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - exceptions
+          - functions
+          - maybe
+      b64:
+        repo: https://github.com/menelaos/purescript-b64.git
+        version: v0.0.8
+        dependencies:
+          - arraybuffer-types
+          - either
+          - encoding
+          - enums
+          - exceptions
+          - functions
+          - partial
+          - prelude
+          - strings
+      barlow-lens:
+        repo: https://github.com/sigma-andex/purescript-barlow-lens.git
+        version: v0.9.0
+        dependencies:
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - profunctor-lenses
+          - tuples
+          - typelevel-prelude
+      bifunctors:
+        repo: https://github.com/purescript/purescript-bifunctors.git
+        version: v6.0.0
+        dependencies:
+          - const
+          - either
+          - newtype
+          - prelude
+          - tuples
+      bigints:
+        repo: https://github.com/sharkdp/purescript-bigints.git
+        version: v7.0.1
+        dependencies:
+          - integers
+          - maybe
+          - strings
+      bower-json:
+        repo: https://github.com/klntsky/purescript-bower-json.git
+        version: v3.0.0
+        dependencies:
+          - argonaut-codecs
+          - arrays
+          - either
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - newtype
+          - prelude
+          - tuples
+      call-by-name:
+        repo: https://github.com/natefaubion/purescript-call-by-name.git
+        version: v4.0.1
+        dependencies:
+          - control
+          - either
+          - lazy
+          - maybe
+          - unsafe-coerce
+      canvas:
+        repo: https://github.com/purescript-web/purescript-canvas.git
+        version: v6.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - exceptions
+          - functions
+          - maybe
+      canvas-action:
+        repo: https://github.com/artemisSystem/purescript-canvas-action.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - arrays
+          - canvas
+          - colors
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - maybe
+          - numbers
+          - polymorphic-vectors
+          - prelude
+          - refs
+          - run
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-html
+      cartesian:
+        repo: https://github.com/Ebmtranceboy/purescript-cartesian.git
+        version: v1.0.6
+        dependencies:
+          - console
+          - effect
+          - integers
+          - psci-support
+      catenable-lists:
+        repo: https://github.com/purescript/purescript-catenable-lists.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - lists
+          - maybe
+          - prelude
+          - tuples
+          - unfoldable
+      channel:
+        repo: https://github.com/ConnorDillon/purescript-channel.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - assert
+          - avar
+          - console
+          - contravariant
+          - control
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - lazy
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      checked-exceptions:
+        repo: https://github.com/natefaubion/purescript-checked-exceptions.git
+        version: v3.1.1
+        dependencies:
+          - prelude
+          - transformers
+          - variant
+      codec:
+        repo: https://github.com/garyb/purescript-codec.git
+        version: v5.0.0
+        dependencies:
+          - profunctor
+          - transformers
+      codec-argonaut:
+        repo: https://github.com/garyb/purescript-codec-argonaut.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-core
+          - codec
+          - ordered-collections
+          - type-equality
+          - variant
+      colors:
+        repo: https://github.com/purescript-contrib/purescript-colors.git
+        version: v7.0.1
+        dependencies:
+          - arrays
+          - integers
+          - lists
+          - numbers
+          - partial
+          - strings
+      concurrent-queues:
+        repo: https://github.com/purescript-contrib/purescript-concurrent-queues.git
+        version: v3.0.0
+        dependencies:
+          - aff
+          - avar
+          - effect
+      console:
+        repo: https://github.com/purescript/purescript-console.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - prelude
+      const:
+        repo: https://github.com/purescript/purescript-const.git
+        version: v6.0.0
+        dependencies:
+          - invariant
+          - newtype
+          - prelude
+      contravariant:
+        repo: https://github.com/purescript/purescript-contravariant.git
+        version: v6.0.0
+        dependencies:
+          - const
+          - either
+          - newtype
+          - prelude
+          - tuples
+      control:
+        repo: https://github.com/purescript/purescript-control.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      convertable-options:
+        repo: https://github.com/natefaubion/purescript-convertable-options.git
+        version: v1.0.0
+        dependencies:
+          - console
+          - effect
+          - maybe
+          - record
+      coroutines:
+        repo: https://github.com/purescript-contrib/purescript-coroutines.git
+        version: v7.0.0
+        dependencies:
+          - freet
+          - parallel
+          - profunctor
+      css:
+        repo: https://github.com/purescript-contrib/purescript-css.git
+        version: v6.0.0
+        dependencies:
+          - colors
+          - console
+          - effect
+          - nonempty
+          - profunctor
+          - strings
+          - these
+          - transformers
+      datetime:
+        repo: https://github.com/purescript/purescript-datetime.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - either
+          - enums
+          - foldable-traversable
+          - functions
+          - gen
+          - integers
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - ordered-collections
+          - partial
+          - prelude
+          - tuples
+      datetime-parsing:
+        repo: https://github.com/flounders/purescript-datetime-parsing.git
+        version: v0.2.0
+        dependencies:
+          - arrays
+          - datetime
+          - either
+          - enums
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - numbers
+          - parsing
+          - prelude
+          - strings
+          - unicode
+      debug:
+        repo: https://github.com/garyb/purescript-debug.git
+        version: v6.0.0
+        dependencies:
+          - functions
+          - prelude
+      decimals:
+        repo: https://github.com/sharkdp/purescript-decimals.git
+        version: v7.0.0
+        dependencies:
+          - maybe
+      dissect:
+        repo: https://github.com/PureFunctor/purescript-dissect.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - foreign-object
+          - functors
+          - newtype
+          - partial
+          - prelude
+          - tailrec
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - variant
+      distributive:
+        repo: https://github.com/purescript/purescript-distributive.git
+        version: v6.0.0
+        dependencies:
+          - identity
+          - newtype
+          - prelude
+          - tuples
+          - type-equality
+      dodo-printer:
+        repo: https://github.com/natefaubion/purescript-dodo-printer.git
+        version: v2.2.0
+        dependencies:
+          - aff
+          - ansi
+          - avar
+          - console
+          - effect
+          - foldable-traversable
+          - lists
+          - maybe
+          - minibench
+          - node-child-process
+          - node-fs-aff
+          - node-process
+          - psci-support
+          - strings
+      dom-indexed:
+        repo: https://github.com/purescript-halogen/purescript-dom-indexed.git
+        version: v11.0.0
+        dependencies:
+          - media-types
+          - prelude
+          - web-clipboard
+          - web-pointerevents
+          - web-touchevents
+      droplet:
+        repo: https://github.com/easafe/purescript-droplet.git
+        version: v0.4.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - bigints
+          - datetime
+          - debug
+          - effect
+          - either
+          - enums
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - integers
+          - maybe
+          - newtype
+          - nullable
+          - ordered-collections
+          - partial
+          - prelude
+          - profunctor
+          - record
+          - spec
+          - strings
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+      dynamic-buffer:
+        repo: https://github.com/kritzcreek/purescript-dynamic-buffer.git
+        version: v3.0.1
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - refs
+      effect:
+        repo: https://github.com/purescript/purescript-effect.git
+        version: v4.0.0
+        dependencies:
+          - prelude
+      either:
+        repo: https://github.com/purescript/purescript-either.git
+        version: v6.1.0
+        dependencies:
+          - control
+          - invariant
+          - maybe
+          - prelude
+      elmish:
+        repo: https://github.com/collegevine/purescript-elmish.git
+        version: v0.8.1
+        dependencies:
+          - aff
+          - argonaut-core
+          - arrays
+          - bifunctors
+          - console
+          - debug
+          - effect
+          - either
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - functions
+          - integers
+          - js-date
+          - maybe
+          - nullable
+          - partial
+          - prelude
+          - refs
+          - typelevel-prelude
+          - undefined-is-not-a-problem
+          - unsafe-coerce
+          - web-dom
+          - web-html
+      elmish-enzyme:
+        repo: https://github.com/collegevine/purescript-elmish-enzyme.git
+        version: v0.1.1
+        dependencies:
+          - aff
+          - aff-promise
+          - arrays
+          - console
+          - debug
+          - effect
+          - elmish
+          - foldable-traversable
+          - foreign
+          - functions
+          - prelude
+          - transformers
+          - unsafe-coerce
+      elmish-hooks:
+        repo: https://github.com/collegevine/purescript-elmish-hooks.git
+        version: v0.8.2
+        dependencies:
+          - aff
+          - debug
+          - elmish
+          - maybe
+          - prelude
+          - tuples
+          - undefined-is-not-a-problem
+      elmish-html:
+        repo: https://github.com/collegevine/purescript-elmish-html.git
+        version: v0.7.1
+        dependencies:
+          - effect
+          - elmish
+          - foreign
+          - foreign-object
+          - prelude
+          - record
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-html
+      email-validate:
+        repo: https://github.com/cdepillabout/purescript-email-validate.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - string-parsers
+          - transformers
+      encoding:
+        repo: https://github.com/menelaos/purescript-encoding.git
+        version: v0.0.8
+        dependencies:
+          - arraybuffer-types
+          - either
+          - exceptions
+          - functions
+          - prelude
+      enums:
+        repo: https://github.com/purescript/purescript-enums.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - either
+          - gen
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tuples
+          - unfoldable
+      exceptions:
+        repo: https://github.com/purescript/purescript-exceptions.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - either
+          - maybe
+          - prelude
+      exists:
+        repo: https://github.com/purescript/purescript-exists.git
+        version: v6.0.0
+        dependencies:
+          - unsafe-coerce
+      exitcodes:
+        repo: https://github.com/Risto-Stevcev/purescript-exitcodes.git
+        version: v4.0.0
+        dependencies:
+          - enums
+      expect-inferred:
+        repo: https://github.com/justinwoo/purescript-expect-inferred.git
+        version: v3.0.0
+        dependencies:
+          - prelude
+          - typelevel-prelude
+      fast-vect:
+        repo: https://github.com/sigma-andex/purescript-fast-vect.git
+        version: v0.7.0
+        dependencies:
+          - arrays
+          - filterable
+          - foldable-traversable
+          - lists
+          - maybe
+          - ordered-collections
+          - prelude
+          - profunctor
+          - tuples
+          - unfoldable
+      filterable:
+        repo: https://github.com/purescript/purescript-filterable.git
+        version: v5.0.0
+        dependencies:
+          - arrays
+          - either
+          - foldable-traversable
+          - identity
+          - lists
+          - ordered-collections
+      fixed-points:
+        repo: https://github.com/purescript-contrib/purescript-fixed-points.git
+        version: v7.0.0
+        dependencies:
+          - exists
+          - newtype
+          - prelude
+          - transformers
+      fixed-precision:
+        repo: https://github.com/lumihq/purescript-fixed-precision.git
+        version: v5.0.0
+        dependencies:
+          - arrays
+          - bigints
+          - control
+          - integers
+          - maybe
+          - numbers
+          - partial
+          - prelude
+          - strings
+      flame:
+        repo: https://github.com/easafe/purescript-flame.git
+        version: v1.2.0
+        dependencies:
+          - aff
+          - argonaut-codecs
+          - argonaut-core
+          - argonaut-generic
+          - arrays
+          - bifunctors
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - maybe
+          - newtype
+          - nullable
+          - partial
+          - prelude
+          - random
+          - refs
+          - spec
+          - strings
+          - tuples
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-html
+          - web-uievents
+      float32:
+        repo: https://github.com/purescript-contrib/purescript-float32.git
+        version: v2.0.0
+        dependencies:
+          - gen
+          - maybe
+          - prelude
+      foldable-traversable:
+        repo: https://github.com/purescript/purescript-foldable-traversable.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - const
+          - control
+          - either
+          - functors
+          - identity
+          - maybe
+          - newtype
+          - orders
+          - prelude
+          - tuples
+      foreign:
+        repo: https://github.com/purescript/purescript-foreign.git
+        version: v7.0.0
+        dependencies:
+          - either
+          - functions
+          - identity
+          - integers
+          - lists
+          - maybe
+          - prelude
+          - strings
+          - transformers
+      foreign-object:
+        repo: https://github.com/purescript/purescript-foreign-object.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - functions
+          - gen
+          - lists
+          - maybe
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - typelevel-prelude
+          - unfoldable
+      foreign-readwrite:
+        repo: https://github.com/artemisSystem/purescript-foreign-readwrite.git
+        version: v3.0.0
+        dependencies:
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - record
+          - safe-coerce
+          - transformers
+          - unsafe-coerce
+      fork:
+        repo: https://github.com/purescript-contrib/purescript-fork.git
+        version: v6.0.0
+        dependencies:
+          - aff
+      form-urlencoded:
+        repo: https://github.com/purescript-contrib/purescript-form-urlencoded.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - js-uri
+          - maybe
+          - newtype
+          - prelude
+          - strings
+          - tuples
+      formatters:
+        repo: https://github.com/purescript-contrib/purescript-formatters.git
+        version: v7.0.0
+        dependencies:
+          - datetime
+          - fixed-points
+          - lists
+          - numbers
+          - parsing
+          - prelude
+          - transformers
+      free:
+        repo: https://github.com/purescript/purescript-free.git
+        version: v7.0.0
+        dependencies:
+          - catenable-lists
+          - control
+          - distributive
+          - either
+          - exists
+          - foldable-traversable
+          - invariant
+          - lazy
+          - maybe
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+      freeap:
+        repo: https://github.com/ethul/purescript-freeap.git
+        version: v7.0.0
+        dependencies:
+          - const
+          - exists
+          - gen
+          - lists
+      freet:
+        repo: https://github.com/purescript-contrib/purescript-freet.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - bifunctors
+          - effect
+          - either
+          - exists
+          - free
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      functions:
+        repo: https://github.com/purescript/purescript-functions.git
+        version: v6.0.0
+        dependencies:
+          - prelude
+      functors:
+        repo: https://github.com/purescript/purescript-functors.git
+        version: v5.0.0
+        dependencies:
+          - bifunctors
+          - const
+          - contravariant
+          - control
+          - distributive
+          - either
+          - invariant
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - tuples
+          - unsafe-coerce
+      fuzzy:
+        repo: https://github.com/citizennet/purescript-fuzzy.git
+        version: v0.4.0
+        dependencies:
+          - foldable-traversable
+          - foreign-object
+          - newtype
+          - ordered-collections
+          - prelude
+          - rationals
+          - strings
+          - tuples
+      gen:
+        repo: https://github.com/purescript/purescript-gen.git
+        version: v4.0.0
+        dependencies:
+          - either
+          - foldable-traversable
+          - identity
+          - maybe
+          - newtype
+          - nonempty
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      generate-values:
+        repo: https://github.com/jordanmartinez/purescript-generate-values.git
+        version: v1.0.1
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - enums
+          - foldable-traversable
+          - gen
+          - identity
+          - integers
+          - lcg
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - partial
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      geometry-plane:
+        repo: https://github.com/Ebmtranceboy/purescript-geometry-plane.git
+        version: v1.0.3
+        dependencies:
+          - console
+          - effect
+          - psci-support
+          - sparse-polynomials
+      github-actions-toolkit:
+        repo: https://github.com/purescript-contrib/purescript-github-actions-toolkit.git
+        version: v0.5.0
+        dependencies:
+          - aff
+          - aff-promise
+          - effect
+          - foreign-object
+          - node-buffer
+          - node-path
+          - node-streams
+          - nullable
+          - transformers
+      graphs:
+        repo: https://github.com/purescript/purescript-graphs.git
+        version: v8.0.0
+        dependencies:
+          - catenable-lists
+          - ordered-collections
+      group:
+        repo: https://github.com/morganthomas/purescript-group.git
+        version: v4.1.1
+        dependencies:
+          - lists
+      halogen:
+        repo: https://github.com/purescript-halogen/purescript-halogen.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - avar
+          - console
+          - const
+          - dom-indexed
+          - effect
+          - foreign
+          - fork
+          - free
+          - freeap
+          - halogen-subscriptions
+          - halogen-vdom
+          - media-types
+          - nullable
+          - ordered-collections
+          - parallel
+          - profunctor
+          - transformers
+          - unsafe-coerce
+          - unsafe-reference
+          - web-file
+          - web-uievents
+      halogen-css:
+        repo: https://github.com/purescript-halogen/purescript-halogen-css.git
+        version: v10.0.0
+        dependencies:
+          - css
+          - halogen
+      halogen-formless:
+        repo: https://github.com/thomashoneyman/purescript-halogen-formless.git
+        version: v4.0.0
+        dependencies:
+          - convertable-options
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - halogen
+          - heterogeneous
+          - maybe
+          - prelude
+          - record
+          - safe-coerce
+          - type-equality
+          - unsafe-coerce
+          - unsafe-reference
+          - variant
+          - web-events
+          - web-uievents
+      halogen-hooks:
+        repo: https://github.com/thomashoneyman/purescript-halogen-hooks.git
+        version: v0.6.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - effect
+          - exceptions
+          - foldable-traversable
+          - foreign-object
+          - free
+          - freeap
+          - halogen
+          - halogen-subscriptions
+          - maybe
+          - newtype
+          - ordered-collections
+          - parallel
+          - partial
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+          - unsafe-reference
+          - web-dom
+          - web-html
+      halogen-hooks-extra:
+        repo: https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git
+        version: v0.9.0
+        dependencies:
+          - halogen-hooks
+      halogen-store:
+        repo: https://github.com/thomashoneyman/purescript-halogen-store.git
+        version: v0.5.0
+        dependencies:
+          - aff
+          - distributive
+          - effect
+          - fork
+          - halogen
+          - halogen-hooks
+          - halogen-subscriptions
+          - maybe
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-reference
+      halogen-storybook:
+        repo: https://github.com/rnons/purescript-halogen-storybook.git
+        version: v2.0.0
+        dependencies:
+          - foreign-object
+          - halogen
+          - prelude
+          - routing
+      halogen-subscriptions:
+        repo: https://github.com/purescript-halogen/purescript-halogen-subscriptions.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - effect
+          - foldable-traversable
+          - functors
+          - refs
+          - safe-coerce
+          - unsafe-reference
+      halogen-svg-elems:
+        repo: https://github.com/JordanMartinez/purescript-halogen-svg-elems.git
+        version: v6.0.0
+        dependencies:
+          - halogen
+      halogen-vdom:
+        repo: https://github.com/purescript-halogen/purescript-halogen-vdom.git
+        version: v8.0.0
+        dependencies:
+          - bifunctors
+          - effect
+          - foreign
+          - foreign-object
+          - maybe
+          - prelude
+          - refs
+          - tuples
+          - unsafe-coerce
+          - web-html
+      halogen-vdom-string-renderer:
+        repo: https://github.com/purescript-halogen/purescript-halogen-vdom-string-renderer.git
+        version: v0.5.0
+        dependencies:
+          - foreign
+          - halogen-vdom
+          - ordered-collections
+          - prelude
+      heckin:
+        repo: https://github.com/maxdeviant/purescript-heckin.git
+        version: v2.0.1
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - maybe
+          - prelude
+          - strings
+          - transformers
+          - tuples
+          - unicode
+      heterogeneous:
+        repo: https://github.com/natefaubion/purescript-heterogeneous.git
+        version: v0.6.0
+        dependencies:
+          - either
+          - functors
+          - prelude
+          - record
+          - tuples
+          - variant
+      heterogeneous-extrablatt:
+        repo: https://github.com/sigma-andex/purescript-heterogeneous-extrablatt.git
+        version: v0.2.1
+        dependencies:
+          - heterogeneous
+          - prelude
+          - record
+      http-methods:
+        repo: https://github.com/purescript-contrib/purescript-http-methods.git
+        version: v6.0.0
+        dependencies:
+          - either
+          - prelude
+          - strings
+      httpure:
+        repo: https://github.com/citizennet/purescript-httpure.git
+        version: v0.15.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - js-uri
+          - maybe
+          - newtype
+          - node-buffer
+          - node-fs
+          - node-http
+          - node-streams
+          - options
+          - ordered-collections
+          - prelude
+          - refs
+          - strings
+          - tuples
+          - type-equality
+      httpurple:
+        repo: https://github.com/sigma-andex/purescript-httpurple.git
+        version: v1.3.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - js-uri
+          - justifill
+          - maybe
+          - newtype
+          - node-buffer
+          - node-fs
+          - node-http
+          - node-net
+          - node-process
+          - node-streams
+          - options
+          - ordered-collections
+          - posix-types
+          - prelude
+          - profunctor
+          - record
+          - refs
+          - routing-duplex
+          - strings
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+      httpurple-argonaut:
+        repo: https://github.com/sigma-andex/purescript-httpurple-argonaut.git
+        version: v1.0.1
+        dependencies:
+          - argonaut
+          - console
+          - effect
+          - either
+          - httpurple
+          - prelude
+      httpurple-yoga-json:
+        repo: https://github.com/sigma-andex/purescript-httpurple-yoga-json.git
+        version: v1.0.0
+        dependencies:
+          - console
+          - effect
+          - either
+          - foreign
+          - httpurple
+          - lists
+          - prelude
+          - yoga-json
+      identity:
+        repo: https://github.com/purescript/purescript-identity.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - invariant
+          - newtype
+          - prelude
+      indexed-monad:
+        repo: https://github.com/garyb/purescript-indexed-monad.git
+        version: v2.1.0
+        dependencies:
+          - control
+          - newtype
+      int64:
+        repo: https://github.com/purescript-contrib/purescript-int64.git
+        version: v2.0.0
+        dependencies:
+          - effect
+          - foreign
+          - functions
+          - integers
+          - maybe
+          - nullable
+          - prelude
+          - quickcheck
+      integers:
+        repo: https://github.com/purescript/purescript-integers.git
+        version: v6.0.0
+        dependencies:
+          - maybe
+          - numbers
+          - prelude
+      interpolate:
+        repo: https://github.com/jordanmartinez/purescript-interpolate.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+      invariant:
+        repo: https://github.com/purescript/purescript-invariant.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - prelude
+      js-date:
+        repo: https://github.com/purescript-contrib/purescript-js-date.git
+        version: v8.0.0
+        dependencies:
+          - datetime
+          - effect
+          - exceptions
+          - foreign
+          - integers
+          - now
+      js-fileio:
+        repo: https://github.com/newlandsvalley/purescript-js-fileio.git
+        version: v3.0.0
+        dependencies:
+          - aff
+          - effect
+          - prelude
+      js-timers:
+        repo: https://github.com/purescript-contrib/purescript-js-timers.git
+        version: v6.1.0
+        dependencies:
+          - effect
+      js-uri:
+        repo: https://github.com/purescript-contrib/purescript-js-uri.git
+        version: v3.0.0
+        dependencies:
+          - functions
+          - maybe
+      justifill:
+        repo: https://github.com/i-am-the-slime/purescript-justifill.git
+        version: v0.5.0
+        dependencies:
+          - maybe
+          - prelude
+          - record
+          - typelevel-prelude
+      jwt:
+        repo: https://github.com/menelaos/purescript-jwt.git
+        version: v0.0.9
+        dependencies:
+          - argonaut-core
+          - arrays
+          - b64
+          - either
+          - exceptions
+          - prelude
+          - profunctor-lenses
+          - strings
+      language-cst-parser:
+        repo: https://github.com/natefaubion/purescript-language-cst-parser.git
+        version: v0.12.0
+        dependencies:
+          - arrays
+          - const
+          - control
+          - either
+          - foldable-traversable
+          - free
+          - functions
+          - functors
+          - identity
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - ordered-collections
+          - partial
+          - prelude
+          - st
+          - strings
+          - transformers
+          - tuples
+          - typelevel-prelude
+          - unfoldable
+          - unsafe-coerce
+      lazy:
+        repo: https://github.com/purescript/purescript-lazy.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - invariant
+          - prelude
+      lcg:
+        repo: https://github.com/purescript/purescript-lcg.git
+        version: v4.0.0
+        dependencies:
+          - effect
+          - integers
+          - maybe
+          - partial
+          - prelude
+          - random
+      leibniz:
+        repo: https://github.com/paf31/purescript-leibniz.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+          - unsafe-coerce
+      linalg:
+        repo: https://github.com/gbagan/purescript-linalg.git
+        version: v5.1.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - functions
+          - maybe
+          - prelude
+          - tuples
+      lists:
+        repo: https://github.com/purescript/purescript-lists.git
+        version: v7.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - foldable-traversable
+          - lazy
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      logging:
+        repo: https://github.com/rightfold/purescript-logging.git
+        version: v3.0.0
+        dependencies:
+          - console
+          - contravariant
+          - effect
+          - either
+          - prelude
+          - transformers
+          - tuples
+      machines:
+        repo: https://github.com/purescript-contrib/purescript-machines.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - lists
+          - maybe
+          - prelude
+          - profunctor
+          - tuples
+          - unfoldable
+      matrices:
+        repo: https://github.com/kRITZCREEK/purescript-matrices.git
+        version: v5.0.1
+        dependencies:
+          - arrays
+          - strings
+      matryoshka:
+        repo: https://github.com/purescript-contrib/purescript-matryoshka.git
+        version: v1.0.0
+        dependencies:
+          - fixed-points
+          - free
+          - prelude
+          - profunctor
+          - transformers
+      maybe:
+        repo: https://github.com/purescript/purescript-maybe.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - invariant
+          - newtype
+          - prelude
+      media-types:
+        repo: https://github.com/purescript-contrib/purescript-media-types.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      metadata:
+        repo: https://github.com/purescript/purescript-metadata.git
+        version: v0.15.0
+        dependencies: []
+      midi:
+        repo: https://github.com/newlandsvalley/purescript-midi.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - ordered-collections
+          - prelude
+          - signal
+          - string-parsers
+          - strings
+          - tuples
+          - unfoldable
+      minibench:
+        repo: https://github.com/purescript/purescript-minibench.git
+        version: v4.0.0
+        dependencies:
+          - console
+          - effect
+          - integers
+          - numbers
+          - partial
+          - prelude
+          - refs
+      mmorph:
+        repo: https://github.com/Thimoteus/purescript-mmorph.git
+        version: v7.0.0
+        dependencies:
+          - free
+          - functors
+          - transformers
+      monad-control:
+        repo: https://github.com/athanclark/purescript-monad-control.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - freet
+          - identity
+          - lists
+      monad-logger:
+        repo: https://github.com/cprussin/purescript-monad-logger.git
+        version: v1.3.1
+        dependencies:
+          - aff
+          - ansi
+          - argonaut
+          - arrays
+          - console
+          - control
+          - effect
+          - foldable-traversable
+          - foreign-object
+          - integers
+          - js-date
+          - maybe
+          - newtype
+          - ordered-collections
+          - prelude
+          - strings
+          - transformers
+          - tuples
+      monad-loops:
+        repo: https://github.com/mlang/purescript-monad-loops.git
+        version: v0.5.0
+        dependencies:
+          - lists
+          - maybe
+          - prelude
+          - tailrec
+          - tuples
+      monad-unlift:
+        repo: https://github.com/athanclark/purescript-monad-unlift.git
+        version: v1.0.1
+        dependencies:
+          - monad-control
+      monoidal:
+        repo: https://github.com/mcneissue/purescript-monoidal.git
+        version: v0.16.0
+        dependencies:
+          - either
+          - profunctor
+          - these
+          - tuples
+      morello:
+        repo: https://github.com/sigma-andex/purescript-morello.git
+        version: v0.3.2
+        dependencies:
+          - arrays
+          - barlow-lens
+          - foldable-traversable
+          - heterogeneous
+          - heterogeneous-extrablatt
+          - newtype
+          - prelude
+          - profunctor
+          - profunctor-lenses
+          - record
+          - tuples
+          - typelevel-prelude
+          - validation
+      motsunabe:
+        repo: https://github.com/justinwoo/purescript-motsunabe.git
+        version: v2.0.0
+        dependencies:
+          - lists
+          - strings
+      nano-id:
+        repo: https://github.com/eikooc/nano-id.git
+        version: v1.1.0
+        dependencies:
+          - aff
+          - effect
+          - lists
+          - maybe
+          - prelude
+          - random
+          - spec
+          - strings
+          - stringutils
+      naturals:
+        repo: https://github.com/LiamGoodacre/purescript-naturals.git
+        version: v3.0.0
+        dependencies:
+          - enums
+          - maybe
+          - prelude
+      nested-functor:
+        repo: https://github.com/acple/purescript-nested-functor.git
+        version: v0.2.1
+        dependencies:
+          - prelude
+          - type-equality
+      newtype:
+        repo: https://github.com/purescript/purescript-newtype.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+          - safe-coerce
+      node-buffer:
+        repo: https://github.com/purescript-node/purescript-node-buffer.git
+        version: v8.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - maybe
+          - st
+          - unsafe-coerce
+      node-buffer-blob:
+        repo: https://github.com/purescript-node/purescript-node-buffer-blob.git
+        version: v1.0.0
+        dependencies:
+          - aff-promise
+          - arraybuffer-types
+          - arrays
+          - console
+          - effect
+          - maybe
+          - media-types
+          - newtype
+          - node-buffer
+          - nullable
+          - prelude
+          - web-streams
+      node-child-process:
+        repo: https://github.com/purescript-node/purescript-node-child-process.git
+        version: v9.0.0
+        dependencies:
+          - exceptions
+          - foreign
+          - foreign-object
+          - functions
+          - node-fs
+          - node-streams
+          - nullable
+          - posix-types
+          - unsafe-coerce
+      node-fs:
+        repo: https://github.com/purescript-node/purescript-node-fs.git
+        version: v8.0.0
+        dependencies:
+          - datetime
+          - effect
+          - either
+          - enums
+          - exceptions
+          - functions
+          - integers
+          - js-date
+          - maybe
+          - node-buffer
+          - node-path
+          - node-streams
+          - nullable
+          - partial
+          - prelude
+          - strings
+          - unsafe-coerce
+      node-fs-aff:
+        repo: https://github.com/purescript-node/purescript-node-fs-aff.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - either
+          - node-fs
+          - node-path
+      node-http:
+        repo: https://github.com/purescript-node/purescript-node-http.git
+        version: v8.0.0
+        dependencies:
+          - arraybuffer-types
+          - contravariant
+          - effect
+          - foreign
+          - foreign-object
+          - maybe
+          - node-buffer
+          - node-net
+          - node-streams
+          - node-url
+          - nullable
+          - options
+          - prelude
+          - unsafe-coerce
+      node-net:
+        repo: https://github.com/purescript-node/purescript-node-net.git
+        version: v4.0.0
+        dependencies:
+          - effect
+          - either
+          - exceptions
+          - foreign
+          - maybe
+          - node-buffer
+          - node-fs
+          - nullable
+          - options
+          - prelude
+          - transformers
+      node-path:
+        repo: https://github.com/purescript-node/purescript-node-path.git
+        version: v5.0.0
+        dependencies:
+          - effect
+      node-process:
+        repo: https://github.com/purescript-node/purescript-node-process.git
+        version: v10.0.0
+        dependencies:
+          - effect
+          - foreign-object
+          - maybe
+          - node-streams
+          - posix-types
+          - prelude
+          - unsafe-coerce
+      node-readline:
+        repo: https://github.com/purescript-node/purescript-node-readline.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - foreign
+          - node-process
+          - node-streams
+          - options
+          - prelude
+      node-streams:
+        repo: https://github.com/purescript-node/purescript-node-streams.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - either
+          - exceptions
+          - node-buffer
+          - nullable
+          - prelude
+      node-streams-aff:
+        repo: https://github.com/jamesdbrock/purescript-node-streams-aff.git
+        version: v2.0.0
+        dependencies:
+          - aff
+          - arrays
+          - effect
+          - either
+          - exceptions
+          - maybe
+          - node-buffer
+          - node-streams
+          - prelude
+          - st
+          - tuples
+      node-url:
+        repo: https://github.com/purescript-node/purescript-node-url.git
+        version: v6.0.0
+        dependencies:
+          - nullable
+      nonempty:
+        repo: https://github.com/purescript/purescript-nonempty.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - maybe
+          - prelude
+          - tuples
+          - unfoldable
+      now:
+        repo: https://github.com/purescript-contrib/purescript-now.git
+        version: v6.0.0
+        dependencies:
+          - datetime
+          - effect
+      npm-package-json:
+        repo: https://github.com/maxdeviant/purescript-npm-package-json.git
+        version: v2.0.0
+        dependencies:
+          - argonaut
+          - control
+          - either
+          - foreign-object
+          - maybe
+          - ordered-collections
+          - prelude
+      nullable:
+        repo: https://github.com/purescript-contrib/purescript-nullable.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - functions
+          - maybe
+      numbers:
+        repo: https://github.com/purescript/purescript-numbers.git
+        version: v9.0.0
+        dependencies:
+          - functions
+          - maybe
+      open-folds:
+        repo: https://github.com/purescript-open-community/purescript-open-folds.git
+        version: v6.3.0
+        dependencies:
+          - bifunctors
+          - console
+          - control
+          - distributive
+          - effect
+          - either
+          - foldable-traversable
+          - identity
+          - invariant
+          - maybe
+          - newtype
+          - ordered-collections
+          - prelude
+          - profunctor
+          - psci-support
+          - tuples
+      open-memoize:
+        repo: https://github.com/purescript-open-community/purescript-open-memoize.git
+        version: v6.1.0
+        dependencies:
+          - console
+          - effect
+          - either
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - psci-support
+          - strings
+          - tuples
+      open-pairing:
+        repo: https://github.com/purescript-open-community/purescript-open-pairing.git
+        version: v6.1.0
+        dependencies:
+          - console
+          - control
+          - effect
+          - either
+          - free
+          - functors
+          - identity
+          - newtype
+          - prelude
+          - psci-support
+          - transformers
+          - tuples
+      options:
+        repo: https://github.com/purescript-contrib/purescript-options.git
+        version: v7.0.0
+        dependencies:
+          - contravariant
+          - foreign
+          - foreign-object
+          - maybe
+          - tuples
+      optparse:
+        repo: https://github.com/f-o-a-m/purescript-optparse.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - control
+          - effect
+          - either
+          - enums
+          - exists
+          - exitcodes
+          - foldable-traversable
+          - free
+          - gen
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - newtype
+          - node-buffer
+          - node-process
+          - node-streams
+          - nonempty
+          - numbers
+          - open-memoize
+          - partial
+          - prelude
+          - quickcheck
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+      ordered-collections:
+        repo: https://github.com/purescript/purescript-ordered-collections.git
+        version: v3.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - gen
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - unfoldable
+      ordered-set:
+        repo: https://github.com/flip111/purescript-ordered-set.git
+        version: v0.4.0
+        dependencies:
+          - argonaut-codecs
+          - arrays
+          - partial
+          - prelude
+          - unfoldable
+      orders:
+        repo: https://github.com/purescript/purescript-orders.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      pairs:
+        repo: https://github.com/sharkdp/purescript-pairs.git
+        version: v9.0.0
+        dependencies:
+          - console
+          - distributive
+          - foldable-traversable
+          - quickcheck
+      parallel:
+        repo: https://github.com/purescript/purescript-parallel.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - functors
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - refs
+          - transformers
+      parsing:
+        repo: https://github.com/purescript-contrib/purescript-parsing.git
+        version: v9.1.0
+        dependencies:
+          - arrays
+          - either
+          - foldable-traversable
+          - identity
+          - integers
+          - lists
+          - maybe
+          - nullable
+          - prelude
+          - strings
+          - transformers
+          - unicode
+      parsing-dataview:
+        repo: https://github.com/jamesdbrock/purescript-parsing-dataview.git
+        version: v3.1.0
+        dependencies:
+          - arraybuffer
+          - arraybuffer-types
+          - effect
+          - float32
+          - maybe
+          - parsing
+          - prelude
+          - transformers
+          - tuples
+          - uint
+      partial:
+        repo: https://github.com/purescript/purescript-partial.git
+        version: v4.0.0
+        dependencies: []
+      pathy:
+        repo: https://github.com/purescript-contrib/purescript-pathy.git
+        version: v9.0.0
+        dependencies:
+          - console
+          - exceptions
+          - lists
+          - partial
+          - profunctor
+          - strings
+          - transformers
+          - typelevel-prelude
+          - unsafe-coerce
+      pha:
+        repo: https://github.com/gbagan/purescript-pha.git
+        version: v0.9.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - datetime
+          - effect
+          - foldable-traversable
+          - free
+          - integers
+          - maybe
+          - prelude
+          - profunctor-lenses
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+          - unsafe-reference
+          - web-dom
+          - web-events
+          - web-html
+          - web-pointerevents
+          - web-uievents
+      phaser:
+        repo: https://github.com/lfarroco/purescript-phaser.git
+        version: v0.6.0
+        dependencies:
+          - canvas
+          - console
+          - effect
+          - maybe
+          - nullable
+          - options
+          - prelude
+          - web-html
+      pipes:
+        repo: https://github.com/felixschl/purescript-pipes.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - lists
+          - mmorph
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      point-free:
+        repo: https://github.com/ursi/purescript-point-free.git
+        version: v1.0.0
+        dependencies:
+          - prelude
+      polymorphic-vectors:
+        repo: https://github.com/artemisSystem/purescript-polymorphic-vectors.git
+        version: v4.0.0
+        dependencies:
+          - distributive
+          - foldable-traversable
+          - numbers
+          - prelude
+          - record
+          - safe-coerce
+          - type-equality
+          - typelevel-prelude
+      posix-types:
+        repo: https://github.com/purescript-node/purescript-posix-types.git
+        version: v6.0.0
+        dependencies:
+          - maybe
+          - prelude
+      precise:
+        repo: https://github.com/purescript-contrib/purescript-precise.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - exceptions
+          - gen
+          - integers
+          - lists
+          - numbers
+          - prelude
+          - strings
+      precise-datetime:
+        repo: https://github.com/awakesecurity/purescript-precise-datetime.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - datetime
+          - decimals
+          - either
+          - enums
+          - foldable-traversable
+          - formatters
+          - integers
+          - js-date
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - strings
+          - tuples
+          - unicode
+      prelude:
+        repo: https://github.com/purescript/purescript-prelude.git
+        version: v6.0.0
+        dependencies: []
+      prettier-printer:
+        repo: https://github.com/paulyoung/purescript-prettier-printer.git
+        version: v3.0.0
+        dependencies:
+          - console
+          - lists
+          - prelude
+          - strings
+          - tuples
+      profunctor:
+        repo: https://github.com/purescript/purescript-profunctor.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - distributive
+          - either
+          - exists
+          - invariant
+          - newtype
+          - prelude
+          - tuples
+      profunctor-lenses:
+        repo: https://github.com/purescript-contrib/purescript-profunctor-lenses.git
+        version: v8.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - const
+          - control
+          - distributive
+          - either
+          - foldable-traversable
+          - foreign-object
+          - functors
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - ordered-collections
+          - partial
+          - prelude
+          - profunctor
+          - record
+          - transformers
+          - tuples
+      protobuf:
+        repo: https://github.com/xc-jp/purescript-protobuf.git
+        version: v4.0.0
+        dependencies:
+          - arraybuffer
+          - arraybuffer-builder
+          - arraybuffer-types
+          - arrays
+          - control
+          - effect
+          - either
+          - enums
+          - exceptions
+          - float32
+          - foldable-traversable
+          - functions
+          - int64
+          - maybe
+          - newtype
+          - parsing
+          - parsing-dataview
+          - prelude
+          - record
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+          - uint
+          - web-encoding
+      ps-cst:
+        repo: https://github.com/purescript-codegen/purescript-ps-cst.git
+        version: v1.2.0
+        dependencies:
+          - ansi
+          - console
+          - dodo-printer
+          - effect
+          - node-fs-aff
+          - node-path
+          - psci-support
+          - record
+          - strings
+      psa-utils:
+        repo: https://github.com/natefaubion/purescript-psa-utils.git
+        version: v8.0.0
+        dependencies:
+          - ansi
+          - argonaut-codecs
+          - argonaut-core
+          - arrays
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - maybe
+          - node-path
+          - ordered-collections
+          - prelude
+          - strings
+          - tuples
+          - unsafe-coerce
+      psc-ide:
+        repo: https://github.com/kRITZCREEK/purescript-psc-ide.git
+        version: v19.0.0
+        dependencies:
+          - aff
+          - argonaut
+          - arrays
+          - console
+          - maybe
+          - node-child-process
+          - node-fs
+          - parallel
+          - random
+      psci-support:
+        repo: https://github.com/purescript/purescript-psci-support.git
+        version: v6.0.0
+        dependencies:
+          - console
+          - effect
+          - prelude
+      qualified-do:
+        repo: https://github.com/artemisSystem/purescript-qualified-do.git
+        version: v2.2.0
+        dependencies:
+          - arrays
+          - control
+          - foldable-traversable
+          - parallel
+          - prelude
+          - unfoldable
+      quantities:
+        repo: https://github.com/sharkdp/purescript-quantities.git
+        version: v12.0.1
+        dependencies:
+          - decimals
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - newtype
+          - nonempty
+          - numbers
+          - pairs
+          - prelude
+          - tuples
+      quickcheck:
+        repo: https://github.com/purescript/purescript-quickcheck.git
+        version: v8.0.1
+        dependencies:
+          - arrays
+          - console
+          - control
+          - effect
+          - either
+          - enums
+          - exceptions
+          - foldable-traversable
+          - gen
+          - identity
+          - integers
+          - lazy
+          - lcg
+          - lists
+          - maybe
+          - newtype
+          - nonempty
+          - numbers
+          - partial
+          - prelude
+          - record
+          - st
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+          - unfoldable
+      quickcheck-combinators:
+        repo: https://github.com/athanclark/purescript-quickcheck-combinators.git
+        version: v0.1.3
+        dependencies:
+          - quickcheck
+          - typelevel
+      quickcheck-laws:
+        repo: https://github.com/purescript-contrib/purescript-quickcheck-laws.git
+        version: v7.0.0
+        dependencies:
+          - enums
+          - quickcheck
+      quickcheck-utf8:
+        repo: https://github.com/openchronology/purescript-quickcheck-utf8.git
+        version: v0.0.0
+        dependencies:
+          - quickcheck
+      quotient:
+        repo: https://github.com/rightfold/purescript-quotient.git
+        version: v3.0.0
+        dependencies:
+          - prelude
+          - quickcheck
+      random:
+        repo: https://github.com/purescript/purescript-random.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - integers
+      rationals:
+        repo: https://github.com/anttih/purescript-rationals.git
+        version: v5.0.0
+        dependencies:
+          - integers
+          - prelude
+      react:
+        repo: https://github.com/purescript-contrib/purescript-react.git
+        version: v10.0.1
+        dependencies:
+          - effect
+          - exceptions
+          - maybe
+          - nullable
+          - prelude
+          - typelevel-prelude
+          - unsafe-coerce
+      react-basic:
+        repo: https://github.com/lumihq/purescript-react-basic.git
+        version: v17.0.0
+        dependencies:
+          - effect
+          - prelude
+          - record
+      react-basic-dom:
+        repo: https://github.com/lumihq/purescript-react-basic-dom.git
+        version: v5.0.0
+        dependencies:
+          - effect
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - nullable
+          - prelude
+          - react-basic
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-file
+          - web-html
+      react-basic-hooks:
+        repo: https://github.com/megamaddu/purescript-react-basic-hooks.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - aff-promise
+          - bifunctors
+          - console
+          - control
+          - datetime
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - functions
+          - indexed-monad
+          - integers
+          - maybe
+          - newtype
+          - now
+          - nullable
+          - ordered-collections
+          - prelude
+          - react-basic
+          - refs
+          - tuples
+          - type-equality
+          - unsafe-coerce
+          - unsafe-reference
+          - web-html
+      react-dom:
+        repo: https://github.com/purescript-contrib/purescript-react-dom.git
+        version: v8.0.0
+        dependencies:
+          - effect
+          - react
+          - web-dom
+      read:
+        repo: https://github.com/truqu/purescript-read.git
+        version: v1.0.1
+        dependencies:
+          - maybe
+          - prelude
+          - strings
+      record:
+        repo: https://github.com/purescript/purescript-record.git
+        version: v4.0.0
+        dependencies:
+          - functions
+          - prelude
+          - unsafe-coerce
+      refined:
+        repo: https://github.com/danieljharvey/purescript-refined.git
+        version: v1.0.0
+        dependencies:
+          - argonaut
+          - effect
+          - prelude
+          - quickcheck
+          - typelevel
+      refs:
+        repo: https://github.com/purescript/purescript-refs.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - prelude
+      remotedata:
+        repo: https://github.com/krisajenkins/purescript-remotedata.git
+        version: v5.0.0
+        dependencies:
+          - bifunctors
+          - either
+          - profunctor-lenses
+      resource:
+        repo: https://github.com/joneshf/purescript-resource.git
+        version: v2.0.1
+        dependencies:
+          - aff
+          - console
+          - control
+          - effect
+          - newtype
+          - prelude
+          - psci-support
+          - refs
+      resourcet:
+        repo: https://github.com/robertdp/purescript-resourcet.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - effect
+          - foldable-traversable
+          - maybe
+          - ordered-collections
+          - parallel
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+      result:
+        repo: https://github.com/ad-si/purescript-result.git
+        version: v1.0.3
+        dependencies:
+          - either
+          - foldable-traversable
+          - prelude
+      return:
+        repo: https://github.com/ursi/purescript-return.git
+        version: v0.2.0
+        dependencies:
+          - foldable-traversable
+          - point-free
+          - prelude
+      ring-modules:
+        repo: https://github.com/f-o-a-m/purescript-ring-modules.git
+        version: v5.0.1
+        dependencies:
+          - prelude
+      routing:
+        repo: https://github.com/purescript-contrib/purescript-routing.git
+        version: v11.0.0
+        dependencies:
+          - aff
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - integers
+          - js-uri
+          - lists
+          - maybe
+          - numbers
+          - partial
+          - prelude
+          - semirings
+          - tuples
+          - validation
+          - web-html
+      routing-duplex:
+        repo: https://github.com/natefaubion/purescript-routing-duplex.git
+        version: v0.6.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - js-uri
+          - lazy
+          - numbers
+          - prelude
+          - profunctor
+          - record
+          - strings
+          - typelevel-prelude
+      run:
+        repo: https://github.com/natefaubion/purescript-run.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - free
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - tailrec
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - variant
+      safe-coerce:
+        repo: https://github.com/purescript/purescript-safe-coerce.git
+        version: v2.0.0
+        dependencies:
+          - unsafe-coerce
+      safely:
+        repo: https://github.com/paf31/purescript-safely.git
+        version: v4.0.1
+        dependencies:
+          - freet
+          - lists
+      selection-foldable:
+        repo: https://github.com/jamieyung/purescript-selection-foldable.git
+        version: v0.2.0
+        dependencies:
+          - filterable
+          - foldable-traversable
+          - maybe
+          - prelude
+      semirings:
+        repo: https://github.com/purescript/purescript-semirings.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - lists
+          - newtype
+          - prelude
+      signal:
+        repo: https://github.com/bodil/purescript-signal.git
+        version: v13.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - foldable-traversable
+          - maybe
+          - prelude
+      simple-emitter:
+        repo: https://github.com/oreshinya/purescript-simple-emitter.git
+        version: v2.0.0
+        dependencies:
+          - ordered-collections
+          - refs
+      sized-matrices:
+        repo: https://github.com/csicar/purescript-sized-matrices.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - distributive
+          - foldable-traversable
+          - maybe
+          - prelude
+          - sized-vectors
+          - strings
+          - typelevel
+          - unfoldable
+          - vectorfield
+      sized-vectors:
+        repo: https://github.com/bodil/purescript-sized-vectors.git
+        version: v5.0.2
+        dependencies:
+          - argonaut
+          - arrays
+          - distributive
+          - foldable-traversable
+          - maybe
+          - prelude
+          - quickcheck
+          - typelevel
+          - unfoldable
+      slug:
+        repo: https://github.com/thomashoneyman/purescript-slug.git
+        version: v3.0.1
+        dependencies:
+          - argonaut-codecs
+          - maybe
+          - prelude
+          - strings
+          - unicode
+      soundfonts:
+        repo: https://github.com/newlandsvalley/purescript-soundfonts.git
+        version: v4.1.0
+        dependencies:
+          - aff
+          - affjax
+          - affjax-web
+          - argonaut-core
+          - arraybuffer-types
+          - arrays
+          - b64
+          - bifunctors
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign-object
+          - http-methods
+          - integers
+          - lists
+          - maybe
+          - midi
+          - ordered-collections
+          - parallel
+          - partial
+          - prelude
+          - strings
+          - transformers
+          - tuples
+      sparse-matrices:
+        repo: https://github.com/Ebmtranceboy/purescript-sparse-matrices.git
+        version: v1.2.1
+        dependencies:
+          - console
+          - effect
+          - prelude
+          - sparse-polynomials
+      sparse-polynomials:
+        repo: https://github.com/Ebmtranceboy/purescript-sparse-polynomials.git
+        version: v1.0.5
+        dependencies:
+          - cartesian
+          - console
+          - effect
+          - ordered-collections
+          - prelude
+          - rationals
+          - tuples
+      spec:
+        repo: https://github.com/purescript-spec/purescript-spec.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - ansi
+          - avar
+          - console
+          - exceptions
+          - foldable-traversable
+          - fork
+          - now
+          - pipes
+          - prelude
+          - strings
+          - transformers
+      spec-discovery:
+        repo: https://github.com/purescript-spec/purescript-spec-discovery.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - aff-promise
+          - arrays
+          - console
+          - effect
+          - foldable-traversable
+          - node-fs
+          - prelude
+          - spec
+      spec-quickcheck:
+        repo: https://github.com/purescript-spec/purescript-spec-quickcheck.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - prelude
+          - quickcheck
+          - random
+          - spec
+      ssrs:
+        repo: https://github.com/PureFunctor/purescript-ssrs.git
+        version: v1.0.0
+        dependencies:
+          - dissect
+          - either
+          - fixed-points
+          - free
+          - lists
+          - prelude
+          - safe-coerce
+          - tailrec
+          - tuples
+          - variant
+      st:
+        repo: https://github.com/purescript/purescript-st.git
+        version: v6.0.0
+        dependencies:
+          - partial
+          - prelude
+          - tailrec
+          - unsafe-coerce
+      strictlypositiveint:
+        repo: https://github.com/jamieyung/purescript-strictlypositiveint.git
+        version: v1.0.1
+        dependencies:
+          - prelude
+      string-parsers:
+        repo: https://github.com/purescript-contrib/purescript-string-parsers.git
+        version: v8.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - prelude
+          - strings
+          - tailrec
+      strings:
+        repo: https://github.com/purescript/purescript-strings.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - enums
+          - foldable-traversable
+          - gen
+          - integers
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+          - unsafe-coerce
+      strings-extra:
+        repo: https://github.com/purescript-contrib/purescript-strings-extra.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - maybe
+          - prelude
+          - strings
+          - unicode
+      stringutils:
+        repo: https://github.com/menelaos/purescript-stringutils.git
+        version: v0.0.12
+        dependencies:
+          - arrays
+          - integers
+          - maybe
+          - partial
+          - prelude
+          - strings
+      substitute:
+        repo: https://github.com/ursi/purescript-substitute.git
+        version: v0.2.3
+        dependencies:
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - prelude
+          - return
+          - strings
+      supply:
+        repo: https://github.com/ajnsit/purescript-supply.git
+        version: v0.2.0
+        dependencies:
+          - console
+          - control
+          - effect
+          - lazy
+          - prelude
+          - refs
+          - tuples
+      tailrec:
+        repo: https://github.com/purescript/purescript-tailrec.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - effect
+          - either
+          - identity
+          - maybe
+          - partial
+          - prelude
+          - refs
+      test-unit:
+        repo: https://github.com/bodil/purescript-test-unit.git
+        version: v17.0.0
+        dependencies:
+          - aff
+          - avar
+          - effect
+          - either
+          - free
+          - js-timers
+          - lists
+          - prelude
+          - quickcheck
+          - strings
+      thermite:
+        repo: https://github.com/paf31/purescript-thermite.git
+        version: v6.3.1
+        dependencies:
+          - aff
+          - coroutines
+          - freet
+          - profunctor-lenses
+          - react
+      thermite-dom:
+        repo: https://github.com/athanclark/purescript-thermite-dom.git
+        version: v0.3.1
+        dependencies:
+          - react
+          - react-dom
+          - thermite
+          - web-html
+      these:
+        repo: https://github.com/purescript-contrib/purescript-these.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - gen
+          - lists
+          - quickcheck
+          - quickcheck-laws
+          - tuples
+      transformers:
+        repo: https://github.com/purescript/purescript-transformers.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - distributive
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - identity
+          - lazy
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      tree-rose:
+        repo: https://github.com/jordanmartinez/purescript-tree-rose.git
+        version: v4.0.2
+        dependencies:
+          - control
+          - foldable-traversable
+          - free
+          - lists
+          - maybe
+          - prelude
+          - tailrec
+      tuples:
+        repo: https://github.com/purescript/purescript-tuples.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - invariant
+          - prelude
+      two-or-more:
+        repo: https://github.com/i-am-the-slime/purescript-two-or-more.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - foldable-traversable
+          - maybe
+          - partial
+          - prelude
+          - psci-support
+          - tuples
+      type-equality:
+        repo: https://github.com/purescript/purescript-type-equality.git
+        version: v4.0.1
+        dependencies: []
+      typelevel:
+        repo: https://github.com/bodil/purescript-typelevel.git
+        version: v6.0.0
+        dependencies:
+          - partial
+          - prelude
+          - tuples
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-lists:
+        repo: https://github.com/PureFunctor/purescript-typelevel-lists.git
+        version: v2.1.0
+        dependencies:
+          - prelude
+          - tuples
+          - typelevel-peano
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-peano:
+        repo: https://github.com/csicar/purescript-typelevel-peano.git
+        version: v1.0.1
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - prelude
+          - psci-support
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-prelude:
+        repo: https://github.com/purescript/purescript-typelevel-prelude.git
+        version: v7.0.0
+        dependencies:
+          - prelude
+          - type-equality
+      typelevel-rows:
+        repo: https://github.com/jordanmartinez/purescript-typelevel-rows.git
+        version: v0.1.0
+        dependencies:
+          - prelude
+      uint:
+        repo: https://github.com/purescript-contrib/purescript-uint.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - enums
+          - gen
+          - maybe
+          - numbers
+          - prelude
+      uncurried-transformers:
+        repo: https://github.com/PureFunctor/purescript-uncurried-transformers.git
+        version: v1.1.0
+        dependencies:
+          - control
+          - effect
+          - either
+          - functions
+          - identity
+          - prelude
+          - safe-coerce
+          - tailrec
+          - transformers
+          - tuples
+      undefined-is-not-a-problem:
+        repo: https://github.com/paluh/purescript-undefined-is-not-a-problem.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - assert
+          - effect
+          - either
+          - foreign
+          - maybe
+          - newtype
+          - prelude
+          - random
+          - tuples
+          - type-equality
+          - unsafe-coerce
+      unfoldable:
+        repo: https://github.com/purescript/purescript-unfoldable.git
+        version: v6.0.0
+        dependencies:
+          - foldable-traversable
+          - maybe
+          - partial
+          - prelude
+          - tuples
+      unicode:
+        repo: https://github.com/purescript-contrib/purescript-unicode.git
+        version: v6.0.0
+        dependencies:
+          - foldable-traversable
+          - maybe
+          - strings
+      unlift:
+        repo: https://github.com/tweag/purescript-unlift.git
+        version: v1.0.1
+        dependencies:
+          - aff
+          - effect
+          - either
+          - freet
+          - identity
+          - lists
+          - maybe
+          - monad-control
+          - prelude
+          - st
+          - transformers
+          - tuples
+      unsafe-coerce:
+        repo: https://github.com/purescript/purescript-unsafe-coerce.git
+        version: v6.0.0
+        dependencies: []
+      unsafe-reference:
+        repo: https://github.com/purescript-contrib/purescript-unsafe-reference.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+      uri:
+        repo: https://github.com/purescript-contrib/purescript-uri.git
+        version: v9.0.0
+        dependencies:
+          - arrays
+          - integers
+          - js-uri
+          - numbers
+          - parsing
+          - prelude
+          - profunctor-lenses
+          - these
+          - transformers
+          - unfoldable
+      validation:
+        repo: https://github.com/purescript/purescript-validation.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - newtype
+          - prelude
+      variant:
+        repo: https://github.com/natefaubion/purescript-variant.git
+        version: v8.0.0
+        dependencies:
+          - enums
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - record
+          - tuples
+          - unsafe-coerce
+      vectorfield:
+        repo: https://github.com/csicar/purescript-vectorfield.git
+        version: v1.0.1
+        dependencies:
+          - console
+          - effect
+          - group
+          - prelude
+          - psci-support
+      versions:
+        repo: https://github.com/hdgarrood/purescript-versions.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - either
+          - foldable-traversable
+          - functions
+          - integers
+          - lists
+          - maybe
+          - orders
+          - parsing
+          - partial
+          - strings
+      web-clipboard:
+        repo: https://github.com/purescript-web/purescript-web-clipboard.git
+        version: v4.0.0
+        dependencies:
+          - web-html
+      web-cssom:
+        repo: https://github.com/purescript-web/purescript-web-cssom.git
+        version: v2.0.0
+        dependencies:
+          - web-dom
+          - web-html
+          - web-uievents
+      web-dom:
+        repo: https://github.com/purescript-web/purescript-web-dom.git
+        version: v6.0.0
+        dependencies:
+          - web-events
+      web-dom-parser:
+        repo: https://github.com/purescript-web/purescript-web-dom-parser.git
+        version: v8.0.0
+        dependencies:
+          - effect
+          - partial
+          - prelude
+          - web-dom
+      web-dom-xpath:
+        repo: https://github.com/purescript-web/purescript-web-dom-xpath.git
+        version: v3.0.0
+        dependencies:
+          - web-dom
+      web-encoding:
+        repo: https://github.com/purescript-web/purescript-web-encoding.git
+        version: v3.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - newtype
+          - prelude
+      web-events:
+        repo: https://github.com/purescript-web/purescript-web-events.git
+        version: v4.0.0
+        dependencies:
+          - datetime
+          - enums
+          - foreign
+          - nullable
+      web-fetch:
+        repo: https://github.com/purescript-web/purescript-web-fetch.git
+        version: v3.0.0
+        dependencies:
+          - effect
+          - foreign-object
+          - http-methods
+          - prelude
+          - record
+          - typelevel-prelude
+          - web-file
+          - web-promise
+          - web-streams
+      web-file:
+        repo: https://github.com/purescript-web/purescript-web-file.git
+        version: v4.0.0
+        dependencies:
+          - foreign
+          - media-types
+          - web-dom
+      web-html:
+        repo: https://github.com/purescript-web/purescript-web-html.git
+        version: v4.0.0
+        dependencies:
+          - js-date
+          - web-dom
+          - web-file
+          - web-storage
+      web-page-visibility:
+        repo: https://git.sr.ht/~toastal/purescript-web-page-visibility
+        version: v2.0.0
+        dependencies:
+          - effect
+          - enums
+          - exceptions
+          - maybe
+          - prelude
+          - strings
+          - web-events
+          - web-html
+      web-pointerevents:
+        repo: https://github.com/purescript-web/purescript-web-pointerevents.git
+        version: v1.0.0
+        dependencies:
+          - effect
+          - maybe
+          - prelude
+          - web-dom
+          - web-uievents
+      web-promise:
+        repo: https://github.com/purescript-web/purescript-web-promise.git
+        version: v3.0.0
+        dependencies:
+          - effect
+          - exceptions
+          - foldable-traversable
+          - functions
+          - maybe
+          - prelude
+      web-socket:
+        repo: https://github.com/purescript-web/purescript-web-socket.git
+        version: v4.0.0
+        dependencies:
+          - arraybuffer-types
+          - web-file
+      web-storage:
+        repo: https://github.com/purescript-web/purescript-web-storage.git
+        version: v5.0.0
+        dependencies:
+          - nullable
+          - web-events
+      web-streams:
+        repo: https://github.com/purescript-web/purescript-web-streams.git
+        version: v3.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - exceptions
+          - nullable
+          - prelude
+          - tuples
+          - web-promise
+      web-touchevents:
+        repo: https://github.com/purescript-web/purescript-web-touchevents.git
+        version: v4.0.0
+        dependencies:
+          - web-uievents
+      web-uievents:
+        repo: https://github.com/purescript-web/purescript-web-uievents.git
+        version: v4.0.0
+        dependencies:
+          - web-html
+      web-workers:
+        repo: https://github.com/gbagan/purescript-web-workers.git
+        version: v1.1.0
+        dependencies:
+          - effect
+          - foreign
+          - maybe
+          - prelude
+          - unsafe-coerce
+          - web-events
+      web-xhr:
+        repo: https://github.com/purescript-web/purescript-web-xhr.git
+        version: v5.0.0
+        dependencies:
+          - arraybuffer-types
+          - datetime
+          - http-methods
+          - web-dom
+          - web-file
+          - web-html
+      yoga-fetch:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-fetch.git
+        version: v1.0.1
+        dependencies:
+          - aff
+          - aff-promise
+          - arraybuffer-types
+          - effect
+          - foreign
+          - foreign-object
+          - newtype
+          - prelude
+          - typelevel-prelude
+          - unsafe-coerce
+      yoga-json:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-json.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - identity
+          - lists
+          - maybe
+          - nullable
+          - partial
+          - prelude
+          - record
+          - transformers
+          - typelevel-prelude
+          - variant
+      yoga-postgres:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-postgres.git
+        version: v6.0.0
+        dependencies:
+          - aff
+          - arrays
+          - datetime
+          - effect
+          - either
+          - enums
+          - foldable-traversable
+          - foreign
+          - integers
+          - maybe
+          - nullable
+          - prelude
+          - transformers
+          - unsafe-coerce
+  extra_packages: {}
+packages:
+  arrays:
+    type: git
+    url: https://github.com/purescript/purescript-arrays.git
+    rev: d20bae2f76db6cf29b7b75e26e82b8a54c32295e
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - maybe
+      - nonempty
+      - partial
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  bifunctors:
+    type: git
+    url: https://github.com/purescript/purescript-bifunctors.git
+    rev: 16ba2fb6dd7f05528ebd9e2f9ca3a068b325e5b3
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  console:
+    type: git
+    url: https://github.com/purescript/purescript-console.git
+    rev: 3b83d7b792d03872afeea5e62b4f686ab0f09842
+    dependencies:
+      - effect
+      - prelude
+  const:
+    type: git
+    url: https://github.com/purescript/purescript-const.git
+    rev: ab9570cf2b6e67f7e441178211db1231cfd75c37
+    dependencies:
+      - invariant
+      - newtype
+      - prelude
+  contravariant:
+    type: git
+    url: https://github.com/purescript/purescript-contravariant.git
+    rev: 9ad3e105b8855bcc25f4e0893c784789d05a58de
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  control:
+    type: git
+    url: https://github.com/purescript/purescript-control.git
+    rev: a6033808790879a17b2729e73747a9ed3fb2264e
+    dependencies:
+      - newtype
+      - prelude
+  distributive:
+    type: git
+    url: https://github.com/purescript/purescript-distributive.git
+    rev: 6005e513642e855ebf6f884d24a35c2803ca252a
+    dependencies:
+      - identity
+      - newtype
+      - prelude
+      - tuples
+      - type-equality
+  effect:
+    type: git
+    url: https://github.com/purescript/purescript-effect.git
+    rev: a192ddb923027d426d6ea3d8deb030c9aa7c7dda
+    dependencies:
+      - prelude
+  either:
+    type: git
+    url: https://github.com/purescript/purescript-either.git
+    rev: af655a04ed2fd694b6688af39ee20d7907ad0763
+    dependencies:
+      - control
+      - invariant
+      - maybe
+      - prelude
+  enums:
+    type: git
+    url: https://github.com/purescript/purescript-enums.git
+    rev: bae47961d401f9acf88da38f32e87403e5f0cf2f
+    dependencies:
+      - control
+      - either
+      - gen
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tuples
+      - unfoldable
+  exceptions:
+    type: git
+    url: https://github.com/purescript/purescript-exceptions.git
+    rev: afab3c07c820bb49b6c5be50049db46a964a6161
+    dependencies:
+      - effect
+      - either
+      - maybe
+      - prelude
+  exists:
+    type: git
+    url: https://github.com/purescript/purescript-exists.git
+    rev: f765b4ace7869c27b9c05949e18c843881f9173b
+    dependencies:
+      - unsafe-coerce
+  foldable-traversable:
+    type: git
+    url: https://github.com/purescript/purescript-foldable-traversable.git
+    rev: b3926f870532d287ea59e2d5cd3873b81ef2a93a
+    dependencies:
+      - bifunctors
+      - const
+      - control
+      - either
+      - functors
+      - identity
+      - maybe
+      - newtype
+      - orders
+      - prelude
+      - tuples
+  functions:
+    type: git
+    url: https://github.com/purescript/purescript-functions.git
+    rev: f626f20580483977c5b27a01aac6471e28aff367
+    dependencies:
+      - prelude
+  functors:
+    type: git
+    url: https://github.com/purescript/purescript-functors.git
+    rev: 022ffd7a2a7ec12080314f3d217b400674a247b4
+    dependencies:
+      - bifunctors
+      - const
+      - contravariant
+      - control
+      - distributive
+      - either
+      - invariant
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - tuples
+      - unsafe-coerce
+  gen:
+    type: git
+    url: https://github.com/purescript/purescript-gen.git
+    rev: 9fbcc2a1261c32e30d79c5418edef4d96fe76931
+    dependencies:
+      - either
+      - foldable-traversable
+      - identity
+      - maybe
+      - newtype
+      - nonempty
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  identity:
+    type: git
+    url: https://github.com/purescript/purescript-identity.git
+    rev: ef6768f8a52ab0bc943a85f5761ba07c257f639f
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  integers:
+    type: git
+    url: https://github.com/purescript/purescript-integers.git
+    rev: 54d712b25c594833083d15dc9ff2418eb9c52822
+    dependencies:
+      - maybe
+      - numbers
+      - prelude
+  invariant:
+    type: git
+    url: https://github.com/purescript/purescript-invariant.git
+    rev: 1d2a196d51e90623adb88496c2cfd759c6736894
+    dependencies:
+      - control
+      - prelude
+  lazy:
+    type: git
+    url: https://github.com/purescript/purescript-lazy.git
+    rev: 48347841226b27af5205a1a8ec71e27a93ce86fd
+    dependencies:
+      - control
+      - foldable-traversable
+      - invariant
+      - prelude
+  lcg:
+    type: git
+    url: https://github.com/purescript/purescript-lcg.git
+    rev: 67c6c6483a563a59ae036d9dca0f1be2835326a5
+    dependencies:
+      - effect
+      - integers
+      - maybe
+      - partial
+      - prelude
+      - random
+  lists:
+    type: git
+    url: https://github.com/purescript/purescript-lists.git
+    rev: b113451e5b41cad87d669a3165f955c71cd863e2
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - lazy
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  maybe:
+    type: git
+    url: https://github.com/purescript/purescript-maybe.git
+    rev: c6f98ac1088766287106c5d9c8e30e7648d36786
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  newtype:
+    type: git
+    url: https://github.com/purescript/purescript-newtype.git
+    rev: 29d8e6dd77aec2c975c948364ec3faf26e14ee7b
+    dependencies:
+      - prelude
+      - safe-coerce
+  nonempty:
+    type: git
+    url: https://github.com/purescript/purescript-nonempty.git
+    rev: 28150ecc7419238b187abd609a92a645273348bb
+    dependencies:
+      - control
+      - foldable-traversable
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  numbers:
+    type: git
+    url: https://github.com/purescript/purescript-numbers.git
+    rev: 2a53528f18f9415334bae28e7bb3cf3be86342c2
+    dependencies:
+      - functions
+      - maybe
+  orders:
+    type: git
+    url: https://github.com/purescript/purescript-orders.git
+    rev: f86db621ec5eef1274145f8b1fd8ebbfe0ed4a2c
+    dependencies:
+      - newtype
+      - prelude
+  partial:
+    type: git
+    url: https://github.com/purescript/purescript-partial.git
+    rev: 0fa0646f5ea1ec5f0c46dcbd770c705a6c9ad3ec
+    dependencies: []
+  prelude:
+    type: git
+    url: https://github.com/purescript/purescript-prelude.git
+    rev: 32787f4399c92459c41602131a5858559eb868c5
+    dependencies: []
+  profunctor:
+    type: git
+    url: https://github.com/purescript/purescript-profunctor.git
+    rev: 0a966a14e7b0c827d44657dc1710cdc712d2e034
+    dependencies:
+      - control
+      - distributive
+      - either
+      - exists
+      - invariant
+      - newtype
+      - prelude
+      - tuples
+  quickcheck:
+    type: git
+    url: https://github.com/purescript/purescript-quickcheck.git
+    rev: bf5029f97e6c0d7552d3a08d2ab793a19e2c5e3d
+    dependencies:
+      - arrays
+      - console
+      - control
+      - effect
+      - either
+      - enums
+      - exceptions
+      - foldable-traversable
+      - gen
+      - identity
+      - integers
+      - lazy
+      - lcg
+      - lists
+      - maybe
+      - newtype
+      - nonempty
+      - numbers
+      - partial
+      - prelude
+      - record
+      - st
+      - strings
+      - tailrec
+      - transformers
+      - tuples
+      - unfoldable
+  random:
+    type: git
+    url: https://github.com/purescript/purescript-random.git
+    rev: 9540bc965a9596da02fefd9949418bb19c92533a
+    dependencies:
+      - effect
+      - integers
+  record:
+    type: git
+    url: https://github.com/purescript/purescript-record.git
+    rev: c89cd1ada6b636692571fc374196b1c39c4c9f70
+    dependencies:
+      - functions
+      - prelude
+      - unsafe-coerce
+  refs:
+    type: git
+    url: https://github.com/purescript/purescript-refs.git
+    rev: f8e6216da4cb9309fde1f20cd6f69ac3a3b7f9e8
+    dependencies:
+      - effect
+      - prelude
+  safe-coerce:
+    type: git
+    url: https://github.com/purescript/purescript-safe-coerce.git
+    rev: 7fa799ae80a38b8d948efcb52608e58e198b3da7
+    dependencies:
+      - unsafe-coerce
+  st:
+    type: git
+    url: https://github.com/purescript/purescript-st.git
+    rev: 2cc7ae1c3318a303378c4a9f3fa0f10ee7cc3589
+    dependencies:
+      - partial
+      - prelude
+      - tailrec
+      - unsafe-coerce
+  strings:
+    type: git
+    url: https://github.com/purescript/purescript-strings.git
+    rev: 4bc6954448d056f8aa7a659695a6ad60ad4fdf19
+    dependencies:
+      - arrays
+      - control
+      - either
+      - enums
+      - foldable-traversable
+      - gen
+      - integers
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  tailrec:
+    type: git
+    url: https://github.com/purescript/purescript-tailrec.git
+    rev: 5e2104aa734b31a17074cc805bf087d72b65afd1
+    dependencies:
+      - bifunctors
+      - effect
+      - either
+      - identity
+      - maybe
+      - partial
+      - prelude
+      - refs
+  transformers:
+    type: git
+    url: https://github.com/purescript/purescript-transformers.git
+    rev: be72ab52357d9a665cbf93d73ba1c07c4b0957ee
+    dependencies:
+      - control
+      - distributive
+      - effect
+      - either
+      - exceptions
+      - foldable-traversable
+      - identity
+      - lazy
+      - maybe
+      - newtype
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  tuples:
+    type: git
+    url: https://github.com/purescript/purescript-tuples.git
+    rev: 4f52da2729b448c8564369378f1232d8d2dc1d8b
+    dependencies:
+      - control
+      - invariant
+      - prelude
+  type-equality:
+    type: git
+    url: https://github.com/purescript/purescript-type-equality.git
+    rev: 0525b7d39e0fbd81b4209518139fb8ab02695774
+    dependencies: []
+  unfoldable:
+    type: git
+    url: https://github.com/purescript/purescript-unfoldable.git
+    rev: 493dfe04ed590e20d8f69079df2f58486882748d
+    dependencies:
+      - foldable-traversable
+      - maybe
+      - partial
+      - prelude
+      - tuples
+  unsafe-coerce:
+    type: git
+    url: https://github.com/purescript/purescript-unsafe-coerce.git
+    rev: ab956f82e66e633f647fb3098e8ddd3ec58d689f
+    dependencies: []

--- a/exercises/chapter13/spago.lock
+++ b/exercises/chapter13/spago.lock
@@ -58,3440 +58,440 @@ workspace:
         - unsafe-coerce
   package_set:
     address:
-      url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
-    compiler: ">=0.15.0 <0.16.0"
+      registry: 10.0.0
+    compiler: ">=0.15.4 <0.16.0"
     content:
-      ace:
-        repo: https://github.com/purescript-contrib/purescript-ace.git
-        version: v9.0.0
-        dependencies:
-          - arrays
-          - effect
-          - foreign
-          - nullable
-          - prelude
-          - web-html
-          - web-uievents
-      aff:
-        repo: https://github.com/purescript-contrib/purescript-aff.git
-        version: v7.0.0
-        dependencies:
-          - datetime
-          - effect
-          - exceptions
-          - functions
-          - parallel
-          - transformers
-          - unsafe-coerce
-      aff-bus:
-        repo: https://github.com/purescript-contrib/purescript-aff-bus.git
-        version: v6.0.0
-        dependencies:
-          - aff
-          - avar
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - lists
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-      aff-coroutines:
-        repo: https://github.com/purescript-contrib/purescript-aff-coroutines.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - avar
-          - coroutines
-          - effect
-      aff-promise:
-        repo: https://github.com/nwolverson/purescript-aff-promise.git
-        version: v4.0.0
-        dependencies:
-          - aff
-          - foreign
-      aff-retry:
-        repo: https://github.com/Unisay/purescript-aff-retry.git
-        version: v2.0.0
-        dependencies:
-          - aff
-          - arrays
-          - datetime
-          - effect
-          - either
-          - exceptions
-          - integers
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - random
-          - transformers
-      affjax:
-        repo: https://github.com/purescript-contrib/purescript-affjax.git
-        version: v13.0.0
-        dependencies:
-          - aff
-          - argonaut-core
-          - arraybuffer-types
-          - foreign
-          - form-urlencoded
-          - http-methods
-          - integers
-          - media-types
-          - nullable
-          - refs
-          - unsafe-coerce
-          - web-xhr
-      affjax-node:
-        repo: https://github.com/purescript-contrib/purescript-affjax-node.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - affjax
-          - either
-          - maybe
-          - prelude
-      affjax-web:
-        repo: https://github.com/purescript-contrib/purescript-affjax-web.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - affjax
-          - either
-          - maybe
-          - prelude
-      ansi:
-        repo: https://github.com/hdgarrood/purescript-ansi.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - lists
-          - strings
-      argonaut:
-        repo: https://github.com/purescript-contrib/purescript-argonaut.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - argonaut-traversals
-      argonaut-codecs:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-codecs.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-core
-          - arrays
-          - effect
-          - foreign-object
-          - identity
-          - integers
-          - maybe
-          - nonempty
-          - ordered-collections
-          - prelude
-          - record
-      argonaut-core:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-core.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - foreign-object
-          - functions
-          - gen
-          - maybe
-          - nonempty
-          - prelude
-          - strings
-          - tailrec
-      argonaut-generic:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-generic.git
-        version: v8.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - prelude
-          - record
-      argonaut-traversals:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-traversals.git
-        version: v10.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - profunctor-lenses
-      argparse-basic:
-        repo: https://github.com/natefaubion/purescript-argparse-basic.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - record
-          - strings
-          - tuples
-          - unfoldable
-      arraybuffer:
-        repo: https://github.com/purescript-contrib/purescript-arraybuffer.git
-        version: v13.0.0
-        dependencies:
-          - arraybuffer-types
-          - arrays
-          - effect
-          - float32
-          - functions
-          - gen
-          - maybe
-          - nullable
-          - prelude
-          - tailrec
-          - uint
-          - unfoldable
-      arraybuffer-builder:
-        repo: https://github.com/jamesdbrock/purescript-arraybuffer-builder.git
-        version: v3.0.1
-        dependencies:
-          - arraybuffer
-          - arraybuffer-types
-          - effect
-          - float32
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - transformers
-          - uint
-      arraybuffer-types:
-        repo: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
-        version: v3.0.2
-        dependencies: []
-      arrays:
-        repo: https://github.com/purescript/purescript-arrays.git
-        version: v7.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - foldable-traversable
-          - maybe
-          - nonempty
-          - partial
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - unfoldable
-          - unsafe-coerce
-      arrays-zipper:
-        repo: https://github.com/JordanMartinez/purescript-arrays-zipper.git
-        version: v2.0.1
-        dependencies:
-          - arrays
-          - control
-          - quickcheck
-      ask:
-        repo: https://github.com/Mateiadrielrafael/purescript-ask.git
-        version: v1.0.0
-        dependencies:
-          - unsafe-coerce
-      assert:
-        repo: https://github.com/purescript/purescript-assert.git
-        version: v6.0.0
-        dependencies:
-          - console
-          - effect
-          - prelude
-      avar:
-        repo: https://github.com/purescript-contrib/purescript-avar.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - exceptions
-          - functions
-          - maybe
-      b64:
-        repo: https://github.com/menelaos/purescript-b64.git
-        version: v0.0.8
-        dependencies:
-          - arraybuffer-types
-          - either
-          - encoding
-          - enums
-          - exceptions
-          - functions
-          - partial
-          - prelude
-          - strings
-      barlow-lens:
-        repo: https://github.com/sigma-andex/purescript-barlow-lens.git
-        version: v0.9.0
-        dependencies:
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - profunctor-lenses
-          - tuples
-          - typelevel-prelude
-      bifunctors:
-        repo: https://github.com/purescript/purescript-bifunctors.git
-        version: v6.0.0
-        dependencies:
-          - const
-          - either
-          - newtype
-          - prelude
-          - tuples
-      bigints:
-        repo: https://github.com/sharkdp/purescript-bigints.git
-        version: v7.0.1
-        dependencies:
-          - integers
-          - maybe
-          - strings
-      bower-json:
-        repo: https://github.com/klntsky/purescript-bower-json.git
-        version: v3.0.0
-        dependencies:
-          - argonaut-codecs
-          - arrays
-          - either
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - newtype
-          - prelude
-          - tuples
-      call-by-name:
-        repo: https://github.com/natefaubion/purescript-call-by-name.git
-        version: v4.0.1
-        dependencies:
-          - control
-          - either
-          - lazy
-          - maybe
-          - unsafe-coerce
-      canvas:
-        repo: https://github.com/purescript-web/purescript-canvas.git
-        version: v6.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - exceptions
-          - functions
-          - maybe
-      canvas-action:
-        repo: https://github.com/artemisSystem/purescript-canvas-action.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - arrays
-          - canvas
-          - colors
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - maybe
-          - numbers
-          - polymorphic-vectors
-          - prelude
-          - refs
-          - run
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-html
-      cartesian:
-        repo: https://github.com/Ebmtranceboy/purescript-cartesian.git
-        version: v1.0.6
-        dependencies:
-          - console
-          - effect
-          - integers
-          - psci-support
-      catenable-lists:
-        repo: https://github.com/purescript/purescript-catenable-lists.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - lists
-          - maybe
-          - prelude
-          - tuples
-          - unfoldable
-      channel:
-        repo: https://github.com/ConnorDillon/purescript-channel.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - assert
-          - avar
-          - console
-          - contravariant
-          - control
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - lazy
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      checked-exceptions:
-        repo: https://github.com/natefaubion/purescript-checked-exceptions.git
-        version: v3.1.1
-        dependencies:
-          - prelude
-          - transformers
-          - variant
-      codec:
-        repo: https://github.com/garyb/purescript-codec.git
-        version: v5.0.0
-        dependencies:
-          - profunctor
-          - transformers
-      codec-argonaut:
-        repo: https://github.com/garyb/purescript-codec-argonaut.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-core
-          - codec
-          - ordered-collections
-          - type-equality
-          - variant
-      colors:
-        repo: https://github.com/purescript-contrib/purescript-colors.git
-        version: v7.0.1
-        dependencies:
-          - arrays
-          - integers
-          - lists
-          - numbers
-          - partial
-          - strings
-      concurrent-queues:
-        repo: https://github.com/purescript-contrib/purescript-concurrent-queues.git
-        version: v3.0.0
-        dependencies:
-          - aff
-          - avar
-          - effect
-      console:
-        repo: https://github.com/purescript/purescript-console.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - prelude
-      const:
-        repo: https://github.com/purescript/purescript-const.git
-        version: v6.0.0
-        dependencies:
-          - invariant
-          - newtype
-          - prelude
-      contravariant:
-        repo: https://github.com/purescript/purescript-contravariant.git
-        version: v6.0.0
-        dependencies:
-          - const
-          - either
-          - newtype
-          - prelude
-          - tuples
-      control:
-        repo: https://github.com/purescript/purescript-control.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      convertable-options:
-        repo: https://github.com/natefaubion/purescript-convertable-options.git
-        version: v1.0.0
-        dependencies:
-          - console
-          - effect
-          - maybe
-          - record
-      coroutines:
-        repo: https://github.com/purescript-contrib/purescript-coroutines.git
-        version: v7.0.0
-        dependencies:
-          - freet
-          - parallel
-          - profunctor
-      css:
-        repo: https://github.com/purescript-contrib/purescript-css.git
-        version: v6.0.0
-        dependencies:
-          - colors
-          - console
-          - effect
-          - nonempty
-          - profunctor
-          - strings
-          - these
-          - transformers
-      datetime:
-        repo: https://github.com/purescript/purescript-datetime.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - either
-          - enums
-          - foldable-traversable
-          - functions
-          - gen
-          - integers
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - ordered-collections
-          - partial
-          - prelude
-          - tuples
-      datetime-parsing:
-        repo: https://github.com/flounders/purescript-datetime-parsing.git
-        version: v0.2.0
-        dependencies:
-          - arrays
-          - datetime
-          - either
-          - enums
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - numbers
-          - parsing
-          - prelude
-          - strings
-          - unicode
-      debug:
-        repo: https://github.com/garyb/purescript-debug.git
-        version: v6.0.0
-        dependencies:
-          - functions
-          - prelude
-      decimals:
-        repo: https://github.com/sharkdp/purescript-decimals.git
-        version: v7.0.0
-        dependencies:
-          - maybe
-      dissect:
-        repo: https://github.com/PureFunctor/purescript-dissect.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - foreign-object
-          - functors
-          - newtype
-          - partial
-          - prelude
-          - tailrec
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - variant
-      distributive:
-        repo: https://github.com/purescript/purescript-distributive.git
-        version: v6.0.0
-        dependencies:
-          - identity
-          - newtype
-          - prelude
-          - tuples
-          - type-equality
-      dodo-printer:
-        repo: https://github.com/natefaubion/purescript-dodo-printer.git
-        version: v2.2.0
-        dependencies:
-          - aff
-          - ansi
-          - avar
-          - console
-          - effect
-          - foldable-traversable
-          - lists
-          - maybe
-          - minibench
-          - node-child-process
-          - node-fs-aff
-          - node-process
-          - psci-support
-          - strings
-      dom-indexed:
-        repo: https://github.com/purescript-halogen/purescript-dom-indexed.git
-        version: v11.0.0
-        dependencies:
-          - media-types
-          - prelude
-          - web-clipboard
-          - web-pointerevents
-          - web-touchevents
-      droplet:
-        repo: https://github.com/easafe/purescript-droplet.git
-        version: v0.4.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - bigints
-          - datetime
-          - debug
-          - effect
-          - either
-          - enums
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - integers
-          - maybe
-          - newtype
-          - nullable
-          - ordered-collections
-          - partial
-          - prelude
-          - profunctor
-          - record
-          - spec
-          - strings
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-      dynamic-buffer:
-        repo: https://github.com/kritzcreek/purescript-dynamic-buffer.git
-        version: v3.0.1
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - refs
-      effect:
-        repo: https://github.com/purescript/purescript-effect.git
-        version: v4.0.0
-        dependencies:
-          - prelude
-      either:
-        repo: https://github.com/purescript/purescript-either.git
-        version: v6.1.0
-        dependencies:
-          - control
-          - invariant
-          - maybe
-          - prelude
-      elmish:
-        repo: https://github.com/collegevine/purescript-elmish.git
-        version: v0.8.1
-        dependencies:
-          - aff
-          - argonaut-core
-          - arrays
-          - bifunctors
-          - console
-          - debug
-          - effect
-          - either
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - functions
-          - integers
-          - js-date
-          - maybe
-          - nullable
-          - partial
-          - prelude
-          - refs
-          - typelevel-prelude
-          - undefined-is-not-a-problem
-          - unsafe-coerce
-          - web-dom
-          - web-html
-      elmish-enzyme:
-        repo: https://github.com/collegevine/purescript-elmish-enzyme.git
-        version: v0.1.1
-        dependencies:
-          - aff
-          - aff-promise
-          - arrays
-          - console
-          - debug
-          - effect
-          - elmish
-          - foldable-traversable
-          - foreign
-          - functions
-          - prelude
-          - transformers
-          - unsafe-coerce
-      elmish-hooks:
-        repo: https://github.com/collegevine/purescript-elmish-hooks.git
-        version: v0.8.2
-        dependencies:
-          - aff
-          - debug
-          - elmish
-          - maybe
-          - prelude
-          - tuples
-          - undefined-is-not-a-problem
-      elmish-html:
-        repo: https://github.com/collegevine/purescript-elmish-html.git
-        version: v0.7.1
-        dependencies:
-          - effect
-          - elmish
-          - foreign
-          - foreign-object
-          - prelude
-          - record
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-html
-      email-validate:
-        repo: https://github.com/cdepillabout/purescript-email-validate.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - string-parsers
-          - transformers
-      encoding:
-        repo: https://github.com/menelaos/purescript-encoding.git
-        version: v0.0.8
-        dependencies:
-          - arraybuffer-types
-          - either
-          - exceptions
-          - functions
-          - prelude
-      enums:
-        repo: https://github.com/purescript/purescript-enums.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - either
-          - gen
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tuples
-          - unfoldable
-      exceptions:
-        repo: https://github.com/purescript/purescript-exceptions.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - either
-          - maybe
-          - prelude
-      exists:
-        repo: https://github.com/purescript/purescript-exists.git
-        version: v6.0.0
-        dependencies:
-          - unsafe-coerce
-      exitcodes:
-        repo: https://github.com/Risto-Stevcev/purescript-exitcodes.git
-        version: v4.0.0
-        dependencies:
-          - enums
-      expect-inferred:
-        repo: https://github.com/justinwoo/purescript-expect-inferred.git
-        version: v3.0.0
-        dependencies:
-          - prelude
-          - typelevel-prelude
-      fast-vect:
-        repo: https://github.com/sigma-andex/purescript-fast-vect.git
-        version: v0.7.0
-        dependencies:
-          - arrays
-          - filterable
-          - foldable-traversable
-          - lists
-          - maybe
-          - ordered-collections
-          - prelude
-          - profunctor
-          - tuples
-          - unfoldable
-      filterable:
-        repo: https://github.com/purescript/purescript-filterable.git
-        version: v5.0.0
-        dependencies:
-          - arrays
-          - either
-          - foldable-traversable
-          - identity
-          - lists
-          - ordered-collections
-      fixed-points:
-        repo: https://github.com/purescript-contrib/purescript-fixed-points.git
-        version: v7.0.0
-        dependencies:
-          - exists
-          - newtype
-          - prelude
-          - transformers
-      fixed-precision:
-        repo: https://github.com/lumihq/purescript-fixed-precision.git
-        version: v5.0.0
-        dependencies:
-          - arrays
-          - bigints
-          - control
-          - integers
-          - maybe
-          - numbers
-          - partial
-          - prelude
-          - strings
-      flame:
-        repo: https://github.com/easafe/purescript-flame.git
-        version: v1.2.0
-        dependencies:
-          - aff
-          - argonaut-codecs
-          - argonaut-core
-          - argonaut-generic
-          - arrays
-          - bifunctors
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - maybe
-          - newtype
-          - nullable
-          - partial
-          - prelude
-          - random
-          - refs
-          - spec
-          - strings
-          - tuples
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-html
-          - web-uievents
-      float32:
-        repo: https://github.com/purescript-contrib/purescript-float32.git
-        version: v2.0.0
-        dependencies:
-          - gen
-          - maybe
-          - prelude
-      foldable-traversable:
-        repo: https://github.com/purescript/purescript-foldable-traversable.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - const
-          - control
-          - either
-          - functors
-          - identity
-          - maybe
-          - newtype
-          - orders
-          - prelude
-          - tuples
-      foreign:
-        repo: https://github.com/purescript/purescript-foreign.git
-        version: v7.0.0
-        dependencies:
-          - either
-          - functions
-          - identity
-          - integers
-          - lists
-          - maybe
-          - prelude
-          - strings
-          - transformers
-      foreign-object:
-        repo: https://github.com/purescript/purescript-foreign-object.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - functions
-          - gen
-          - lists
-          - maybe
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - typelevel-prelude
-          - unfoldable
-      foreign-readwrite:
-        repo: https://github.com/artemisSystem/purescript-foreign-readwrite.git
-        version: v3.0.0
-        dependencies:
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - record
-          - safe-coerce
-          - transformers
-          - unsafe-coerce
-      fork:
-        repo: https://github.com/purescript-contrib/purescript-fork.git
-        version: v6.0.0
-        dependencies:
-          - aff
-      form-urlencoded:
-        repo: https://github.com/purescript-contrib/purescript-form-urlencoded.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - js-uri
-          - maybe
-          - newtype
-          - prelude
-          - strings
-          - tuples
-      formatters:
-        repo: https://github.com/purescript-contrib/purescript-formatters.git
-        version: v7.0.0
-        dependencies:
-          - datetime
-          - fixed-points
-          - lists
-          - numbers
-          - parsing
-          - prelude
-          - transformers
-      free:
-        repo: https://github.com/purescript/purescript-free.git
-        version: v7.0.0
-        dependencies:
-          - catenable-lists
-          - control
-          - distributive
-          - either
-          - exists
-          - foldable-traversable
-          - invariant
-          - lazy
-          - maybe
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-      freeap:
-        repo: https://github.com/ethul/purescript-freeap.git
-        version: v7.0.0
-        dependencies:
-          - const
-          - exists
-          - gen
-          - lists
-      freet:
-        repo: https://github.com/purescript-contrib/purescript-freet.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - bifunctors
-          - effect
-          - either
-          - exists
-          - free
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      functions:
-        repo: https://github.com/purescript/purescript-functions.git
-        version: v6.0.0
-        dependencies:
-          - prelude
-      functors:
-        repo: https://github.com/purescript/purescript-functors.git
-        version: v5.0.0
-        dependencies:
-          - bifunctors
-          - const
-          - contravariant
-          - control
-          - distributive
-          - either
-          - invariant
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - tuples
-          - unsafe-coerce
-      fuzzy:
-        repo: https://github.com/citizennet/purescript-fuzzy.git
-        version: v0.4.0
-        dependencies:
-          - foldable-traversable
-          - foreign-object
-          - newtype
-          - ordered-collections
-          - prelude
-          - rationals
-          - strings
-          - tuples
-      gen:
-        repo: https://github.com/purescript/purescript-gen.git
-        version: v4.0.0
-        dependencies:
-          - either
-          - foldable-traversable
-          - identity
-          - maybe
-          - newtype
-          - nonempty
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      generate-values:
-        repo: https://github.com/jordanmartinez/purescript-generate-values.git
-        version: v1.0.1
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - enums
-          - foldable-traversable
-          - gen
-          - identity
-          - integers
-          - lcg
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - partial
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      geometry-plane:
-        repo: https://github.com/Ebmtranceboy/purescript-geometry-plane.git
-        version: v1.0.3
-        dependencies:
-          - console
-          - effect
-          - psci-support
-          - sparse-polynomials
-      github-actions-toolkit:
-        repo: https://github.com/purescript-contrib/purescript-github-actions-toolkit.git
-        version: v0.5.0
-        dependencies:
-          - aff
-          - aff-promise
-          - effect
-          - foreign-object
-          - node-buffer
-          - node-path
-          - node-streams
-          - nullable
-          - transformers
-      graphs:
-        repo: https://github.com/purescript/purescript-graphs.git
-        version: v8.0.0
-        dependencies:
-          - catenable-lists
-          - ordered-collections
-      group:
-        repo: https://github.com/morganthomas/purescript-group.git
-        version: v4.1.1
-        dependencies:
-          - lists
-      halogen:
-        repo: https://github.com/purescript-halogen/purescript-halogen.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - avar
-          - console
-          - const
-          - dom-indexed
-          - effect
-          - foreign
-          - fork
-          - free
-          - freeap
-          - halogen-subscriptions
-          - halogen-vdom
-          - media-types
-          - nullable
-          - ordered-collections
-          - parallel
-          - profunctor
-          - transformers
-          - unsafe-coerce
-          - unsafe-reference
-          - web-file
-          - web-uievents
-      halogen-css:
-        repo: https://github.com/purescript-halogen/purescript-halogen-css.git
-        version: v10.0.0
-        dependencies:
-          - css
-          - halogen
-      halogen-formless:
-        repo: https://github.com/thomashoneyman/purescript-halogen-formless.git
-        version: v4.0.0
-        dependencies:
-          - convertable-options
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - halogen
-          - heterogeneous
-          - maybe
-          - prelude
-          - record
-          - safe-coerce
-          - type-equality
-          - unsafe-coerce
-          - unsafe-reference
-          - variant
-          - web-events
-          - web-uievents
-      halogen-hooks:
-        repo: https://github.com/thomashoneyman/purescript-halogen-hooks.git
-        version: v0.6.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - effect
-          - exceptions
-          - foldable-traversable
-          - foreign-object
-          - free
-          - freeap
-          - halogen
-          - halogen-subscriptions
-          - maybe
-          - newtype
-          - ordered-collections
-          - parallel
-          - partial
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-          - unsafe-reference
-          - web-dom
-          - web-html
-      halogen-hooks-extra:
-        repo: https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git
-        version: v0.9.0
-        dependencies:
-          - halogen-hooks
-      halogen-store:
-        repo: https://github.com/thomashoneyman/purescript-halogen-store.git
-        version: v0.5.0
-        dependencies:
-          - aff
-          - distributive
-          - effect
-          - fork
-          - halogen
-          - halogen-hooks
-          - halogen-subscriptions
-          - maybe
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-reference
-      halogen-storybook:
-        repo: https://github.com/rnons/purescript-halogen-storybook.git
-        version: v2.0.0
-        dependencies:
-          - foreign-object
-          - halogen
-          - prelude
-          - routing
-      halogen-subscriptions:
-        repo: https://github.com/purescript-halogen/purescript-halogen-subscriptions.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - effect
-          - foldable-traversable
-          - functors
-          - refs
-          - safe-coerce
-          - unsafe-reference
-      halogen-svg-elems:
-        repo: https://github.com/JordanMartinez/purescript-halogen-svg-elems.git
-        version: v6.0.0
-        dependencies:
-          - halogen
-      halogen-vdom:
-        repo: https://github.com/purescript-halogen/purescript-halogen-vdom.git
-        version: v8.0.0
-        dependencies:
-          - bifunctors
-          - effect
-          - foreign
-          - foreign-object
-          - maybe
-          - prelude
-          - refs
-          - tuples
-          - unsafe-coerce
-          - web-html
-      halogen-vdom-string-renderer:
-        repo: https://github.com/purescript-halogen/purescript-halogen-vdom-string-renderer.git
-        version: v0.5.0
-        dependencies:
-          - foreign
-          - halogen-vdom
-          - ordered-collections
-          - prelude
-      heckin:
-        repo: https://github.com/maxdeviant/purescript-heckin.git
-        version: v2.0.1
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - maybe
-          - prelude
-          - strings
-          - transformers
-          - tuples
-          - unicode
-      heterogeneous:
-        repo: https://github.com/natefaubion/purescript-heterogeneous.git
-        version: v0.6.0
-        dependencies:
-          - either
-          - functors
-          - prelude
-          - record
-          - tuples
-          - variant
-      heterogeneous-extrablatt:
-        repo: https://github.com/sigma-andex/purescript-heterogeneous-extrablatt.git
-        version: v0.2.1
-        dependencies:
-          - heterogeneous
-          - prelude
-          - record
-      http-methods:
-        repo: https://github.com/purescript-contrib/purescript-http-methods.git
-        version: v6.0.0
-        dependencies:
-          - either
-          - prelude
-          - strings
-      httpure:
-        repo: https://github.com/citizennet/purescript-httpure.git
-        version: v0.15.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - js-uri
-          - maybe
-          - newtype
-          - node-buffer
-          - node-fs
-          - node-http
-          - node-streams
-          - options
-          - ordered-collections
-          - prelude
-          - refs
-          - strings
-          - tuples
-          - type-equality
-      httpurple:
-        repo: https://github.com/sigma-andex/purescript-httpurple.git
-        version: v1.3.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - js-uri
-          - justifill
-          - maybe
-          - newtype
-          - node-buffer
-          - node-fs
-          - node-http
-          - node-net
-          - node-process
-          - node-streams
-          - options
-          - ordered-collections
-          - posix-types
-          - prelude
-          - profunctor
-          - record
-          - refs
-          - routing-duplex
-          - strings
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-      httpurple-argonaut:
-        repo: https://github.com/sigma-andex/purescript-httpurple-argonaut.git
-        version: v1.0.1
-        dependencies:
-          - argonaut
-          - console
-          - effect
-          - either
-          - httpurple
-          - prelude
-      httpurple-yoga-json:
-        repo: https://github.com/sigma-andex/purescript-httpurple-yoga-json.git
-        version: v1.0.0
-        dependencies:
-          - console
-          - effect
-          - either
-          - foreign
-          - httpurple
-          - lists
-          - prelude
-          - yoga-json
-      identity:
-        repo: https://github.com/purescript/purescript-identity.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - invariant
-          - newtype
-          - prelude
-      indexed-monad:
-        repo: https://github.com/garyb/purescript-indexed-monad.git
-        version: v2.1.0
-        dependencies:
-          - control
-          - newtype
-      int64:
-        repo: https://github.com/purescript-contrib/purescript-int64.git
-        version: v2.0.0
-        dependencies:
-          - effect
-          - foreign
-          - functions
-          - integers
-          - maybe
-          - nullable
-          - prelude
-          - quickcheck
-      integers:
-        repo: https://github.com/purescript/purescript-integers.git
-        version: v6.0.0
-        dependencies:
-          - maybe
-          - numbers
-          - prelude
-      interpolate:
-        repo: https://github.com/jordanmartinez/purescript-interpolate.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-      invariant:
-        repo: https://github.com/purescript/purescript-invariant.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - prelude
-      js-date:
-        repo: https://github.com/purescript-contrib/purescript-js-date.git
-        version: v8.0.0
-        dependencies:
-          - datetime
-          - effect
-          - exceptions
-          - foreign
-          - integers
-          - now
-      js-fileio:
-        repo: https://github.com/newlandsvalley/purescript-js-fileio.git
-        version: v3.0.0
-        dependencies:
-          - aff
-          - effect
-          - prelude
-      js-timers:
-        repo: https://github.com/purescript-contrib/purescript-js-timers.git
-        version: v6.1.0
-        dependencies:
-          - effect
-      js-uri:
-        repo: https://github.com/purescript-contrib/purescript-js-uri.git
-        version: v3.0.0
-        dependencies:
-          - functions
-          - maybe
-      justifill:
-        repo: https://github.com/i-am-the-slime/purescript-justifill.git
-        version: v0.5.0
-        dependencies:
-          - maybe
-          - prelude
-          - record
-          - typelevel-prelude
-      jwt:
-        repo: https://github.com/menelaos/purescript-jwt.git
-        version: v0.0.9
-        dependencies:
-          - argonaut-core
-          - arrays
-          - b64
-          - either
-          - exceptions
-          - prelude
-          - profunctor-lenses
-          - strings
-      language-cst-parser:
-        repo: https://github.com/natefaubion/purescript-language-cst-parser.git
-        version: v0.12.0
-        dependencies:
-          - arrays
-          - const
-          - control
-          - either
-          - foldable-traversable
-          - free
-          - functions
-          - functors
-          - identity
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - ordered-collections
-          - partial
-          - prelude
-          - st
-          - strings
-          - transformers
-          - tuples
-          - typelevel-prelude
-          - unfoldable
-          - unsafe-coerce
-      lazy:
-        repo: https://github.com/purescript/purescript-lazy.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - invariant
-          - prelude
-      lcg:
-        repo: https://github.com/purescript/purescript-lcg.git
-        version: v4.0.0
-        dependencies:
-          - effect
-          - integers
-          - maybe
-          - partial
-          - prelude
-          - random
-      leibniz:
-        repo: https://github.com/paf31/purescript-leibniz.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-          - unsafe-coerce
-      linalg:
-        repo: https://github.com/gbagan/purescript-linalg.git
-        version: v5.1.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - functions
-          - maybe
-          - prelude
-          - tuples
-      lists:
-        repo: https://github.com/purescript/purescript-lists.git
-        version: v7.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - foldable-traversable
-          - lazy
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      logging:
-        repo: https://github.com/rightfold/purescript-logging.git
-        version: v3.0.0
-        dependencies:
-          - console
-          - contravariant
-          - effect
-          - either
-          - prelude
-          - transformers
-          - tuples
-      machines:
-        repo: https://github.com/purescript-contrib/purescript-machines.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - lists
-          - maybe
-          - prelude
-          - profunctor
-          - tuples
-          - unfoldable
-      matrices:
-        repo: https://github.com/kRITZCREEK/purescript-matrices.git
-        version: v5.0.1
-        dependencies:
-          - arrays
-          - strings
-      matryoshka:
-        repo: https://github.com/purescript-contrib/purescript-matryoshka.git
-        version: v1.0.0
-        dependencies:
-          - fixed-points
-          - free
-          - prelude
-          - profunctor
-          - transformers
-      maybe:
-        repo: https://github.com/purescript/purescript-maybe.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - invariant
-          - newtype
-          - prelude
-      media-types:
-        repo: https://github.com/purescript-contrib/purescript-media-types.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      metadata:
-        repo: https://github.com/purescript/purescript-metadata.git
-        version: v0.15.0
-        dependencies: []
-      midi:
-        repo: https://github.com/newlandsvalley/purescript-midi.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - ordered-collections
-          - prelude
-          - signal
-          - string-parsers
-          - strings
-          - tuples
-          - unfoldable
-      minibench:
-        repo: https://github.com/purescript/purescript-minibench.git
-        version: v4.0.0
-        dependencies:
-          - console
-          - effect
-          - integers
-          - numbers
-          - partial
-          - prelude
-          - refs
-      mmorph:
-        repo: https://github.com/Thimoteus/purescript-mmorph.git
-        version: v7.0.0
-        dependencies:
-          - free
-          - functors
-          - transformers
-      monad-control:
-        repo: https://github.com/athanclark/purescript-monad-control.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - freet
-          - identity
-          - lists
-      monad-logger:
-        repo: https://github.com/cprussin/purescript-monad-logger.git
-        version: v1.3.1
-        dependencies:
-          - aff
-          - ansi
-          - argonaut
-          - arrays
-          - console
-          - control
-          - effect
-          - foldable-traversable
-          - foreign-object
-          - integers
-          - js-date
-          - maybe
-          - newtype
-          - ordered-collections
-          - prelude
-          - strings
-          - transformers
-          - tuples
-      monad-loops:
-        repo: https://github.com/mlang/purescript-monad-loops.git
-        version: v0.5.0
-        dependencies:
-          - lists
-          - maybe
-          - prelude
-          - tailrec
-          - tuples
-      monad-unlift:
-        repo: https://github.com/athanclark/purescript-monad-unlift.git
-        version: v1.0.1
-        dependencies:
-          - monad-control
-      monoidal:
-        repo: https://github.com/mcneissue/purescript-monoidal.git
-        version: v0.16.0
-        dependencies:
-          - either
-          - profunctor
-          - these
-          - tuples
-      morello:
-        repo: https://github.com/sigma-andex/purescript-morello.git
-        version: v0.3.2
-        dependencies:
-          - arrays
-          - barlow-lens
-          - foldable-traversable
-          - heterogeneous
-          - heterogeneous-extrablatt
-          - newtype
-          - prelude
-          - profunctor
-          - profunctor-lenses
-          - record
-          - tuples
-          - typelevel-prelude
-          - validation
-      motsunabe:
-        repo: https://github.com/justinwoo/purescript-motsunabe.git
-        version: v2.0.0
-        dependencies:
-          - lists
-          - strings
-      nano-id:
-        repo: https://github.com/eikooc/nano-id.git
-        version: v1.1.0
-        dependencies:
-          - aff
-          - effect
-          - lists
-          - maybe
-          - prelude
-          - random
-          - spec
-          - strings
-          - stringutils
-      naturals:
-        repo: https://github.com/LiamGoodacre/purescript-naturals.git
-        version: v3.0.0
-        dependencies:
-          - enums
-          - maybe
-          - prelude
-      nested-functor:
-        repo: https://github.com/acple/purescript-nested-functor.git
-        version: v0.2.1
-        dependencies:
-          - prelude
-          - type-equality
-      newtype:
-        repo: https://github.com/purescript/purescript-newtype.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-          - safe-coerce
-      node-buffer:
-        repo: https://github.com/purescript-node/purescript-node-buffer.git
-        version: v8.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - maybe
-          - st
-          - unsafe-coerce
-      node-buffer-blob:
-        repo: https://github.com/purescript-node/purescript-node-buffer-blob.git
-        version: v1.0.0
-        dependencies:
-          - aff-promise
-          - arraybuffer-types
-          - arrays
-          - console
-          - effect
-          - maybe
-          - media-types
-          - newtype
-          - node-buffer
-          - nullable
-          - prelude
-          - web-streams
-      node-child-process:
-        repo: https://github.com/purescript-node/purescript-node-child-process.git
-        version: v9.0.0
-        dependencies:
-          - exceptions
-          - foreign
-          - foreign-object
-          - functions
-          - node-fs
-          - node-streams
-          - nullable
-          - posix-types
-          - unsafe-coerce
-      node-fs:
-        repo: https://github.com/purescript-node/purescript-node-fs.git
-        version: v8.0.0
-        dependencies:
-          - datetime
-          - effect
-          - either
-          - enums
-          - exceptions
-          - functions
-          - integers
-          - js-date
-          - maybe
-          - node-buffer
-          - node-path
-          - node-streams
-          - nullable
-          - partial
-          - prelude
-          - strings
-          - unsafe-coerce
-      node-fs-aff:
-        repo: https://github.com/purescript-node/purescript-node-fs-aff.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - either
-          - node-fs
-          - node-path
-      node-http:
-        repo: https://github.com/purescript-node/purescript-node-http.git
-        version: v8.0.0
-        dependencies:
-          - arraybuffer-types
-          - contravariant
-          - effect
-          - foreign
-          - foreign-object
-          - maybe
-          - node-buffer
-          - node-net
-          - node-streams
-          - node-url
-          - nullable
-          - options
-          - prelude
-          - unsafe-coerce
-      node-net:
-        repo: https://github.com/purescript-node/purescript-node-net.git
-        version: v4.0.0
-        dependencies:
-          - effect
-          - either
-          - exceptions
-          - foreign
-          - maybe
-          - node-buffer
-          - node-fs
-          - nullable
-          - options
-          - prelude
-          - transformers
-      node-path:
-        repo: https://github.com/purescript-node/purescript-node-path.git
-        version: v5.0.0
-        dependencies:
-          - effect
-      node-process:
-        repo: https://github.com/purescript-node/purescript-node-process.git
-        version: v10.0.0
-        dependencies:
-          - effect
-          - foreign-object
-          - maybe
-          - node-streams
-          - posix-types
-          - prelude
-          - unsafe-coerce
-      node-readline:
-        repo: https://github.com/purescript-node/purescript-node-readline.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - foreign
-          - node-process
-          - node-streams
-          - options
-          - prelude
-      node-streams:
-        repo: https://github.com/purescript-node/purescript-node-streams.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - either
-          - exceptions
-          - node-buffer
-          - nullable
-          - prelude
-      node-streams-aff:
-        repo: https://github.com/jamesdbrock/purescript-node-streams-aff.git
-        version: v2.0.0
-        dependencies:
-          - aff
-          - arrays
-          - effect
-          - either
-          - exceptions
-          - maybe
-          - node-buffer
-          - node-streams
-          - prelude
-          - st
-          - tuples
-      node-url:
-        repo: https://github.com/purescript-node/purescript-node-url.git
-        version: v6.0.0
-        dependencies:
-          - nullable
-      nonempty:
-        repo: https://github.com/purescript/purescript-nonempty.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - maybe
-          - prelude
-          - tuples
-          - unfoldable
-      now:
-        repo: https://github.com/purescript-contrib/purescript-now.git
-        version: v6.0.0
-        dependencies:
-          - datetime
-          - effect
-      npm-package-json:
-        repo: https://github.com/maxdeviant/purescript-npm-package-json.git
-        version: v2.0.0
-        dependencies:
-          - argonaut
-          - control
-          - either
-          - foreign-object
-          - maybe
-          - ordered-collections
-          - prelude
-      nullable:
-        repo: https://github.com/purescript-contrib/purescript-nullable.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - functions
-          - maybe
-      numbers:
-        repo: https://github.com/purescript/purescript-numbers.git
-        version: v9.0.0
-        dependencies:
-          - functions
-          - maybe
-      open-folds:
-        repo: https://github.com/purescript-open-community/purescript-open-folds.git
-        version: v6.3.0
-        dependencies:
-          - bifunctors
-          - console
-          - control
-          - distributive
-          - effect
-          - either
-          - foldable-traversable
-          - identity
-          - invariant
-          - maybe
-          - newtype
-          - ordered-collections
-          - prelude
-          - profunctor
-          - psci-support
-          - tuples
-      open-memoize:
-        repo: https://github.com/purescript-open-community/purescript-open-memoize.git
-        version: v6.1.0
-        dependencies:
-          - console
-          - effect
-          - either
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - psci-support
-          - strings
-          - tuples
-      open-pairing:
-        repo: https://github.com/purescript-open-community/purescript-open-pairing.git
-        version: v6.1.0
-        dependencies:
-          - console
-          - control
-          - effect
-          - either
-          - free
-          - functors
-          - identity
-          - newtype
-          - prelude
-          - psci-support
-          - transformers
-          - tuples
-      options:
-        repo: https://github.com/purescript-contrib/purescript-options.git
-        version: v7.0.0
-        dependencies:
-          - contravariant
-          - foreign
-          - foreign-object
-          - maybe
-          - tuples
-      optparse:
-        repo: https://github.com/f-o-a-m/purescript-optparse.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - control
-          - effect
-          - either
-          - enums
-          - exists
-          - exitcodes
-          - foldable-traversable
-          - free
-          - gen
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - newtype
-          - node-buffer
-          - node-process
-          - node-streams
-          - nonempty
-          - numbers
-          - open-memoize
-          - partial
-          - prelude
-          - quickcheck
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-      ordered-collections:
-        repo: https://github.com/purescript/purescript-ordered-collections.git
-        version: v3.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - gen
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - unfoldable
-      ordered-set:
-        repo: https://github.com/flip111/purescript-ordered-set.git
-        version: v0.4.0
-        dependencies:
-          - argonaut-codecs
-          - arrays
-          - partial
-          - prelude
-          - unfoldable
-      orders:
-        repo: https://github.com/purescript/purescript-orders.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      pairs:
-        repo: https://github.com/sharkdp/purescript-pairs.git
-        version: v9.0.0
-        dependencies:
-          - console
-          - distributive
-          - foldable-traversable
-          - quickcheck
-      parallel:
-        repo: https://github.com/purescript/purescript-parallel.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - functors
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - refs
-          - transformers
-      parsing:
-        repo: https://github.com/purescript-contrib/purescript-parsing.git
-        version: v9.1.0
-        dependencies:
-          - arrays
-          - either
-          - foldable-traversable
-          - identity
-          - integers
-          - lists
-          - maybe
-          - nullable
-          - prelude
-          - strings
-          - transformers
-          - unicode
-      parsing-dataview:
-        repo: https://github.com/jamesdbrock/purescript-parsing-dataview.git
-        version: v3.1.0
-        dependencies:
-          - arraybuffer
-          - arraybuffer-types
-          - effect
-          - float32
-          - maybe
-          - parsing
-          - prelude
-          - transformers
-          - tuples
-          - uint
-      partial:
-        repo: https://github.com/purescript/purescript-partial.git
-        version: v4.0.0
-        dependencies: []
-      pathy:
-        repo: https://github.com/purescript-contrib/purescript-pathy.git
-        version: v9.0.0
-        dependencies:
-          - console
-          - exceptions
-          - lists
-          - partial
-          - profunctor
-          - strings
-          - transformers
-          - typelevel-prelude
-          - unsafe-coerce
-      pha:
-        repo: https://github.com/gbagan/purescript-pha.git
-        version: v0.9.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - datetime
-          - effect
-          - foldable-traversable
-          - free
-          - integers
-          - maybe
-          - prelude
-          - profunctor-lenses
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-          - unsafe-reference
-          - web-dom
-          - web-events
-          - web-html
-          - web-pointerevents
-          - web-uievents
-      phaser:
-        repo: https://github.com/lfarroco/purescript-phaser.git
-        version: v0.6.0
-        dependencies:
-          - canvas
-          - console
-          - effect
-          - maybe
-          - nullable
-          - options
-          - prelude
-          - web-html
-      pipes:
-        repo: https://github.com/felixschl/purescript-pipes.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - lists
-          - mmorph
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      point-free:
-        repo: https://github.com/ursi/purescript-point-free.git
-        version: v1.0.0
-        dependencies:
-          - prelude
-      polymorphic-vectors:
-        repo: https://github.com/artemisSystem/purescript-polymorphic-vectors.git
-        version: v4.0.0
-        dependencies:
-          - distributive
-          - foldable-traversable
-          - numbers
-          - prelude
-          - record
-          - safe-coerce
-          - type-equality
-          - typelevel-prelude
-      posix-types:
-        repo: https://github.com/purescript-node/purescript-posix-types.git
-        version: v6.0.0
-        dependencies:
-          - maybe
-          - prelude
-      precise:
-        repo: https://github.com/purescript-contrib/purescript-precise.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - exceptions
-          - gen
-          - integers
-          - lists
-          - numbers
-          - prelude
-          - strings
-      precise-datetime:
-        repo: https://github.com/awakesecurity/purescript-precise-datetime.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - datetime
-          - decimals
-          - either
-          - enums
-          - foldable-traversable
-          - formatters
-          - integers
-          - js-date
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - strings
-          - tuples
-          - unicode
-      prelude:
-        repo: https://github.com/purescript/purescript-prelude.git
-        version: v6.0.0
-        dependencies: []
-      prettier-printer:
-        repo: https://github.com/paulyoung/purescript-prettier-printer.git
-        version: v3.0.0
-        dependencies:
-          - console
-          - lists
-          - prelude
-          - strings
-          - tuples
-      profunctor:
-        repo: https://github.com/purescript/purescript-profunctor.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - distributive
-          - either
-          - exists
-          - invariant
-          - newtype
-          - prelude
-          - tuples
-      profunctor-lenses:
-        repo: https://github.com/purescript-contrib/purescript-profunctor-lenses.git
-        version: v8.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - const
-          - control
-          - distributive
-          - either
-          - foldable-traversable
-          - foreign-object
-          - functors
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - ordered-collections
-          - partial
-          - prelude
-          - profunctor
-          - record
-          - transformers
-          - tuples
-      protobuf:
-        repo: https://github.com/xc-jp/purescript-protobuf.git
-        version: v4.0.0
-        dependencies:
-          - arraybuffer
-          - arraybuffer-builder
-          - arraybuffer-types
-          - arrays
-          - control
-          - effect
-          - either
-          - enums
-          - exceptions
-          - float32
-          - foldable-traversable
-          - functions
-          - int64
-          - maybe
-          - newtype
-          - parsing
-          - parsing-dataview
-          - prelude
-          - record
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-          - uint
-          - web-encoding
-      ps-cst:
-        repo: https://github.com/purescript-codegen/purescript-ps-cst.git
-        version: v1.2.0
-        dependencies:
-          - ansi
-          - console
-          - dodo-printer
-          - effect
-          - node-fs-aff
-          - node-path
-          - psci-support
-          - record
-          - strings
-      psa-utils:
-        repo: https://github.com/natefaubion/purescript-psa-utils.git
-        version: v8.0.0
-        dependencies:
-          - ansi
-          - argonaut-codecs
-          - argonaut-core
-          - arrays
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - maybe
-          - node-path
-          - ordered-collections
-          - prelude
-          - strings
-          - tuples
-          - unsafe-coerce
-      psc-ide:
-        repo: https://github.com/kRITZCREEK/purescript-psc-ide.git
-        version: v19.0.0
-        dependencies:
-          - aff
-          - argonaut
-          - arrays
-          - console
-          - maybe
-          - node-child-process
-          - node-fs
-          - parallel
-          - random
-      psci-support:
-        repo: https://github.com/purescript/purescript-psci-support.git
-        version: v6.0.0
-        dependencies:
-          - console
-          - effect
-          - prelude
-      qualified-do:
-        repo: https://github.com/artemisSystem/purescript-qualified-do.git
-        version: v2.2.0
-        dependencies:
-          - arrays
-          - control
-          - foldable-traversable
-          - parallel
-          - prelude
-          - unfoldable
-      quantities:
-        repo: https://github.com/sharkdp/purescript-quantities.git
-        version: v12.0.1
-        dependencies:
-          - decimals
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - newtype
-          - nonempty
-          - numbers
-          - pairs
-          - prelude
-          - tuples
-      quickcheck:
-        repo: https://github.com/purescript/purescript-quickcheck.git
-        version: v8.0.1
-        dependencies:
-          - arrays
-          - console
-          - control
-          - effect
-          - either
-          - enums
-          - exceptions
-          - foldable-traversable
-          - gen
-          - identity
-          - integers
-          - lazy
-          - lcg
-          - lists
-          - maybe
-          - newtype
-          - nonempty
-          - numbers
-          - partial
-          - prelude
-          - record
-          - st
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-          - unfoldable
-      quickcheck-combinators:
-        repo: https://github.com/athanclark/purescript-quickcheck-combinators.git
-        version: v0.1.3
-        dependencies:
-          - quickcheck
-          - typelevel
-      quickcheck-laws:
-        repo: https://github.com/purescript-contrib/purescript-quickcheck-laws.git
-        version: v7.0.0
-        dependencies:
-          - enums
-          - quickcheck
-      quickcheck-utf8:
-        repo: https://github.com/openchronology/purescript-quickcheck-utf8.git
-        version: v0.0.0
-        dependencies:
-          - quickcheck
-      quotient:
-        repo: https://github.com/rightfold/purescript-quotient.git
-        version: v3.0.0
-        dependencies:
-          - prelude
-          - quickcheck
-      random:
-        repo: https://github.com/purescript/purescript-random.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - integers
-      rationals:
-        repo: https://github.com/anttih/purescript-rationals.git
-        version: v5.0.0
-        dependencies:
-          - integers
-          - prelude
-      react:
-        repo: https://github.com/purescript-contrib/purescript-react.git
-        version: v10.0.1
-        dependencies:
-          - effect
-          - exceptions
-          - maybe
-          - nullable
-          - prelude
-          - typelevel-prelude
-          - unsafe-coerce
-      react-basic:
-        repo: https://github.com/lumihq/purescript-react-basic.git
-        version: v17.0.0
-        dependencies:
-          - effect
-          - prelude
-          - record
-      react-basic-dom:
-        repo: https://github.com/lumihq/purescript-react-basic-dom.git
-        version: v5.0.0
-        dependencies:
-          - effect
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - nullable
-          - prelude
-          - react-basic
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-file
-          - web-html
-      react-basic-hooks:
-        repo: https://github.com/megamaddu/purescript-react-basic-hooks.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - aff-promise
-          - bifunctors
-          - console
-          - control
-          - datetime
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - functions
-          - indexed-monad
-          - integers
-          - maybe
-          - newtype
-          - now
-          - nullable
-          - ordered-collections
-          - prelude
-          - react-basic
-          - refs
-          - tuples
-          - type-equality
-          - unsafe-coerce
-          - unsafe-reference
-          - web-html
-      react-dom:
-        repo: https://github.com/purescript-contrib/purescript-react-dom.git
-        version: v8.0.0
-        dependencies:
-          - effect
-          - react
-          - web-dom
-      read:
-        repo: https://github.com/truqu/purescript-read.git
-        version: v1.0.1
-        dependencies:
-          - maybe
-          - prelude
-          - strings
-      record:
-        repo: https://github.com/purescript/purescript-record.git
-        version: v4.0.0
-        dependencies:
-          - functions
-          - prelude
-          - unsafe-coerce
-      refined:
-        repo: https://github.com/danieljharvey/purescript-refined.git
-        version: v1.0.0
-        dependencies:
-          - argonaut
-          - effect
-          - prelude
-          - quickcheck
-          - typelevel
-      refs:
-        repo: https://github.com/purescript/purescript-refs.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - prelude
-      remotedata:
-        repo: https://github.com/krisajenkins/purescript-remotedata.git
-        version: v5.0.0
-        dependencies:
-          - bifunctors
-          - either
-          - profunctor-lenses
-      resource:
-        repo: https://github.com/joneshf/purescript-resource.git
-        version: v2.0.1
-        dependencies:
-          - aff
-          - console
-          - control
-          - effect
-          - newtype
-          - prelude
-          - psci-support
-          - refs
-      resourcet:
-        repo: https://github.com/robertdp/purescript-resourcet.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - effect
-          - foldable-traversable
-          - maybe
-          - ordered-collections
-          - parallel
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-      result:
-        repo: https://github.com/ad-si/purescript-result.git
-        version: v1.0.3
-        dependencies:
-          - either
-          - foldable-traversable
-          - prelude
-      return:
-        repo: https://github.com/ursi/purescript-return.git
-        version: v0.2.0
-        dependencies:
-          - foldable-traversable
-          - point-free
-          - prelude
-      ring-modules:
-        repo: https://github.com/f-o-a-m/purescript-ring-modules.git
-        version: v5.0.1
-        dependencies:
-          - prelude
-      routing:
-        repo: https://github.com/purescript-contrib/purescript-routing.git
-        version: v11.0.0
-        dependencies:
-          - aff
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - integers
-          - js-uri
-          - lists
-          - maybe
-          - numbers
-          - partial
-          - prelude
-          - semirings
-          - tuples
-          - validation
-          - web-html
-      routing-duplex:
-        repo: https://github.com/natefaubion/purescript-routing-duplex.git
-        version: v0.6.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - js-uri
-          - lazy
-          - numbers
-          - prelude
-          - profunctor
-          - record
-          - strings
-          - typelevel-prelude
-      run:
-        repo: https://github.com/natefaubion/purescript-run.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - free
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - tailrec
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - variant
-      safe-coerce:
-        repo: https://github.com/purescript/purescript-safe-coerce.git
-        version: v2.0.0
-        dependencies:
-          - unsafe-coerce
-      safely:
-        repo: https://github.com/paf31/purescript-safely.git
-        version: v4.0.1
-        dependencies:
-          - freet
-          - lists
-      selection-foldable:
-        repo: https://github.com/jamieyung/purescript-selection-foldable.git
-        version: v0.2.0
-        dependencies:
-          - filterable
-          - foldable-traversable
-          - maybe
-          - prelude
-      semirings:
-        repo: https://github.com/purescript/purescript-semirings.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - lists
-          - newtype
-          - prelude
-      signal:
-        repo: https://github.com/bodil/purescript-signal.git
-        version: v13.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - foldable-traversable
-          - maybe
-          - prelude
-      simple-emitter:
-        repo: https://github.com/oreshinya/purescript-simple-emitter.git
-        version: v2.0.0
-        dependencies:
-          - ordered-collections
-          - refs
-      sized-matrices:
-        repo: https://github.com/csicar/purescript-sized-matrices.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - distributive
-          - foldable-traversable
-          - maybe
-          - prelude
-          - sized-vectors
-          - strings
-          - typelevel
-          - unfoldable
-          - vectorfield
-      sized-vectors:
-        repo: https://github.com/bodil/purescript-sized-vectors.git
-        version: v5.0.2
-        dependencies:
-          - argonaut
-          - arrays
-          - distributive
-          - foldable-traversable
-          - maybe
-          - prelude
-          - quickcheck
-          - typelevel
-          - unfoldable
-      slug:
-        repo: https://github.com/thomashoneyman/purescript-slug.git
-        version: v3.0.1
-        dependencies:
-          - argonaut-codecs
-          - maybe
-          - prelude
-          - strings
-          - unicode
-      soundfonts:
-        repo: https://github.com/newlandsvalley/purescript-soundfonts.git
-        version: v4.1.0
-        dependencies:
-          - aff
-          - affjax
-          - affjax-web
-          - argonaut-core
-          - arraybuffer-types
-          - arrays
-          - b64
-          - bifunctors
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign-object
-          - http-methods
-          - integers
-          - lists
-          - maybe
-          - midi
-          - ordered-collections
-          - parallel
-          - partial
-          - prelude
-          - strings
-          - transformers
-          - tuples
-      sparse-matrices:
-        repo: https://github.com/Ebmtranceboy/purescript-sparse-matrices.git
-        version: v1.2.1
-        dependencies:
-          - console
-          - effect
-          - prelude
-          - sparse-polynomials
-      sparse-polynomials:
-        repo: https://github.com/Ebmtranceboy/purescript-sparse-polynomials.git
-        version: v1.0.5
-        dependencies:
-          - cartesian
-          - console
-          - effect
-          - ordered-collections
-          - prelude
-          - rationals
-          - tuples
-      spec:
-        repo: https://github.com/purescript-spec/purescript-spec.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - ansi
-          - avar
-          - console
-          - exceptions
-          - foldable-traversable
-          - fork
-          - now
-          - pipes
-          - prelude
-          - strings
-          - transformers
-      spec-discovery:
-        repo: https://github.com/purescript-spec/purescript-spec-discovery.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - aff-promise
-          - arrays
-          - console
-          - effect
-          - foldable-traversable
-          - node-fs
-          - prelude
-          - spec
-      spec-quickcheck:
-        repo: https://github.com/purescript-spec/purescript-spec-quickcheck.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - prelude
-          - quickcheck
-          - random
-          - spec
-      ssrs:
-        repo: https://github.com/PureFunctor/purescript-ssrs.git
-        version: v1.0.0
-        dependencies:
-          - dissect
-          - either
-          - fixed-points
-          - free
-          - lists
-          - prelude
-          - safe-coerce
-          - tailrec
-          - tuples
-          - variant
-      st:
-        repo: https://github.com/purescript/purescript-st.git
-        version: v6.0.0
-        dependencies:
-          - partial
-          - prelude
-          - tailrec
-          - unsafe-coerce
-      strictlypositiveint:
-        repo: https://github.com/jamieyung/purescript-strictlypositiveint.git
-        version: v1.0.1
-        dependencies:
-          - prelude
-      string-parsers:
-        repo: https://github.com/purescript-contrib/purescript-string-parsers.git
-        version: v8.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - prelude
-          - strings
-          - tailrec
-      strings:
-        repo: https://github.com/purescript/purescript-strings.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - enums
-          - foldable-traversable
-          - gen
-          - integers
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-          - unsafe-coerce
-      strings-extra:
-        repo: https://github.com/purescript-contrib/purescript-strings-extra.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - maybe
-          - prelude
-          - strings
-          - unicode
-      stringutils:
-        repo: https://github.com/menelaos/purescript-stringutils.git
-        version: v0.0.12
-        dependencies:
-          - arrays
-          - integers
-          - maybe
-          - partial
-          - prelude
-          - strings
-      substitute:
-        repo: https://github.com/ursi/purescript-substitute.git
-        version: v0.2.3
-        dependencies:
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - prelude
-          - return
-          - strings
-      supply:
-        repo: https://github.com/ajnsit/purescript-supply.git
-        version: v0.2.0
-        dependencies:
-          - console
-          - control
-          - effect
-          - lazy
-          - prelude
-          - refs
-          - tuples
-      tailrec:
-        repo: https://github.com/purescript/purescript-tailrec.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - effect
-          - either
-          - identity
-          - maybe
-          - partial
-          - prelude
-          - refs
-      test-unit:
-        repo: https://github.com/bodil/purescript-test-unit.git
-        version: v17.0.0
-        dependencies:
-          - aff
-          - avar
-          - effect
-          - either
-          - free
-          - js-timers
-          - lists
-          - prelude
-          - quickcheck
-          - strings
-      thermite:
-        repo: https://github.com/paf31/purescript-thermite.git
-        version: v6.3.1
-        dependencies:
-          - aff
-          - coroutines
-          - freet
-          - profunctor-lenses
-          - react
-      thermite-dom:
-        repo: https://github.com/athanclark/purescript-thermite-dom.git
-        version: v0.3.1
-        dependencies:
-          - react
-          - react-dom
-          - thermite
-          - web-html
-      these:
-        repo: https://github.com/purescript-contrib/purescript-these.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - gen
-          - lists
-          - quickcheck
-          - quickcheck-laws
-          - tuples
-      transformers:
-        repo: https://github.com/purescript/purescript-transformers.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - distributive
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - identity
-          - lazy
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      tree-rose:
-        repo: https://github.com/jordanmartinez/purescript-tree-rose.git
-        version: v4.0.2
-        dependencies:
-          - control
-          - foldable-traversable
-          - free
-          - lists
-          - maybe
-          - prelude
-          - tailrec
-      tuples:
-        repo: https://github.com/purescript/purescript-tuples.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - invariant
-          - prelude
-      two-or-more:
-        repo: https://github.com/i-am-the-slime/purescript-two-or-more.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - foldable-traversable
-          - maybe
-          - partial
-          - prelude
-          - psci-support
-          - tuples
-      type-equality:
-        repo: https://github.com/purescript/purescript-type-equality.git
-        version: v4.0.1
-        dependencies: []
-      typelevel:
-        repo: https://github.com/bodil/purescript-typelevel.git
-        version: v6.0.0
-        dependencies:
-          - partial
-          - prelude
-          - tuples
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-lists:
-        repo: https://github.com/PureFunctor/purescript-typelevel-lists.git
-        version: v2.1.0
-        dependencies:
-          - prelude
-          - tuples
-          - typelevel-peano
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-peano:
-        repo: https://github.com/csicar/purescript-typelevel-peano.git
-        version: v1.0.1
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - prelude
-          - psci-support
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-prelude:
-        repo: https://github.com/purescript/purescript-typelevel-prelude.git
-        version: v7.0.0
-        dependencies:
-          - prelude
-          - type-equality
-      typelevel-rows:
-        repo: https://github.com/jordanmartinez/purescript-typelevel-rows.git
-        version: v0.1.0
-        dependencies:
-          - prelude
-      uint:
-        repo: https://github.com/purescript-contrib/purescript-uint.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - enums
-          - gen
-          - maybe
-          - numbers
-          - prelude
-      uncurried-transformers:
-        repo: https://github.com/PureFunctor/purescript-uncurried-transformers.git
-        version: v1.1.0
-        dependencies:
-          - control
-          - effect
-          - either
-          - functions
-          - identity
-          - prelude
-          - safe-coerce
-          - tailrec
-          - transformers
-          - tuples
-      undefined-is-not-a-problem:
-        repo: https://github.com/paluh/purescript-undefined-is-not-a-problem.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - assert
-          - effect
-          - either
-          - foreign
-          - maybe
-          - newtype
-          - prelude
-          - random
-          - tuples
-          - type-equality
-          - unsafe-coerce
-      unfoldable:
-        repo: https://github.com/purescript/purescript-unfoldable.git
-        version: v6.0.0
-        dependencies:
-          - foldable-traversable
-          - maybe
-          - partial
-          - prelude
-          - tuples
-      unicode:
-        repo: https://github.com/purescript-contrib/purescript-unicode.git
-        version: v6.0.0
-        dependencies:
-          - foldable-traversable
-          - maybe
-          - strings
-      unlift:
-        repo: https://github.com/tweag/purescript-unlift.git
-        version: v1.0.1
-        dependencies:
-          - aff
-          - effect
-          - either
-          - freet
-          - identity
-          - lists
-          - maybe
-          - monad-control
-          - prelude
-          - st
-          - transformers
-          - tuples
-      unsafe-coerce:
-        repo: https://github.com/purescript/purescript-unsafe-coerce.git
-        version: v6.0.0
-        dependencies: []
-      unsafe-reference:
-        repo: https://github.com/purescript-contrib/purescript-unsafe-reference.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-      uri:
-        repo: https://github.com/purescript-contrib/purescript-uri.git
-        version: v9.0.0
-        dependencies:
-          - arrays
-          - integers
-          - js-uri
-          - numbers
-          - parsing
-          - prelude
-          - profunctor-lenses
-          - these
-          - transformers
-          - unfoldable
-      validation:
-        repo: https://github.com/purescript/purescript-validation.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - newtype
-          - prelude
-      variant:
-        repo: https://github.com/natefaubion/purescript-variant.git
-        version: v8.0.0
-        dependencies:
-          - enums
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - record
-          - tuples
-          - unsafe-coerce
-      vectorfield:
-        repo: https://github.com/csicar/purescript-vectorfield.git
-        version: v1.0.1
-        dependencies:
-          - console
-          - effect
-          - group
-          - prelude
-          - psci-support
-      versions:
-        repo: https://github.com/hdgarrood/purescript-versions.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - either
-          - foldable-traversable
-          - functions
-          - integers
-          - lists
-          - maybe
-          - orders
-          - parsing
-          - partial
-          - strings
-      web-clipboard:
-        repo: https://github.com/purescript-web/purescript-web-clipboard.git
-        version: v4.0.0
-        dependencies:
-          - web-html
-      web-cssom:
-        repo: https://github.com/purescript-web/purescript-web-cssom.git
-        version: v2.0.0
-        dependencies:
-          - web-dom
-          - web-html
-          - web-uievents
-      web-dom:
-        repo: https://github.com/purescript-web/purescript-web-dom.git
-        version: v6.0.0
-        dependencies:
-          - web-events
-      web-dom-parser:
-        repo: https://github.com/purescript-web/purescript-web-dom-parser.git
-        version: v8.0.0
-        dependencies:
-          - effect
-          - partial
-          - prelude
-          - web-dom
-      web-dom-xpath:
-        repo: https://github.com/purescript-web/purescript-web-dom-xpath.git
-        version: v3.0.0
-        dependencies:
-          - web-dom
-      web-encoding:
-        repo: https://github.com/purescript-web/purescript-web-encoding.git
-        version: v3.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - newtype
-          - prelude
-      web-events:
-        repo: https://github.com/purescript-web/purescript-web-events.git
-        version: v4.0.0
-        dependencies:
-          - datetime
-          - enums
-          - foreign
-          - nullable
-      web-fetch:
-        repo: https://github.com/purescript-web/purescript-web-fetch.git
-        version: v3.0.0
-        dependencies:
-          - effect
-          - foreign-object
-          - http-methods
-          - prelude
-          - record
-          - typelevel-prelude
-          - web-file
-          - web-promise
-          - web-streams
-      web-file:
-        repo: https://github.com/purescript-web/purescript-web-file.git
-        version: v4.0.0
-        dependencies:
-          - foreign
-          - media-types
-          - web-dom
-      web-html:
-        repo: https://github.com/purescript-web/purescript-web-html.git
-        version: v4.0.0
-        dependencies:
-          - js-date
-          - web-dom
-          - web-file
-          - web-storage
-      web-page-visibility:
-        repo: https://git.sr.ht/~toastal/purescript-web-page-visibility
-        version: v2.0.0
-        dependencies:
-          - effect
-          - enums
-          - exceptions
-          - maybe
-          - prelude
-          - strings
-          - web-events
-          - web-html
-      web-pointerevents:
-        repo: https://github.com/purescript-web/purescript-web-pointerevents.git
-        version: v1.0.0
-        dependencies:
-          - effect
-          - maybe
-          - prelude
-          - web-dom
-          - web-uievents
-      web-promise:
-        repo: https://github.com/purescript-web/purescript-web-promise.git
-        version: v3.0.0
-        dependencies:
-          - effect
-          - exceptions
-          - foldable-traversable
-          - functions
-          - maybe
-          - prelude
-      web-socket:
-        repo: https://github.com/purescript-web/purescript-web-socket.git
-        version: v4.0.0
-        dependencies:
-          - arraybuffer-types
-          - web-file
-      web-storage:
-        repo: https://github.com/purescript-web/purescript-web-storage.git
-        version: v5.0.0
-        dependencies:
-          - nullable
-          - web-events
-      web-streams:
-        repo: https://github.com/purescript-web/purescript-web-streams.git
-        version: v3.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - exceptions
-          - nullable
-          - prelude
-          - tuples
-          - web-promise
-      web-touchevents:
-        repo: https://github.com/purescript-web/purescript-web-touchevents.git
-        version: v4.0.0
-        dependencies:
-          - web-uievents
-      web-uievents:
-        repo: https://github.com/purescript-web/purescript-web-uievents.git
-        version: v4.0.0
-        dependencies:
-          - web-html
-      web-workers:
-        repo: https://github.com/gbagan/purescript-web-workers.git
-        version: v1.1.0
-        dependencies:
-          - effect
-          - foreign
-          - maybe
-          - prelude
-          - unsafe-coerce
-          - web-events
-      web-xhr:
-        repo: https://github.com/purescript-web/purescript-web-xhr.git
-        version: v5.0.0
-        dependencies:
-          - arraybuffer-types
-          - datetime
-          - http-methods
-          - web-dom
-          - web-file
-          - web-html
-      yoga-fetch:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-fetch.git
-        version: v1.0.1
-        dependencies:
-          - aff
-          - aff-promise
-          - arraybuffer-types
-          - effect
-          - foreign
-          - foreign-object
-          - newtype
-          - prelude
-          - typelevel-prelude
-          - unsafe-coerce
-      yoga-json:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-json.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - identity
-          - lists
-          - maybe
-          - nullable
-          - partial
-          - prelude
-          - record
-          - transformers
-          - typelevel-prelude
-          - variant
-      yoga-postgres:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-postgres.git
-        version: v6.0.0
-        dependencies:
-          - aff
-          - arrays
-          - datetime
-          - effect
-          - either
-          - enums
-          - foldable-traversable
-          - foreign
-          - integers
-          - maybe
-          - nullable
-          - prelude
-          - transformers
-          - unsafe-coerce
+      abc-parser: 2.0.0
+      ace: 9.0.0
+      aff: 7.1.0
+      aff-bus: 6.0.0
+      aff-coroutines: 9.0.0
+      aff-promise: 4.0.0
+      aff-retry: 2.0.0
+      affjax: 13.0.0
+      affjax-node: 1.0.0
+      affjax-web: 1.0.0
+      ansi: 7.0.0
+      argonaut: 9.0.0
+      argonaut-aeson-generic: 0.4.1
+      argonaut-codecs: 9.1.0
+      argonaut-core: 7.0.0
+      argonaut-generic: 8.0.0
+      argonaut-traversals: 10.0.0
+      argparse-basic: 2.0.0
+      array-builder: 0.1.2
+      arraybuffer: 13.1.1
+      arraybuffer-builder: 3.1.0
+      arraybuffer-types: 3.0.2
+      arrays: 7.1.0
+      arrays-zipper: 2.0.1
+      ask: 1.0.0
+      assert: 6.0.0
+      avar: 5.0.0
+      b64: 0.0.8
+      barbies: 1.0.1
+      barlow-lens: 0.9.0
+      basic-auth: 3.0.1
+      bifunctors: 6.0.0
+      bigints: 7.0.1
+      bolson: 0.3.1
+      bower-json: 3.0.0
+      bucketchain: 1.0.1
+      bucketchain-basic-auth: 1.0.1
+      bucketchain-conditional: 1.0.1
+      bucketchain-cors: 1.0.1
+      bucketchain-csrf: 1.0.1
+      bucketchain-header-utils: 1.0.1
+      bucketchain-health: 1.0.1
+      bucketchain-history-api-fallback: 1.0.1
+      bucketchain-logger: 1.0.1
+      bucketchain-secure: 1.0.1
+      bucketchain-simple-api: 5.0.1
+      bucketchain-sslify: 1.0.1
+      bucketchain-static: 1.0.1
+      call-by-name: 4.0.1
+      canvas: 6.0.0
+      canvas-action: 9.0.0
+      cartesian: 1.0.6
+      catenable-lists: 7.0.0
+      channel: 1.0.0
+      checked-exceptions: 3.1.1
+      classless: 0.1.1
+      classless-arbitrary: 0.1.1
+      classless-decode-json: 0.1.1
+      classless-encode-json: 0.1.3
+      classnames: 2.0.0
+      codec: 6.0.0
+      codec-argonaut: 10.0.0
+      colors: 7.0.1
+      concur-core: 0.5.0
+      concur-react: 0.5.0
+      concurrent-queues: 3.0.0
+      console: 6.0.0
+      const: 6.0.0
+      contravariant: 6.0.0
+      control: 6.0.0
+      convertable-options: 1.0.0
+      coroutines: 7.0.0
+      crypto: 5.0.1
+      css: 6.0.0
+      datetime: 6.1.0
+      datetime-parsing: 0.2.0
+      debug: 6.0.2
+      decimals: 7.1.0
+      default-values: 1.0.1
+      deku: 0.9.9
+      deno: 0.0.5
+      dissect: 1.0.0
+      distributive: 6.0.0
+      dodo-printer: 2.2.1
+      dom-filereader: 7.0.0
+      dom-indexed: 11.0.0
+      dotenv: 3.0.0
+      droplet: 0.5.0
+      dynamic-buffer: 3.0.1
+      echarts-simple: 0.0.1
+      effect: 4.0.0
+      either: 6.1.0
+      elmish: 0.8.3
+      elmish-enzyme: 0.1.1
+      elmish-hooks: 0.9.1
+      elmish-html: 0.7.2
+      elmish-testing-library: 0.3.1
+      email-validate: 7.0.0
+      encoding: 0.0.8
+      enums: 6.0.1
+      error: 2.0.0
+      exceptions: 6.0.0
+      exists: 6.0.0
+      exitcodes: 4.0.0
+      expect-inferred: 3.0.0
+      fahrtwind: 2.0.0
+      fallback: 0.1.0
+      fast-vect: 1.1.0
+      fetch: 1.1.4
+      fetch-argonaut: 1.0.0
+      fetch-core: 4.0.4
+      fetch-yoga-json: 1.1.0
+      filterable: 5.0.0
+      fixed-points: 7.0.0
+      fixed-precision: 5.0.0
+      flame: 1.2.0
+      float32: 2.0.0
+      foldable-traversable: 6.0.0
+      foreign: 7.0.0
+      foreign-object: 4.1.0
+      foreign-readwrite: 3.4.0
+      fork: 6.0.0
+      form-urlencoded: 7.0.0
+      formatters: 7.0.0
+      framer-motion: 1.0.1
+      free: 7.0.0
+      freeap: 7.0.0
+      freer-free: 0.0.1
+      freet: 7.0.0
+      functions: 6.0.0
+      functor1: 3.0.0
+      functors: 5.0.0
+      fuzzy: 0.4.0
+      gen: 4.0.0
+      generate-values: 1.0.1
+      generic-router: 0.0.1
+      geometry-plane: 1.0.3
+      github-actions-toolkit: 0.5.0
+      grain: 3.0.0
+      grain-router: 3.0.0
+      grain-virtualized: 3.0.0
+      graphql-client: 9.3.2
+      graphs: 8.1.0
+      group: 4.1.1
+      halogen: 7.0.0
+      halogen-bootstrap5: 2.1.0
+      halogen-css: 10.0.0
+      halogen-echarts-simple: 0.0.4
+      halogen-formless: 4.0.2
+      halogen-hooks: 0.6.3
+      halogen-hooks-extra: 0.9.0
+      halogen-store: 0.5.4
+      halogen-storybook: 2.0.0
+      halogen-subscriptions: 2.0.0
+      halogen-svg-elems: 7.0.0
+      halogen-vdom: 8.0.0
+      halogen-vdom-string-renderer: 0.5.0
+      heckin: 2.0.1
+      heterogeneous: 0.6.0
+      homogeneous: 0.4.0
+      http-methods: 6.0.0
+      httpure: 0.16.0
+      httpurple: 3.0.1
+      httpurple-argonaut: 1.0.1
+      httpurple-yoga-json: 1.0.0
+      humdrum: 0.0.1
+      hyrule: 2.3.5
+      identity: 6.0.0
+      identy: 4.0.1
+      indexed-monad: 2.1.0
+      int64: 3.0.0
+      integers: 6.0.0
+      interpolate: 5.0.2
+      invariant: 6.0.0
+      jarilo: 1.0.1
+      jelly: 0.9.1
+      jelly-hooks: 0.3.1
+      jelly-router: 0.2.2
+      jelly-signal: 0.3.0
+      jest: 1.0.0
+      js-bigints: 1.2.0
+      js-date: 8.0.0
+      js-fileio: 3.0.0
+      js-promise: 1.0.0
+      js-promise-aff: 1.0.0
+      js-timers: 6.1.0
+      js-uri: 3.1.0
+      justifill: 0.5.0
+      jwt: 0.0.9
+      language-cst-parser: 0.12.1
+      lazy: 6.0.0
+      lazy-joe: 1.0.0
+      lcg: 4.0.0
+      leibniz: 5.0.0
+      linalg: 5.1.0
+      lists: 7.0.0
+      literals: 1.0.2
+      logging: 3.0.0
+      logging-journald: 0.4.0
+      machines: 7.0.0
+      marionette: 1.0.0
+      marionette-commander: 0.1.1
+      marionette-react-basic-hooks: 0.1.1
+      matrices: 5.0.1
+      matryoshka: 1.0.0
+      maybe: 6.0.0
+      mdast-util-from-markdown: 0.2.1
+      media-types: 6.0.0
+      midi: 4.0.0
+      milkis: 9.0.0
+      minibench: 4.0.1
+      mmorph: 7.0.0
+      monad-control: 5.0.0
+      monad-logger: 1.3.1
+      monad-loops: 0.5.0
+      monad-unlift: 1.0.1
+      monoid-extras: 0.0.1
+      monoidal: 0.16.0
+      morello: 0.4.0
+      mote: 3.0.0
+      motsunabe: 2.0.0
+      mysql: 6.0.1
+      n3: 0.1.0
+      nano-id: 1.1.0
+      naturals: 3.0.0
+      nested-functor: 0.2.1
+      newtype: 5.0.0
+      nextui: 0.1.0
+      node-buffer: 8.0.0
+      node-buffer-blob: 1.0.0
+      node-child-process: 9.0.0
+      node-fs: 8.1.1
+      node-fs-aff: 9.1.0
+      node-http: 8.0.0
+      node-net: 4.0.0
+      node-path: 5.0.0
+      node-process: 10.0.0
+      node-readline: 7.0.0
+      node-sqlite3: 8.0.0
+      node-streams: 7.0.0
+      node-streams-aff: 4.0.1
+      node-url: 6.0.0
+      nodemailer: 4.0.1
+      nonempty: 7.0.0
+      now: 6.0.0
+      npm-package-json: 2.0.0
+      nullable: 6.0.0
+      numbers: 9.0.0
+      object-maps: 0.1.1
+      ocarina: 1.5.2
+      open-folds: 6.3.0
+      open-memoize: 6.1.0
+      open-pairing: 6.1.0
+      options: 7.0.0
+      optparse: 5.0.0
+      ordered-collections: 3.0.0
+      ordered-set: 0.4.0
+      orders: 6.0.0
+      pairs: 9.0.0
+      parallel: 6.0.0
+      parsing: 10.2.0
+      parsing-dataview: 3.2.4
+      partial: 4.0.0
+      pathy: 9.0.0
+      pha: 0.9.0
+      phaser: 0.6.0
+      pipes: 8.0.0
+      pirates-charm: 0.0.1
+      point-free: 1.0.0
+      pointed-list: 0.5.1
+      polymorphic-vectors: 4.0.0
+      posix-types: 6.0.0
+      precise: 6.0.0
+      precise-datetime: 7.0.0
+      prelude: 6.0.1
+      prettier-printer: 3.0.0
+      profunctor: 6.0.0
+      profunctor-lenses: 8.0.0
+      protobuf: 4.2.0
+      ps-cst: 1.2.0
+      psa-utils: 8.0.0
+      psc-ide: 19.0.0
+      psci-support: 6.0.0
+      qualified-do: 2.2.0
+      quantities: 12.1.0
+      quickcheck: 8.0.1
+      quickcheck-combinators: 0.1.3
+      quickcheck-laws: 7.0.0
+      quickcheck-utf8: 0.0.0
+      random: 6.0.0
+      rationals: 5.0.1
+      rdf: 0.1.0
+      react: 10.0.1
+      react-aria: 0.2.0
+      react-basic: 17.0.0
+      react-basic-classic: 3.0.0
+      react-basic-dnd: 10.1.0
+      react-basic-dom: 6.0.0
+      react-basic-emotion: 7.1.0
+      react-basic-hooks: 8.1.2
+      react-basic-storybook: 2.0.0
+      react-dom: 8.0.0
+      react-halo: 3.0.0
+      react-icons: 1.0.8
+      react-testing-library: 4.0.1
+      react-virtuoso: 1.0.0
+      read: 1.0.1
+      record: 4.0.0
+      record-extra: 5.0.1
+      record-studio: 1.0.4
+      refs: 6.0.0
+      remotedata: 5.0.0
+      resource: 2.0.1
+      resourcet: 1.0.0
+      result: 1.0.3
+      return: 0.2.0
+      ring-modules: 5.0.1
+      rito: 0.3.2
+      routing: 11.0.0
+      routing-duplex: 0.7.0
+      run: 5.0.0
+      safe-coerce: 2.0.0
+      safely: 4.0.1
+      school-of-music: 1.3.0
+      selection-foldable: 0.2.0
+      semirings: 7.0.0
+      signal: 13.0.0
+      simple-emitter: 3.0.1
+      simple-i18n: 2.0.1
+      simple-json: 9.0.0
+      simple-jwt: 4.0.1
+      simple-ulid: 3.0.0
+      sized-matrices: 1.0.0
+      sized-vectors: 5.0.2
+      slug: 3.0.8
+      small-ffi: 4.0.1
+      soundfonts: 4.1.0
+      sparse-matrices: 1.2.1
+      sparse-polynomials: 1.0.5
+      spec: 7.2.0
+      spec-discovery: 8.0.1
+      spec-quickcheck: 5.0.0
+      splitmix: 2.1.0
+      ssrs: 1.0.0
+      st: 6.2.0
+      strictlypositiveint: 1.0.1
+      string-parsers: 8.0.0
+      strings: 6.0.1
+      strings-extra: 4.0.0
+      stringutils: 0.0.12
+      substitute: 0.2.3
+      sunde: 3.0.0
+      supply: 0.2.0
+      svg-parser: 3.0.0
+      systemd-journald: 0.3.0
+      tagged: 4.0.2
+      tailrec: 6.1.0
+      tecton: 0.1.6
+      tecton-halogen: 0.1.3
+      test-unit: 17.0.0
+      thermite: 6.3.1
+      thermite-dom: 0.3.1
+      these: 6.0.0
+      toppokki: 4.0.0
+      transformers: 6.0.0
+      tree-rose: 4.0.2
+      tuples: 7.0.0
+      two-or-more: 1.0.0
+      type-equality: 4.0.1
+      typelevel: 6.0.0
+      typelevel-lists: 2.1.0
+      typelevel-peano: 1.0.1
+      typelevel-prelude: 7.0.0
+      typelevel-rows: 0.1.0
+      uint: 7.0.0
+      ulid: 3.0.1
+      uncurried-transformers: 1.1.0
+      undefined: 2.0.0
+      undefined-is-not-a-problem: 1.1.0
+      unfoldable: 6.0.0
+      unicode: 6.0.0
+      unlift: 1.0.1
+      unordered-collections: 3.0.1
+      unsafe-coerce: 6.0.0
+      unsafe-reference: 5.0.0
+      untagged-to-tagged: 0.1.4
+      untagged-union: 1.0.0
+      uri: 9.0.0
+      uuid: 9.0.0
+      uuidv4: 1.0.0
+      validation: 6.0.0
+      variant: 8.0.0
+      vectorfield: 1.0.1
+      vectors: 2.1.0
+      versions: 7.0.0
+      visx: 0.0.2
+      web-clipboard: 5.0.0
+      web-cssom: 2.0.0
+      web-dom: 6.0.0
+      web-dom-parser: 8.0.0
+      web-dom-xpath: 3.0.0
+      web-encoding: 3.0.0
+      web-events: 4.0.0
+      web-fetch: 3.0.0
+      web-file: 4.0.0
+      web-html: 4.1.0
+      web-pointerevents: 1.0.0
+      web-proletarian: 1.0.0
+      web-promise: 3.1.0
+      web-resize-observer: 2.0.0
+      web-router: 1.0.0
+      web-socket: 4.0.0
+      web-storage: 5.0.0
+      web-streams: 3.0.0
+      web-touchevents: 4.0.0
+      web-uievents: 4.0.0
+      web-url: 2.0.0
+      web-workers: 1.1.0
+      web-xhr: 5.0.0
+      which: 2.0.0
+      yoga-fetch: 1.0.1
+      yoga-json: 4.0.1
+      yoga-om: 0.1.0
+      yoga-postgres: 6.0.0
+      yoga-tree: 1.0.0
   extra_packages: {}
 packages:
   arrays:
-    type: git
-    url: https://github.com/purescript/purescript-arrays.git
-    rev: d20bae2f76db6cf29b7b75e26e82b8a54c32295e
+    type: registry
+    version: 7.1.0
+    integrity: sha256-Rvb3AVLal0ZLpmpABgOPIUeYHa4M+c5GwcUP5rQ2trA=
     dependencies:
       - bifunctors
       - control
@@ -3500,15 +500,16 @@ packages:
       - nonempty
       - partial
       - prelude
+      - safe-coerce
       - st
       - tailrec
       - tuples
       - unfoldable
       - unsafe-coerce
   bifunctors:
-    type: git
-    url: https://github.com/purescript/purescript-bifunctors.git
-    rev: 16ba2fb6dd7f05528ebd9e2f9ca3a068b325e5b3
+    type: registry
+    version: 6.0.0
+    integrity: sha256-/gZwC9YhNxZNQpnHa5BIYerCGM2jeX9ukZiEvYxm5Nw=
     dependencies:
       - const
       - either
@@ -3516,24 +517,24 @@ packages:
       - prelude
       - tuples
   console:
-    type: git
-    url: https://github.com/purescript/purescript-console.git
-    rev: 3b83d7b792d03872afeea5e62b4f686ab0f09842
+    type: registry
+    version: 6.0.0
+    integrity: sha256-gJpJ53fCDAL8BiCiJXH0HNAJ9K3gJtLo8GDaCK6hA5U=
     dependencies:
       - effect
       - prelude
   const:
-    type: git
-    url: https://github.com/purescript/purescript-const.git
-    rev: ab9570cf2b6e67f7e441178211db1231cfd75c37
+    type: registry
+    version: 6.0.0
+    integrity: sha256-tNrxDW8D8H4jdHE2HiPzpLy08zkzJMmGHdRqt5BQuTc=
     dependencies:
       - invariant
       - newtype
       - prelude
   contravariant:
-    type: git
-    url: https://github.com/purescript/purescript-contravariant.git
-    rev: 9ad3e105b8855bcc25f4e0893c784789d05a58de
+    type: registry
+    version: 6.0.0
+    integrity: sha256-TP+ooAp3vvmdjfQsQJSichF5B4BPDHp3wAJoWchip6c=
     dependencies:
       - const
       - either
@@ -3541,16 +542,16 @@ packages:
       - prelude
       - tuples
   control:
-    type: git
-    url: https://github.com/purescript/purescript-control.git
-    rev: a6033808790879a17b2729e73747a9ed3fb2264e
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sH7Pg9E96JCPF9PIA6oQ8+BjTyO/BH1ZuE/bOcyj4Jk=
     dependencies:
       - newtype
       - prelude
   distributive:
-    type: git
-    url: https://github.com/purescript/purescript-distributive.git
-    rev: 6005e513642e855ebf6f884d24a35c2803ca252a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-HTDdmEnzigMl+02SJB88j+gAXDx9VKsbvR4MJGDPbOQ=
     dependencies:
       - identity
       - newtype
@@ -3558,24 +559,24 @@ packages:
       - tuples
       - type-equality
   effect:
-    type: git
-    url: https://github.com/purescript/purescript-effect.git
-    rev: a192ddb923027d426d6ea3d8deb030c9aa7c7dda
+    type: registry
+    version: 4.0.0
+    integrity: sha256-eBtZu+HZcMa5HilvI6kaDyVX3ji8p0W9MGKy2K4T6+M=
     dependencies:
       - prelude
   either:
-    type: git
-    url: https://github.com/purescript/purescript-either.git
-    rev: af655a04ed2fd694b6688af39ee20d7907ad0763
+    type: registry
+    version: 6.1.0
+    integrity: sha256-6hgTPisnMWVwQivOu2PKYcH8uqjEOOqDyaDQVUchTpY=
     dependencies:
       - control
       - invariant
       - maybe
       - prelude
   enums:
-    type: git
-    url: https://github.com/purescript/purescript-enums.git
-    rev: bae47961d401f9acf88da38f32e87403e5f0cf2f
+    type: registry
+    version: 6.0.1
+    integrity: sha256-HWaD73JFLorc4A6trKIRUeDMdzE+GpkJaEOM1nTNkC8=
     dependencies:
       - control
       - either
@@ -3588,24 +589,24 @@ packages:
       - tuples
       - unfoldable
   exceptions:
-    type: git
-    url: https://github.com/purescript/purescript-exceptions.git
-    rev: afab3c07c820bb49b6c5be50049db46a964a6161
+    type: registry
+    version: 6.0.0
+    integrity: sha256-y/xTAEIZIARCE+50/u1di0ncebJ+CIwNOLswyOWzMTw=
     dependencies:
       - effect
       - either
       - maybe
       - prelude
   exists:
-    type: git
-    url: https://github.com/purescript/purescript-exists.git
-    rev: f765b4ace7869c27b9c05949e18c843881f9173b
+    type: registry
+    version: 6.0.0
+    integrity: sha256-A0JQHpTfo1dNOj9U5/Fd3xndlRSE0g2IQWOGor2yXn8=
     dependencies:
       - unsafe-coerce
   foldable-traversable:
-    type: git
-    url: https://github.com/purescript/purescript-foldable-traversable.git
-    rev: b3926f870532d287ea59e2d5cd3873b81ef2a93a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-fLeqRYM4jUrZD5H4WqcwUgzU7XfYkzO4zhgtNc3jcWM=
     dependencies:
       - bifunctors
       - const
@@ -3619,15 +620,15 @@ packages:
       - prelude
       - tuples
   functions:
-    type: git
-    url: https://github.com/purescript/purescript-functions.git
-    rev: f626f20580483977c5b27a01aac6471e28aff367
+    type: registry
+    version: 6.0.0
+    integrity: sha256-adMyJNEnhGde2unHHAP79gPtlNjNqzgLB8arEOn9hLI=
     dependencies:
       - prelude
   functors:
-    type: git
-    url: https://github.com/purescript/purescript-functors.git
-    rev: 022ffd7a2a7ec12080314f3d217b400674a247b4
+    type: registry
+    version: 5.0.0
+    integrity: sha256-zfPWWYisbD84MqwpJSZFlvM6v86McM68ob8p9s27ywU=
     dependencies:
       - bifunctors
       - const
@@ -3643,9 +644,9 @@ packages:
       - tuples
       - unsafe-coerce
   gen:
-    type: git
-    url: https://github.com/purescript/purescript-gen.git
-    rev: 9fbcc2a1261c32e30d79c5418edef4d96fe76931
+    type: registry
+    version: 4.0.0
+    integrity: sha256-f7yzAXWwr+xnaqEOcvyO3ezKdoes8+WXWdXIHDBCAPI=
     dependencies:
       - either
       - foldable-traversable
@@ -3658,42 +659,42 @@ packages:
       - tuples
       - unfoldable
   identity:
-    type: git
-    url: https://github.com/purescript/purescript-identity.git
-    rev: ef6768f8a52ab0bc943a85f5761ba07c257f639f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-4wY0XZbAksjY6UAg99WkuKyJlQlWAfTi2ssadH0wVMY=
     dependencies:
       - control
       - invariant
       - newtype
       - prelude
   integers:
-    type: git
-    url: https://github.com/purescript/purescript-integers.git
-    rev: 54d712b25c594833083d15dc9ff2418eb9c52822
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sf+sK26R1hzwl3NhXR7WAu9zCDjQnfoXwcyGoseX158=
     dependencies:
       - maybe
       - numbers
       - prelude
   invariant:
-    type: git
-    url: https://github.com/purescript/purescript-invariant.git
-    rev: 1d2a196d51e90623adb88496c2cfd759c6736894
+    type: registry
+    version: 6.0.0
+    integrity: sha256-RGWWyYrz0Hs1KjPDA+87Kia67ZFBhfJ5lMGOMCEFoLo=
     dependencies:
       - control
       - prelude
   lazy:
-    type: git
-    url: https://github.com/purescript/purescript-lazy.git
-    rev: 48347841226b27af5205a1a8ec71e27a93ce86fd
+    type: registry
+    version: 6.0.0
+    integrity: sha256-lMsfFOnlqfe4KzRRiW8ot5ge6HtcU3Eyh2XkXcP5IgU=
     dependencies:
       - control
       - foldable-traversable
       - invariant
       - prelude
   lcg:
-    type: git
-    url: https://github.com/purescript/purescript-lcg.git
-    rev: 67c6c6483a563a59ae036d9dca0f1be2835326a5
+    type: registry
+    version: 4.0.0
+    integrity: sha256-h7ME5cthLfbgJOJdsZcSfFpwXsx4rf8YmhebU+3iSYg=
     dependencies:
       - effect
       - integers
@@ -3702,9 +703,9 @@ packages:
       - prelude
       - random
   lists:
-    type: git
-    url: https://github.com/purescript/purescript-lists.git
-    rev: b113451e5b41cad87d669a3165f955c71cd863e2
+    type: registry
+    version: 7.0.0
+    integrity: sha256-EKF15qYqucuXP2lT/xPxhqy58f0FFT6KHdIB/yBOayI=
     dependencies:
       - bifunctors
       - control
@@ -3719,25 +720,25 @@ packages:
       - tuples
       - unfoldable
   maybe:
-    type: git
-    url: https://github.com/purescript/purescript-maybe.git
-    rev: c6f98ac1088766287106c5d9c8e30e7648d36786
+    type: registry
+    version: 6.0.0
+    integrity: sha256-5cCIb0wPwbat2PRkQhUeZO0jcAmf8jCt2qE0wbC3v2Q=
     dependencies:
       - control
       - invariant
       - newtype
       - prelude
   newtype:
-    type: git
-    url: https://github.com/purescript/purescript-newtype.git
-    rev: 29d8e6dd77aec2c975c948364ec3faf26e14ee7b
+    type: registry
+    version: 5.0.0
+    integrity: sha256-gdrQu8oGe9eZE6L3wOI8ql/igOg+zEGB5ITh2g+uttw=
     dependencies:
       - prelude
       - safe-coerce
   nonempty:
-    type: git
-    url: https://github.com/purescript/purescript-nonempty.git
-    rev: 28150ecc7419238b187abd609a92a645273348bb
+    type: registry
+    version: 7.0.0
+    integrity: sha256-54ablJZUHGvvlTJzi3oXyPCuvY6zsrWJuH/dMJ/MFLs=
     dependencies:
       - control
       - foldable-traversable
@@ -3746,33 +747,33 @@ packages:
       - tuples
       - unfoldable
   numbers:
-    type: git
-    url: https://github.com/purescript/purescript-numbers.git
-    rev: 2a53528f18f9415334bae28e7bb3cf3be86342c2
+    type: registry
+    version: 9.0.0
+    integrity: sha256-fDKXExFxMRFgy+v+kbjVbGBIOOQkWGnmm0vtnE3zWRE=
     dependencies:
       - functions
       - maybe
   orders:
-    type: git
-    url: https://github.com/purescript/purescript-orders.git
-    rev: f86db621ec5eef1274145f8b1fd8ebbfe0ed4a2c
+    type: registry
+    version: 6.0.0
+    integrity: sha256-nBA0g3/ai0euH8q9pSbGqk53W2q6agm/dECZTHcoink=
     dependencies:
       - newtype
       - prelude
   partial:
-    type: git
-    url: https://github.com/purescript/purescript-partial.git
-    rev: 0fa0646f5ea1ec5f0c46dcbd770c705a6c9ad3ec
+    type: registry
+    version: 4.0.0
+    integrity: sha256-fwXerld6Xw1VkReh8yeQsdtLVrjfGiVuC5bA1Wyo/J4=
     dependencies: []
   prelude:
-    type: git
-    url: https://github.com/purescript/purescript-prelude.git
-    rev: 32787f4399c92459c41602131a5858559eb868c5
+    type: registry
+    version: 6.0.1
+    integrity: sha256-o8p6SLYmVPqzXZhQFd2hGAWEwBoXl1swxLG/scpJ0V0=
     dependencies: []
   profunctor:
-    type: git
-    url: https://github.com/purescript/purescript-profunctor.git
-    rev: 0a966a14e7b0c827d44657dc1710cdc712d2e034
+    type: registry
+    version: 6.0.0
+    integrity: sha256-99NzxFgTr4CGlCSRYG1kShL+JhYbihhHtbOk1/0R5zI=
     dependencies:
       - control
       - distributive
@@ -3783,9 +784,9 @@ packages:
       - prelude
       - tuples
   quickcheck:
-    type: git
-    url: https://github.com/purescript/purescript-quickcheck.git
-    rev: bf5029f97e6c0d7552d3a08d2ab793a19e2c5e3d
+    type: registry
+    version: 8.0.1
+    integrity: sha256-ZvpccKQCvgslTXZCNmpYW4bUsFzhZd/kQUr2WmxFTGY=
     dependencies:
       - arrays
       - console
@@ -3815,46 +816,46 @@ packages:
       - tuples
       - unfoldable
   random:
-    type: git
-    url: https://github.com/purescript/purescript-random.git
-    rev: 9540bc965a9596da02fefd9949418bb19c92533a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-CJ611a35MPCE7XQMp0rdC6MCn76znlhisiCRgboAG+Q=
     dependencies:
       - effect
       - integers
   record:
-    type: git
-    url: https://github.com/purescript/purescript-record.git
-    rev: c89cd1ada6b636692571fc374196b1c39c4c9f70
+    type: registry
+    version: 4.0.0
+    integrity: sha256-Za5U85bTRJEfGK5Sk4hM41oXy84YQI0I8TL3WUn1Qzg=
     dependencies:
       - functions
       - prelude
       - unsafe-coerce
   refs:
-    type: git
-    url: https://github.com/purescript/purescript-refs.git
-    rev: f8e6216da4cb9309fde1f20cd6f69ac3a3b7f9e8
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Vgwne7jIbD3ZMoLNNETLT8Litw6lIYo3MfYNdtYWj9s=
     dependencies:
       - effect
       - prelude
   safe-coerce:
-    type: git
-    url: https://github.com/purescript/purescript-safe-coerce.git
-    rev: 7fa799ae80a38b8d948efcb52608e58e198b3da7
+    type: registry
+    version: 2.0.0
+    integrity: sha256-a1ibQkiUcbODbLE/WAq7Ttbbh9ex+x33VCQ7GngKudU=
     dependencies:
       - unsafe-coerce
   st:
-    type: git
-    url: https://github.com/purescript/purescript-st.git
-    rev: 2cc7ae1c3318a303378c4a9f3fa0f10ee7cc3589
+    type: registry
+    version: 6.2.0
+    integrity: sha256-z9X0WsOUlPwNx9GlCC+YccCyz8MejC8Wb0C4+9fiBRY=
     dependencies:
       - partial
       - prelude
       - tailrec
       - unsafe-coerce
   strings:
-    type: git
-    url: https://github.com/purescript/purescript-strings.git
-    rev: 4bc6954448d056f8aa7a659695a6ad60ad4fdf19
+    type: registry
+    version: 6.0.1
+    integrity: sha256-WssD3DbX4OPzxSdjvRMX0yvc9+pS7n5gyPv5I2Trb7k=
     dependencies:
       - arrays
       - control
@@ -3873,9 +874,9 @@ packages:
       - unfoldable
       - unsafe-coerce
   tailrec:
-    type: git
-    url: https://github.com/purescript/purescript-tailrec.git
-    rev: 5e2104aa734b31a17074cc805bf087d72b65afd1
+    type: registry
+    version: 6.1.0
+    integrity: sha256-Xx19ECVDRrDWpz9D2GxQHHV89vd61dnXxQm0IcYQHGk=
     dependencies:
       - bifunctors
       - effect
@@ -3886,9 +887,9 @@ packages:
       - prelude
       - refs
   transformers:
-    type: git
-    url: https://github.com/purescript/purescript-transformers.git
-    rev: be72ab52357d9a665cbf93d73ba1c07c4b0957ee
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Pzw40HjthX77tdPAYzjx43LK3X5Bb7ZspYAp27wksFA=
     dependencies:
       - control
       - distributive
@@ -3905,22 +906,22 @@ packages:
       - tuples
       - unfoldable
   tuples:
-    type: git
-    url: https://github.com/purescript/purescript-tuples.git
-    rev: 4f52da2729b448c8564369378f1232d8d2dc1d8b
+    type: registry
+    version: 7.0.0
+    integrity: sha256-1rXgTomes9105BjgXqIw0FL6Fz1lqqUTLWOumhWec1M=
     dependencies:
       - control
       - invariant
       - prelude
   type-equality:
-    type: git
-    url: https://github.com/purescript/purescript-type-equality.git
-    rev: 0525b7d39e0fbd81b4209518139fb8ab02695774
+    type: registry
+    version: 4.0.1
+    integrity: sha256-Hs9D6Y71zFi/b+qu5NSbuadUQXe5iv5iWx0226vOHUw=
     dependencies: []
   unfoldable:
-    type: git
-    url: https://github.com/purescript/purescript-unfoldable.git
-    rev: 493dfe04ed590e20d8f69079df2f58486882748d
+    type: registry
+    version: 6.0.0
+    integrity: sha256-JtikvJdktRap7vr/K4ITlxUX1QexpnqBq0G/InLr6eg=
     dependencies:
       - foldable-traversable
       - maybe
@@ -3928,7 +929,7 @@ packages:
       - prelude
       - tuples
   unsafe-coerce:
-    type: git
-    url: https://github.com/purescript/purescript-unsafe-coerce.git
-    rev: ab956f82e66e633f647fb3098e8ddd3ec58d689f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-IqIYW4Vkevn8sI+6aUwRGvd87tVL36BBeOr0cGAE7t0=
     dependencies: []

--- a/exercises/chapter13/spago.yaml
+++ b/exercises/chapter13/spago.yaml
@@ -12,4 +12,4 @@ package:
 workspace:
   extraPackages: {}
   packageSet:
-    url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
+    registry: 10.0.0

--- a/exercises/chapter13/spago.yaml
+++ b/exercises/chapter13/spago.yaml
@@ -1,0 +1,15 @@
+package:
+  dependencies:
+    - arrays
+    - console
+    - effect
+    - foldable-traversable
+    - functions
+    - lists
+    - prelude
+    - quickcheck
+  name: my-project
+workspace:
+  extraPackages: {}
+  packageSet:
+    url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json

--- a/exercises/chapter14/spago.lock
+++ b/exercises/chapter14/spago.lock
@@ -57,3440 +57,440 @@ workspace:
         - unsafe-coerce
   package_set:
     address:
-      url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
-    compiler: ">=0.15.0 <0.16.0"
+      registry: 10.0.0
+    compiler: ">=0.15.4 <0.16.0"
     content:
-      ace:
-        repo: https://github.com/purescript-contrib/purescript-ace.git
-        version: v9.0.0
-        dependencies:
-          - arrays
-          - effect
-          - foreign
-          - nullable
-          - prelude
-          - web-html
-          - web-uievents
-      aff:
-        repo: https://github.com/purescript-contrib/purescript-aff.git
-        version: v7.0.0
-        dependencies:
-          - datetime
-          - effect
-          - exceptions
-          - functions
-          - parallel
-          - transformers
-          - unsafe-coerce
-      aff-bus:
-        repo: https://github.com/purescript-contrib/purescript-aff-bus.git
-        version: v6.0.0
-        dependencies:
-          - aff
-          - avar
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - lists
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-      aff-coroutines:
-        repo: https://github.com/purescript-contrib/purescript-aff-coroutines.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - avar
-          - coroutines
-          - effect
-      aff-promise:
-        repo: https://github.com/nwolverson/purescript-aff-promise.git
-        version: v4.0.0
-        dependencies:
-          - aff
-          - foreign
-      aff-retry:
-        repo: https://github.com/Unisay/purescript-aff-retry.git
-        version: v2.0.0
-        dependencies:
-          - aff
-          - arrays
-          - datetime
-          - effect
-          - either
-          - exceptions
-          - integers
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - random
-          - transformers
-      affjax:
-        repo: https://github.com/purescript-contrib/purescript-affjax.git
-        version: v13.0.0
-        dependencies:
-          - aff
-          - argonaut-core
-          - arraybuffer-types
-          - foreign
-          - form-urlencoded
-          - http-methods
-          - integers
-          - media-types
-          - nullable
-          - refs
-          - unsafe-coerce
-          - web-xhr
-      affjax-node:
-        repo: https://github.com/purescript-contrib/purescript-affjax-node.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - affjax
-          - either
-          - maybe
-          - prelude
-      affjax-web:
-        repo: https://github.com/purescript-contrib/purescript-affjax-web.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - affjax
-          - either
-          - maybe
-          - prelude
-      ansi:
-        repo: https://github.com/hdgarrood/purescript-ansi.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - lists
-          - strings
-      argonaut:
-        repo: https://github.com/purescript-contrib/purescript-argonaut.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - argonaut-traversals
-      argonaut-codecs:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-codecs.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-core
-          - arrays
-          - effect
-          - foreign-object
-          - identity
-          - integers
-          - maybe
-          - nonempty
-          - ordered-collections
-          - prelude
-          - record
-      argonaut-core:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-core.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - foreign-object
-          - functions
-          - gen
-          - maybe
-          - nonempty
-          - prelude
-          - strings
-          - tailrec
-      argonaut-generic:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-generic.git
-        version: v8.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - prelude
-          - record
-      argonaut-traversals:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-traversals.git
-        version: v10.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - profunctor-lenses
-      argparse-basic:
-        repo: https://github.com/natefaubion/purescript-argparse-basic.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - record
-          - strings
-          - tuples
-          - unfoldable
-      arraybuffer:
-        repo: https://github.com/purescript-contrib/purescript-arraybuffer.git
-        version: v13.0.0
-        dependencies:
-          - arraybuffer-types
-          - arrays
-          - effect
-          - float32
-          - functions
-          - gen
-          - maybe
-          - nullable
-          - prelude
-          - tailrec
-          - uint
-          - unfoldable
-      arraybuffer-builder:
-        repo: https://github.com/jamesdbrock/purescript-arraybuffer-builder.git
-        version: v3.0.1
-        dependencies:
-          - arraybuffer
-          - arraybuffer-types
-          - effect
-          - float32
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - transformers
-          - uint
-      arraybuffer-types:
-        repo: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
-        version: v3.0.2
-        dependencies: []
-      arrays:
-        repo: https://github.com/purescript/purescript-arrays.git
-        version: v7.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - foldable-traversable
-          - maybe
-          - nonempty
-          - partial
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - unfoldable
-          - unsafe-coerce
-      arrays-zipper:
-        repo: https://github.com/JordanMartinez/purescript-arrays-zipper.git
-        version: v2.0.1
-        dependencies:
-          - arrays
-          - control
-          - quickcheck
-      ask:
-        repo: https://github.com/Mateiadrielrafael/purescript-ask.git
-        version: v1.0.0
-        dependencies:
-          - unsafe-coerce
-      assert:
-        repo: https://github.com/purescript/purescript-assert.git
-        version: v6.0.0
-        dependencies:
-          - console
-          - effect
-          - prelude
-      avar:
-        repo: https://github.com/purescript-contrib/purescript-avar.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - exceptions
-          - functions
-          - maybe
-      b64:
-        repo: https://github.com/menelaos/purescript-b64.git
-        version: v0.0.8
-        dependencies:
-          - arraybuffer-types
-          - either
-          - encoding
-          - enums
-          - exceptions
-          - functions
-          - partial
-          - prelude
-          - strings
-      barlow-lens:
-        repo: https://github.com/sigma-andex/purescript-barlow-lens.git
-        version: v0.9.0
-        dependencies:
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - profunctor-lenses
-          - tuples
-          - typelevel-prelude
-      bifunctors:
-        repo: https://github.com/purescript/purescript-bifunctors.git
-        version: v6.0.0
-        dependencies:
-          - const
-          - either
-          - newtype
-          - prelude
-          - tuples
-      bigints:
-        repo: https://github.com/sharkdp/purescript-bigints.git
-        version: v7.0.1
-        dependencies:
-          - integers
-          - maybe
-          - strings
-      bower-json:
-        repo: https://github.com/klntsky/purescript-bower-json.git
-        version: v3.0.0
-        dependencies:
-          - argonaut-codecs
-          - arrays
-          - either
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - newtype
-          - prelude
-          - tuples
-      call-by-name:
-        repo: https://github.com/natefaubion/purescript-call-by-name.git
-        version: v4.0.1
-        dependencies:
-          - control
-          - either
-          - lazy
-          - maybe
-          - unsafe-coerce
-      canvas:
-        repo: https://github.com/purescript-web/purescript-canvas.git
-        version: v6.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - exceptions
-          - functions
-          - maybe
-      canvas-action:
-        repo: https://github.com/artemisSystem/purescript-canvas-action.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - arrays
-          - canvas
-          - colors
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - maybe
-          - numbers
-          - polymorphic-vectors
-          - prelude
-          - refs
-          - run
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-html
-      cartesian:
-        repo: https://github.com/Ebmtranceboy/purescript-cartesian.git
-        version: v1.0.6
-        dependencies:
-          - console
-          - effect
-          - integers
-          - psci-support
-      catenable-lists:
-        repo: https://github.com/purescript/purescript-catenable-lists.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - lists
-          - maybe
-          - prelude
-          - tuples
-          - unfoldable
-      channel:
-        repo: https://github.com/ConnorDillon/purescript-channel.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - assert
-          - avar
-          - console
-          - contravariant
-          - control
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - lazy
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      checked-exceptions:
-        repo: https://github.com/natefaubion/purescript-checked-exceptions.git
-        version: v3.1.1
-        dependencies:
-          - prelude
-          - transformers
-          - variant
-      codec:
-        repo: https://github.com/garyb/purescript-codec.git
-        version: v5.0.0
-        dependencies:
-          - profunctor
-          - transformers
-      codec-argonaut:
-        repo: https://github.com/garyb/purescript-codec-argonaut.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-core
-          - codec
-          - ordered-collections
-          - type-equality
-          - variant
-      colors:
-        repo: https://github.com/purescript-contrib/purescript-colors.git
-        version: v7.0.1
-        dependencies:
-          - arrays
-          - integers
-          - lists
-          - numbers
-          - partial
-          - strings
-      concurrent-queues:
-        repo: https://github.com/purescript-contrib/purescript-concurrent-queues.git
-        version: v3.0.0
-        dependencies:
-          - aff
-          - avar
-          - effect
-      console:
-        repo: https://github.com/purescript/purescript-console.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - prelude
-      const:
-        repo: https://github.com/purescript/purescript-const.git
-        version: v6.0.0
-        dependencies:
-          - invariant
-          - newtype
-          - prelude
-      contravariant:
-        repo: https://github.com/purescript/purescript-contravariant.git
-        version: v6.0.0
-        dependencies:
-          - const
-          - either
-          - newtype
-          - prelude
-          - tuples
-      control:
-        repo: https://github.com/purescript/purescript-control.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      convertable-options:
-        repo: https://github.com/natefaubion/purescript-convertable-options.git
-        version: v1.0.0
-        dependencies:
-          - console
-          - effect
-          - maybe
-          - record
-      coroutines:
-        repo: https://github.com/purescript-contrib/purescript-coroutines.git
-        version: v7.0.0
-        dependencies:
-          - freet
-          - parallel
-          - profunctor
-      css:
-        repo: https://github.com/purescript-contrib/purescript-css.git
-        version: v6.0.0
-        dependencies:
-          - colors
-          - console
-          - effect
-          - nonempty
-          - profunctor
-          - strings
-          - these
-          - transformers
-      datetime:
-        repo: https://github.com/purescript/purescript-datetime.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - either
-          - enums
-          - foldable-traversable
-          - functions
-          - gen
-          - integers
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - ordered-collections
-          - partial
-          - prelude
-          - tuples
-      datetime-parsing:
-        repo: https://github.com/flounders/purescript-datetime-parsing.git
-        version: v0.2.0
-        dependencies:
-          - arrays
-          - datetime
-          - either
-          - enums
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - numbers
-          - parsing
-          - prelude
-          - strings
-          - unicode
-      debug:
-        repo: https://github.com/garyb/purescript-debug.git
-        version: v6.0.0
-        dependencies:
-          - functions
-          - prelude
-      decimals:
-        repo: https://github.com/sharkdp/purescript-decimals.git
-        version: v7.0.0
-        dependencies:
-          - maybe
-      dissect:
-        repo: https://github.com/PureFunctor/purescript-dissect.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - foreign-object
-          - functors
-          - newtype
-          - partial
-          - prelude
-          - tailrec
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - variant
-      distributive:
-        repo: https://github.com/purescript/purescript-distributive.git
-        version: v6.0.0
-        dependencies:
-          - identity
-          - newtype
-          - prelude
-          - tuples
-          - type-equality
-      dodo-printer:
-        repo: https://github.com/natefaubion/purescript-dodo-printer.git
-        version: v2.2.0
-        dependencies:
-          - aff
-          - ansi
-          - avar
-          - console
-          - effect
-          - foldable-traversable
-          - lists
-          - maybe
-          - minibench
-          - node-child-process
-          - node-fs-aff
-          - node-process
-          - psci-support
-          - strings
-      dom-indexed:
-        repo: https://github.com/purescript-halogen/purescript-dom-indexed.git
-        version: v11.0.0
-        dependencies:
-          - media-types
-          - prelude
-          - web-clipboard
-          - web-pointerevents
-          - web-touchevents
-      droplet:
-        repo: https://github.com/easafe/purescript-droplet.git
-        version: v0.4.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - bigints
-          - datetime
-          - debug
-          - effect
-          - either
-          - enums
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - integers
-          - maybe
-          - newtype
-          - nullable
-          - ordered-collections
-          - partial
-          - prelude
-          - profunctor
-          - record
-          - spec
-          - strings
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-      dynamic-buffer:
-        repo: https://github.com/kritzcreek/purescript-dynamic-buffer.git
-        version: v3.0.1
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - refs
-      effect:
-        repo: https://github.com/purescript/purescript-effect.git
-        version: v4.0.0
-        dependencies:
-          - prelude
-      either:
-        repo: https://github.com/purescript/purescript-either.git
-        version: v6.1.0
-        dependencies:
-          - control
-          - invariant
-          - maybe
-          - prelude
-      elmish:
-        repo: https://github.com/collegevine/purescript-elmish.git
-        version: v0.8.1
-        dependencies:
-          - aff
-          - argonaut-core
-          - arrays
-          - bifunctors
-          - console
-          - debug
-          - effect
-          - either
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - functions
-          - integers
-          - js-date
-          - maybe
-          - nullable
-          - partial
-          - prelude
-          - refs
-          - typelevel-prelude
-          - undefined-is-not-a-problem
-          - unsafe-coerce
-          - web-dom
-          - web-html
-      elmish-enzyme:
-        repo: https://github.com/collegevine/purescript-elmish-enzyme.git
-        version: v0.1.1
-        dependencies:
-          - aff
-          - aff-promise
-          - arrays
-          - console
-          - debug
-          - effect
-          - elmish
-          - foldable-traversable
-          - foreign
-          - functions
-          - prelude
-          - transformers
-          - unsafe-coerce
-      elmish-hooks:
-        repo: https://github.com/collegevine/purescript-elmish-hooks.git
-        version: v0.8.2
-        dependencies:
-          - aff
-          - debug
-          - elmish
-          - maybe
-          - prelude
-          - tuples
-          - undefined-is-not-a-problem
-      elmish-html:
-        repo: https://github.com/collegevine/purescript-elmish-html.git
-        version: v0.7.1
-        dependencies:
-          - effect
-          - elmish
-          - foreign
-          - foreign-object
-          - prelude
-          - record
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-html
-      email-validate:
-        repo: https://github.com/cdepillabout/purescript-email-validate.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - string-parsers
-          - transformers
-      encoding:
-        repo: https://github.com/menelaos/purescript-encoding.git
-        version: v0.0.8
-        dependencies:
-          - arraybuffer-types
-          - either
-          - exceptions
-          - functions
-          - prelude
-      enums:
-        repo: https://github.com/purescript/purescript-enums.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - either
-          - gen
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tuples
-          - unfoldable
-      exceptions:
-        repo: https://github.com/purescript/purescript-exceptions.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - either
-          - maybe
-          - prelude
-      exists:
-        repo: https://github.com/purescript/purescript-exists.git
-        version: v6.0.0
-        dependencies:
-          - unsafe-coerce
-      exitcodes:
-        repo: https://github.com/Risto-Stevcev/purescript-exitcodes.git
-        version: v4.0.0
-        dependencies:
-          - enums
-      expect-inferred:
-        repo: https://github.com/justinwoo/purescript-expect-inferred.git
-        version: v3.0.0
-        dependencies:
-          - prelude
-          - typelevel-prelude
-      fast-vect:
-        repo: https://github.com/sigma-andex/purescript-fast-vect.git
-        version: v0.7.0
-        dependencies:
-          - arrays
-          - filterable
-          - foldable-traversable
-          - lists
-          - maybe
-          - ordered-collections
-          - prelude
-          - profunctor
-          - tuples
-          - unfoldable
-      filterable:
-        repo: https://github.com/purescript/purescript-filterable.git
-        version: v5.0.0
-        dependencies:
-          - arrays
-          - either
-          - foldable-traversable
-          - identity
-          - lists
-          - ordered-collections
-      fixed-points:
-        repo: https://github.com/purescript-contrib/purescript-fixed-points.git
-        version: v7.0.0
-        dependencies:
-          - exists
-          - newtype
-          - prelude
-          - transformers
-      fixed-precision:
-        repo: https://github.com/lumihq/purescript-fixed-precision.git
-        version: v5.0.0
-        dependencies:
-          - arrays
-          - bigints
-          - control
-          - integers
-          - maybe
-          - numbers
-          - partial
-          - prelude
-          - strings
-      flame:
-        repo: https://github.com/easafe/purescript-flame.git
-        version: v1.2.0
-        dependencies:
-          - aff
-          - argonaut-codecs
-          - argonaut-core
-          - argonaut-generic
-          - arrays
-          - bifunctors
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - maybe
-          - newtype
-          - nullable
-          - partial
-          - prelude
-          - random
-          - refs
-          - spec
-          - strings
-          - tuples
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-html
-          - web-uievents
-      float32:
-        repo: https://github.com/purescript-contrib/purescript-float32.git
-        version: v2.0.0
-        dependencies:
-          - gen
-          - maybe
-          - prelude
-      foldable-traversable:
-        repo: https://github.com/purescript/purescript-foldable-traversable.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - const
-          - control
-          - either
-          - functors
-          - identity
-          - maybe
-          - newtype
-          - orders
-          - prelude
-          - tuples
-      foreign:
-        repo: https://github.com/purescript/purescript-foreign.git
-        version: v7.0.0
-        dependencies:
-          - either
-          - functions
-          - identity
-          - integers
-          - lists
-          - maybe
-          - prelude
-          - strings
-          - transformers
-      foreign-object:
-        repo: https://github.com/purescript/purescript-foreign-object.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - functions
-          - gen
-          - lists
-          - maybe
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - typelevel-prelude
-          - unfoldable
-      foreign-readwrite:
-        repo: https://github.com/artemisSystem/purescript-foreign-readwrite.git
-        version: v3.0.0
-        dependencies:
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - record
-          - safe-coerce
-          - transformers
-          - unsafe-coerce
-      fork:
-        repo: https://github.com/purescript-contrib/purescript-fork.git
-        version: v6.0.0
-        dependencies:
-          - aff
-      form-urlencoded:
-        repo: https://github.com/purescript-contrib/purescript-form-urlencoded.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - js-uri
-          - maybe
-          - newtype
-          - prelude
-          - strings
-          - tuples
-      formatters:
-        repo: https://github.com/purescript-contrib/purescript-formatters.git
-        version: v7.0.0
-        dependencies:
-          - datetime
-          - fixed-points
-          - lists
-          - numbers
-          - parsing
-          - prelude
-          - transformers
-      free:
-        repo: https://github.com/purescript/purescript-free.git
-        version: v7.0.0
-        dependencies:
-          - catenable-lists
-          - control
-          - distributive
-          - either
-          - exists
-          - foldable-traversable
-          - invariant
-          - lazy
-          - maybe
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-      freeap:
-        repo: https://github.com/ethul/purescript-freeap.git
-        version: v7.0.0
-        dependencies:
-          - const
-          - exists
-          - gen
-          - lists
-      freet:
-        repo: https://github.com/purescript-contrib/purescript-freet.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - bifunctors
-          - effect
-          - either
-          - exists
-          - free
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      functions:
-        repo: https://github.com/purescript/purescript-functions.git
-        version: v6.0.0
-        dependencies:
-          - prelude
-      functors:
-        repo: https://github.com/purescript/purescript-functors.git
-        version: v5.0.0
-        dependencies:
-          - bifunctors
-          - const
-          - contravariant
-          - control
-          - distributive
-          - either
-          - invariant
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - tuples
-          - unsafe-coerce
-      fuzzy:
-        repo: https://github.com/citizennet/purescript-fuzzy.git
-        version: v0.4.0
-        dependencies:
-          - foldable-traversable
-          - foreign-object
-          - newtype
-          - ordered-collections
-          - prelude
-          - rationals
-          - strings
-          - tuples
-      gen:
-        repo: https://github.com/purescript/purescript-gen.git
-        version: v4.0.0
-        dependencies:
-          - either
-          - foldable-traversable
-          - identity
-          - maybe
-          - newtype
-          - nonempty
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      generate-values:
-        repo: https://github.com/jordanmartinez/purescript-generate-values.git
-        version: v1.0.1
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - enums
-          - foldable-traversable
-          - gen
-          - identity
-          - integers
-          - lcg
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - partial
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      geometry-plane:
-        repo: https://github.com/Ebmtranceboy/purescript-geometry-plane.git
-        version: v1.0.3
-        dependencies:
-          - console
-          - effect
-          - psci-support
-          - sparse-polynomials
-      github-actions-toolkit:
-        repo: https://github.com/purescript-contrib/purescript-github-actions-toolkit.git
-        version: v0.5.0
-        dependencies:
-          - aff
-          - aff-promise
-          - effect
-          - foreign-object
-          - node-buffer
-          - node-path
-          - node-streams
-          - nullable
-          - transformers
-      graphs:
-        repo: https://github.com/purescript/purescript-graphs.git
-        version: v8.0.0
-        dependencies:
-          - catenable-lists
-          - ordered-collections
-      group:
-        repo: https://github.com/morganthomas/purescript-group.git
-        version: v4.1.1
-        dependencies:
-          - lists
-      halogen:
-        repo: https://github.com/purescript-halogen/purescript-halogen.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - avar
-          - console
-          - const
-          - dom-indexed
-          - effect
-          - foreign
-          - fork
-          - free
-          - freeap
-          - halogen-subscriptions
-          - halogen-vdom
-          - media-types
-          - nullable
-          - ordered-collections
-          - parallel
-          - profunctor
-          - transformers
-          - unsafe-coerce
-          - unsafe-reference
-          - web-file
-          - web-uievents
-      halogen-css:
-        repo: https://github.com/purescript-halogen/purescript-halogen-css.git
-        version: v10.0.0
-        dependencies:
-          - css
-          - halogen
-      halogen-formless:
-        repo: https://github.com/thomashoneyman/purescript-halogen-formless.git
-        version: v4.0.0
-        dependencies:
-          - convertable-options
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - halogen
-          - heterogeneous
-          - maybe
-          - prelude
-          - record
-          - safe-coerce
-          - type-equality
-          - unsafe-coerce
-          - unsafe-reference
-          - variant
-          - web-events
-          - web-uievents
-      halogen-hooks:
-        repo: https://github.com/thomashoneyman/purescript-halogen-hooks.git
-        version: v0.6.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - effect
-          - exceptions
-          - foldable-traversable
-          - foreign-object
-          - free
-          - freeap
-          - halogen
-          - halogen-subscriptions
-          - maybe
-          - newtype
-          - ordered-collections
-          - parallel
-          - partial
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-          - unsafe-reference
-          - web-dom
-          - web-html
-      halogen-hooks-extra:
-        repo: https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git
-        version: v0.9.0
-        dependencies:
-          - halogen-hooks
-      halogen-store:
-        repo: https://github.com/thomashoneyman/purescript-halogen-store.git
-        version: v0.5.0
-        dependencies:
-          - aff
-          - distributive
-          - effect
-          - fork
-          - halogen
-          - halogen-hooks
-          - halogen-subscriptions
-          - maybe
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-reference
-      halogen-storybook:
-        repo: https://github.com/rnons/purescript-halogen-storybook.git
-        version: v2.0.0
-        dependencies:
-          - foreign-object
-          - halogen
-          - prelude
-          - routing
-      halogen-subscriptions:
-        repo: https://github.com/purescript-halogen/purescript-halogen-subscriptions.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - effect
-          - foldable-traversable
-          - functors
-          - refs
-          - safe-coerce
-          - unsafe-reference
-      halogen-svg-elems:
-        repo: https://github.com/JordanMartinez/purescript-halogen-svg-elems.git
-        version: v6.0.0
-        dependencies:
-          - halogen
-      halogen-vdom:
-        repo: https://github.com/purescript-halogen/purescript-halogen-vdom.git
-        version: v8.0.0
-        dependencies:
-          - bifunctors
-          - effect
-          - foreign
-          - foreign-object
-          - maybe
-          - prelude
-          - refs
-          - tuples
-          - unsafe-coerce
-          - web-html
-      halogen-vdom-string-renderer:
-        repo: https://github.com/purescript-halogen/purescript-halogen-vdom-string-renderer.git
-        version: v0.5.0
-        dependencies:
-          - foreign
-          - halogen-vdom
-          - ordered-collections
-          - prelude
-      heckin:
-        repo: https://github.com/maxdeviant/purescript-heckin.git
-        version: v2.0.1
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - maybe
-          - prelude
-          - strings
-          - transformers
-          - tuples
-          - unicode
-      heterogeneous:
-        repo: https://github.com/natefaubion/purescript-heterogeneous.git
-        version: v0.6.0
-        dependencies:
-          - either
-          - functors
-          - prelude
-          - record
-          - tuples
-          - variant
-      heterogeneous-extrablatt:
-        repo: https://github.com/sigma-andex/purescript-heterogeneous-extrablatt.git
-        version: v0.2.1
-        dependencies:
-          - heterogeneous
-          - prelude
-          - record
-      http-methods:
-        repo: https://github.com/purescript-contrib/purescript-http-methods.git
-        version: v6.0.0
-        dependencies:
-          - either
-          - prelude
-          - strings
-      httpure:
-        repo: https://github.com/citizennet/purescript-httpure.git
-        version: v0.15.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - js-uri
-          - maybe
-          - newtype
-          - node-buffer
-          - node-fs
-          - node-http
-          - node-streams
-          - options
-          - ordered-collections
-          - prelude
-          - refs
-          - strings
-          - tuples
-          - type-equality
-      httpurple:
-        repo: https://github.com/sigma-andex/purescript-httpurple.git
-        version: v1.3.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - js-uri
-          - justifill
-          - maybe
-          - newtype
-          - node-buffer
-          - node-fs
-          - node-http
-          - node-net
-          - node-process
-          - node-streams
-          - options
-          - ordered-collections
-          - posix-types
-          - prelude
-          - profunctor
-          - record
-          - refs
-          - routing-duplex
-          - strings
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-      httpurple-argonaut:
-        repo: https://github.com/sigma-andex/purescript-httpurple-argonaut.git
-        version: v1.0.1
-        dependencies:
-          - argonaut
-          - console
-          - effect
-          - either
-          - httpurple
-          - prelude
-      httpurple-yoga-json:
-        repo: https://github.com/sigma-andex/purescript-httpurple-yoga-json.git
-        version: v1.0.0
-        dependencies:
-          - console
-          - effect
-          - either
-          - foreign
-          - httpurple
-          - lists
-          - prelude
-          - yoga-json
-      identity:
-        repo: https://github.com/purescript/purescript-identity.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - invariant
-          - newtype
-          - prelude
-      indexed-monad:
-        repo: https://github.com/garyb/purescript-indexed-monad.git
-        version: v2.1.0
-        dependencies:
-          - control
-          - newtype
-      int64:
-        repo: https://github.com/purescript-contrib/purescript-int64.git
-        version: v2.0.0
-        dependencies:
-          - effect
-          - foreign
-          - functions
-          - integers
-          - maybe
-          - nullable
-          - prelude
-          - quickcheck
-      integers:
-        repo: https://github.com/purescript/purescript-integers.git
-        version: v6.0.0
-        dependencies:
-          - maybe
-          - numbers
-          - prelude
-      interpolate:
-        repo: https://github.com/jordanmartinez/purescript-interpolate.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-      invariant:
-        repo: https://github.com/purescript/purescript-invariant.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - prelude
-      js-date:
-        repo: https://github.com/purescript-contrib/purescript-js-date.git
-        version: v8.0.0
-        dependencies:
-          - datetime
-          - effect
-          - exceptions
-          - foreign
-          - integers
-          - now
-      js-fileio:
-        repo: https://github.com/newlandsvalley/purescript-js-fileio.git
-        version: v3.0.0
-        dependencies:
-          - aff
-          - effect
-          - prelude
-      js-timers:
-        repo: https://github.com/purescript-contrib/purescript-js-timers.git
-        version: v6.1.0
-        dependencies:
-          - effect
-      js-uri:
-        repo: https://github.com/purescript-contrib/purescript-js-uri.git
-        version: v3.0.0
-        dependencies:
-          - functions
-          - maybe
-      justifill:
-        repo: https://github.com/i-am-the-slime/purescript-justifill.git
-        version: v0.5.0
-        dependencies:
-          - maybe
-          - prelude
-          - record
-          - typelevel-prelude
-      jwt:
-        repo: https://github.com/menelaos/purescript-jwt.git
-        version: v0.0.9
-        dependencies:
-          - argonaut-core
-          - arrays
-          - b64
-          - either
-          - exceptions
-          - prelude
-          - profunctor-lenses
-          - strings
-      language-cst-parser:
-        repo: https://github.com/natefaubion/purescript-language-cst-parser.git
-        version: v0.12.0
-        dependencies:
-          - arrays
-          - const
-          - control
-          - either
-          - foldable-traversable
-          - free
-          - functions
-          - functors
-          - identity
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - ordered-collections
-          - partial
-          - prelude
-          - st
-          - strings
-          - transformers
-          - tuples
-          - typelevel-prelude
-          - unfoldable
-          - unsafe-coerce
-      lazy:
-        repo: https://github.com/purescript/purescript-lazy.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - invariant
-          - prelude
-      lcg:
-        repo: https://github.com/purescript/purescript-lcg.git
-        version: v4.0.0
-        dependencies:
-          - effect
-          - integers
-          - maybe
-          - partial
-          - prelude
-          - random
-      leibniz:
-        repo: https://github.com/paf31/purescript-leibniz.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-          - unsafe-coerce
-      linalg:
-        repo: https://github.com/gbagan/purescript-linalg.git
-        version: v5.1.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - functions
-          - maybe
-          - prelude
-          - tuples
-      lists:
-        repo: https://github.com/purescript/purescript-lists.git
-        version: v7.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - foldable-traversable
-          - lazy
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      logging:
-        repo: https://github.com/rightfold/purescript-logging.git
-        version: v3.0.0
-        dependencies:
-          - console
-          - contravariant
-          - effect
-          - either
-          - prelude
-          - transformers
-          - tuples
-      machines:
-        repo: https://github.com/purescript-contrib/purescript-machines.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - lists
-          - maybe
-          - prelude
-          - profunctor
-          - tuples
-          - unfoldable
-      matrices:
-        repo: https://github.com/kRITZCREEK/purescript-matrices.git
-        version: v5.0.1
-        dependencies:
-          - arrays
-          - strings
-      matryoshka:
-        repo: https://github.com/purescript-contrib/purescript-matryoshka.git
-        version: v1.0.0
-        dependencies:
-          - fixed-points
-          - free
-          - prelude
-          - profunctor
-          - transformers
-      maybe:
-        repo: https://github.com/purescript/purescript-maybe.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - invariant
-          - newtype
-          - prelude
-      media-types:
-        repo: https://github.com/purescript-contrib/purescript-media-types.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      metadata:
-        repo: https://github.com/purescript/purescript-metadata.git
-        version: v0.15.0
-        dependencies: []
-      midi:
-        repo: https://github.com/newlandsvalley/purescript-midi.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - ordered-collections
-          - prelude
-          - signal
-          - string-parsers
-          - strings
-          - tuples
-          - unfoldable
-      minibench:
-        repo: https://github.com/purescript/purescript-minibench.git
-        version: v4.0.0
-        dependencies:
-          - console
-          - effect
-          - integers
-          - numbers
-          - partial
-          - prelude
-          - refs
-      mmorph:
-        repo: https://github.com/Thimoteus/purescript-mmorph.git
-        version: v7.0.0
-        dependencies:
-          - free
-          - functors
-          - transformers
-      monad-control:
-        repo: https://github.com/athanclark/purescript-monad-control.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - freet
-          - identity
-          - lists
-      monad-logger:
-        repo: https://github.com/cprussin/purescript-monad-logger.git
-        version: v1.3.1
-        dependencies:
-          - aff
-          - ansi
-          - argonaut
-          - arrays
-          - console
-          - control
-          - effect
-          - foldable-traversable
-          - foreign-object
-          - integers
-          - js-date
-          - maybe
-          - newtype
-          - ordered-collections
-          - prelude
-          - strings
-          - transformers
-          - tuples
-      monad-loops:
-        repo: https://github.com/mlang/purescript-monad-loops.git
-        version: v0.5.0
-        dependencies:
-          - lists
-          - maybe
-          - prelude
-          - tailrec
-          - tuples
-      monad-unlift:
-        repo: https://github.com/athanclark/purescript-monad-unlift.git
-        version: v1.0.1
-        dependencies:
-          - monad-control
-      monoidal:
-        repo: https://github.com/mcneissue/purescript-monoidal.git
-        version: v0.16.0
-        dependencies:
-          - either
-          - profunctor
-          - these
-          - tuples
-      morello:
-        repo: https://github.com/sigma-andex/purescript-morello.git
-        version: v0.3.2
-        dependencies:
-          - arrays
-          - barlow-lens
-          - foldable-traversable
-          - heterogeneous
-          - heterogeneous-extrablatt
-          - newtype
-          - prelude
-          - profunctor
-          - profunctor-lenses
-          - record
-          - tuples
-          - typelevel-prelude
-          - validation
-      motsunabe:
-        repo: https://github.com/justinwoo/purescript-motsunabe.git
-        version: v2.0.0
-        dependencies:
-          - lists
-          - strings
-      nano-id:
-        repo: https://github.com/eikooc/nano-id.git
-        version: v1.1.0
-        dependencies:
-          - aff
-          - effect
-          - lists
-          - maybe
-          - prelude
-          - random
-          - spec
-          - strings
-          - stringutils
-      naturals:
-        repo: https://github.com/LiamGoodacre/purescript-naturals.git
-        version: v3.0.0
-        dependencies:
-          - enums
-          - maybe
-          - prelude
-      nested-functor:
-        repo: https://github.com/acple/purescript-nested-functor.git
-        version: v0.2.1
-        dependencies:
-          - prelude
-          - type-equality
-      newtype:
-        repo: https://github.com/purescript/purescript-newtype.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-          - safe-coerce
-      node-buffer:
-        repo: https://github.com/purescript-node/purescript-node-buffer.git
-        version: v8.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - maybe
-          - st
-          - unsafe-coerce
-      node-buffer-blob:
-        repo: https://github.com/purescript-node/purescript-node-buffer-blob.git
-        version: v1.0.0
-        dependencies:
-          - aff-promise
-          - arraybuffer-types
-          - arrays
-          - console
-          - effect
-          - maybe
-          - media-types
-          - newtype
-          - node-buffer
-          - nullable
-          - prelude
-          - web-streams
-      node-child-process:
-        repo: https://github.com/purescript-node/purescript-node-child-process.git
-        version: v9.0.0
-        dependencies:
-          - exceptions
-          - foreign
-          - foreign-object
-          - functions
-          - node-fs
-          - node-streams
-          - nullable
-          - posix-types
-          - unsafe-coerce
-      node-fs:
-        repo: https://github.com/purescript-node/purescript-node-fs.git
-        version: v8.0.0
-        dependencies:
-          - datetime
-          - effect
-          - either
-          - enums
-          - exceptions
-          - functions
-          - integers
-          - js-date
-          - maybe
-          - node-buffer
-          - node-path
-          - node-streams
-          - nullable
-          - partial
-          - prelude
-          - strings
-          - unsafe-coerce
-      node-fs-aff:
-        repo: https://github.com/purescript-node/purescript-node-fs-aff.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - either
-          - node-fs
-          - node-path
-      node-http:
-        repo: https://github.com/purescript-node/purescript-node-http.git
-        version: v8.0.0
-        dependencies:
-          - arraybuffer-types
-          - contravariant
-          - effect
-          - foreign
-          - foreign-object
-          - maybe
-          - node-buffer
-          - node-net
-          - node-streams
-          - node-url
-          - nullable
-          - options
-          - prelude
-          - unsafe-coerce
-      node-net:
-        repo: https://github.com/purescript-node/purescript-node-net.git
-        version: v4.0.0
-        dependencies:
-          - effect
-          - either
-          - exceptions
-          - foreign
-          - maybe
-          - node-buffer
-          - node-fs
-          - nullable
-          - options
-          - prelude
-          - transformers
-      node-path:
-        repo: https://github.com/purescript-node/purescript-node-path.git
-        version: v5.0.0
-        dependencies:
-          - effect
-      node-process:
-        repo: https://github.com/purescript-node/purescript-node-process.git
-        version: v10.0.0
-        dependencies:
-          - effect
-          - foreign-object
-          - maybe
-          - node-streams
-          - posix-types
-          - prelude
-          - unsafe-coerce
-      node-readline:
-        repo: https://github.com/purescript-node/purescript-node-readline.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - foreign
-          - node-process
-          - node-streams
-          - options
-          - prelude
-      node-streams:
-        repo: https://github.com/purescript-node/purescript-node-streams.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - either
-          - exceptions
-          - node-buffer
-          - nullable
-          - prelude
-      node-streams-aff:
-        repo: https://github.com/jamesdbrock/purescript-node-streams-aff.git
-        version: v2.0.0
-        dependencies:
-          - aff
-          - arrays
-          - effect
-          - either
-          - exceptions
-          - maybe
-          - node-buffer
-          - node-streams
-          - prelude
-          - st
-          - tuples
-      node-url:
-        repo: https://github.com/purescript-node/purescript-node-url.git
-        version: v6.0.0
-        dependencies:
-          - nullable
-      nonempty:
-        repo: https://github.com/purescript/purescript-nonempty.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - maybe
-          - prelude
-          - tuples
-          - unfoldable
-      now:
-        repo: https://github.com/purescript-contrib/purescript-now.git
-        version: v6.0.0
-        dependencies:
-          - datetime
-          - effect
-      npm-package-json:
-        repo: https://github.com/maxdeviant/purescript-npm-package-json.git
-        version: v2.0.0
-        dependencies:
-          - argonaut
-          - control
-          - either
-          - foreign-object
-          - maybe
-          - ordered-collections
-          - prelude
-      nullable:
-        repo: https://github.com/purescript-contrib/purescript-nullable.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - functions
-          - maybe
-      numbers:
-        repo: https://github.com/purescript/purescript-numbers.git
-        version: v9.0.0
-        dependencies:
-          - functions
-          - maybe
-      open-folds:
-        repo: https://github.com/purescript-open-community/purescript-open-folds.git
-        version: v6.3.0
-        dependencies:
-          - bifunctors
-          - console
-          - control
-          - distributive
-          - effect
-          - either
-          - foldable-traversable
-          - identity
-          - invariant
-          - maybe
-          - newtype
-          - ordered-collections
-          - prelude
-          - profunctor
-          - psci-support
-          - tuples
-      open-memoize:
-        repo: https://github.com/purescript-open-community/purescript-open-memoize.git
-        version: v6.1.0
-        dependencies:
-          - console
-          - effect
-          - either
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - psci-support
-          - strings
-          - tuples
-      open-pairing:
-        repo: https://github.com/purescript-open-community/purescript-open-pairing.git
-        version: v6.1.0
-        dependencies:
-          - console
-          - control
-          - effect
-          - either
-          - free
-          - functors
-          - identity
-          - newtype
-          - prelude
-          - psci-support
-          - transformers
-          - tuples
-      options:
-        repo: https://github.com/purescript-contrib/purescript-options.git
-        version: v7.0.0
-        dependencies:
-          - contravariant
-          - foreign
-          - foreign-object
-          - maybe
-          - tuples
-      optparse:
-        repo: https://github.com/f-o-a-m/purescript-optparse.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - control
-          - effect
-          - either
-          - enums
-          - exists
-          - exitcodes
-          - foldable-traversable
-          - free
-          - gen
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - newtype
-          - node-buffer
-          - node-process
-          - node-streams
-          - nonempty
-          - numbers
-          - open-memoize
-          - partial
-          - prelude
-          - quickcheck
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-      ordered-collections:
-        repo: https://github.com/purescript/purescript-ordered-collections.git
-        version: v3.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - gen
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - unfoldable
-      ordered-set:
-        repo: https://github.com/flip111/purescript-ordered-set.git
-        version: v0.4.0
-        dependencies:
-          - argonaut-codecs
-          - arrays
-          - partial
-          - prelude
-          - unfoldable
-      orders:
-        repo: https://github.com/purescript/purescript-orders.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      pairs:
-        repo: https://github.com/sharkdp/purescript-pairs.git
-        version: v9.0.0
-        dependencies:
-          - console
-          - distributive
-          - foldable-traversable
-          - quickcheck
-      parallel:
-        repo: https://github.com/purescript/purescript-parallel.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - functors
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - refs
-          - transformers
-      parsing:
-        repo: https://github.com/purescript-contrib/purescript-parsing.git
-        version: v9.1.0
-        dependencies:
-          - arrays
-          - either
-          - foldable-traversable
-          - identity
-          - integers
-          - lists
-          - maybe
-          - nullable
-          - prelude
-          - strings
-          - transformers
-          - unicode
-      parsing-dataview:
-        repo: https://github.com/jamesdbrock/purescript-parsing-dataview.git
-        version: v3.1.0
-        dependencies:
-          - arraybuffer
-          - arraybuffer-types
-          - effect
-          - float32
-          - maybe
-          - parsing
-          - prelude
-          - transformers
-          - tuples
-          - uint
-      partial:
-        repo: https://github.com/purescript/purescript-partial.git
-        version: v4.0.0
-        dependencies: []
-      pathy:
-        repo: https://github.com/purescript-contrib/purescript-pathy.git
-        version: v9.0.0
-        dependencies:
-          - console
-          - exceptions
-          - lists
-          - partial
-          - profunctor
-          - strings
-          - transformers
-          - typelevel-prelude
-          - unsafe-coerce
-      pha:
-        repo: https://github.com/gbagan/purescript-pha.git
-        version: v0.9.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - datetime
-          - effect
-          - foldable-traversable
-          - free
-          - integers
-          - maybe
-          - prelude
-          - profunctor-lenses
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-          - unsafe-reference
-          - web-dom
-          - web-events
-          - web-html
-          - web-pointerevents
-          - web-uievents
-      phaser:
-        repo: https://github.com/lfarroco/purescript-phaser.git
-        version: v0.6.0
-        dependencies:
-          - canvas
-          - console
-          - effect
-          - maybe
-          - nullable
-          - options
-          - prelude
-          - web-html
-      pipes:
-        repo: https://github.com/felixschl/purescript-pipes.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - lists
-          - mmorph
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      point-free:
-        repo: https://github.com/ursi/purescript-point-free.git
-        version: v1.0.0
-        dependencies:
-          - prelude
-      polymorphic-vectors:
-        repo: https://github.com/artemisSystem/purescript-polymorphic-vectors.git
-        version: v4.0.0
-        dependencies:
-          - distributive
-          - foldable-traversable
-          - numbers
-          - prelude
-          - record
-          - safe-coerce
-          - type-equality
-          - typelevel-prelude
-      posix-types:
-        repo: https://github.com/purescript-node/purescript-posix-types.git
-        version: v6.0.0
-        dependencies:
-          - maybe
-          - prelude
-      precise:
-        repo: https://github.com/purescript-contrib/purescript-precise.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - exceptions
-          - gen
-          - integers
-          - lists
-          - numbers
-          - prelude
-          - strings
-      precise-datetime:
-        repo: https://github.com/awakesecurity/purescript-precise-datetime.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - datetime
-          - decimals
-          - either
-          - enums
-          - foldable-traversable
-          - formatters
-          - integers
-          - js-date
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - strings
-          - tuples
-          - unicode
-      prelude:
-        repo: https://github.com/purescript/purescript-prelude.git
-        version: v6.0.0
-        dependencies: []
-      prettier-printer:
-        repo: https://github.com/paulyoung/purescript-prettier-printer.git
-        version: v3.0.0
-        dependencies:
-          - console
-          - lists
-          - prelude
-          - strings
-          - tuples
-      profunctor:
-        repo: https://github.com/purescript/purescript-profunctor.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - distributive
-          - either
-          - exists
-          - invariant
-          - newtype
-          - prelude
-          - tuples
-      profunctor-lenses:
-        repo: https://github.com/purescript-contrib/purescript-profunctor-lenses.git
-        version: v8.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - const
-          - control
-          - distributive
-          - either
-          - foldable-traversable
-          - foreign-object
-          - functors
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - ordered-collections
-          - partial
-          - prelude
-          - profunctor
-          - record
-          - transformers
-          - tuples
-      protobuf:
-        repo: https://github.com/xc-jp/purescript-protobuf.git
-        version: v4.0.0
-        dependencies:
-          - arraybuffer
-          - arraybuffer-builder
-          - arraybuffer-types
-          - arrays
-          - control
-          - effect
-          - either
-          - enums
-          - exceptions
-          - float32
-          - foldable-traversable
-          - functions
-          - int64
-          - maybe
-          - newtype
-          - parsing
-          - parsing-dataview
-          - prelude
-          - record
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-          - uint
-          - web-encoding
-      ps-cst:
-        repo: https://github.com/purescript-codegen/purescript-ps-cst.git
-        version: v1.2.0
-        dependencies:
-          - ansi
-          - console
-          - dodo-printer
-          - effect
-          - node-fs-aff
-          - node-path
-          - psci-support
-          - record
-          - strings
-      psa-utils:
-        repo: https://github.com/natefaubion/purescript-psa-utils.git
-        version: v8.0.0
-        dependencies:
-          - ansi
-          - argonaut-codecs
-          - argonaut-core
-          - arrays
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - maybe
-          - node-path
-          - ordered-collections
-          - prelude
-          - strings
-          - tuples
-          - unsafe-coerce
-      psc-ide:
-        repo: https://github.com/kRITZCREEK/purescript-psc-ide.git
-        version: v19.0.0
-        dependencies:
-          - aff
-          - argonaut
-          - arrays
-          - console
-          - maybe
-          - node-child-process
-          - node-fs
-          - parallel
-          - random
-      psci-support:
-        repo: https://github.com/purescript/purescript-psci-support.git
-        version: v6.0.0
-        dependencies:
-          - console
-          - effect
-          - prelude
-      qualified-do:
-        repo: https://github.com/artemisSystem/purescript-qualified-do.git
-        version: v2.2.0
-        dependencies:
-          - arrays
-          - control
-          - foldable-traversable
-          - parallel
-          - prelude
-          - unfoldable
-      quantities:
-        repo: https://github.com/sharkdp/purescript-quantities.git
-        version: v12.0.1
-        dependencies:
-          - decimals
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - newtype
-          - nonempty
-          - numbers
-          - pairs
-          - prelude
-          - tuples
-      quickcheck:
-        repo: https://github.com/purescript/purescript-quickcheck.git
-        version: v8.0.1
-        dependencies:
-          - arrays
-          - console
-          - control
-          - effect
-          - either
-          - enums
-          - exceptions
-          - foldable-traversable
-          - gen
-          - identity
-          - integers
-          - lazy
-          - lcg
-          - lists
-          - maybe
-          - newtype
-          - nonempty
-          - numbers
-          - partial
-          - prelude
-          - record
-          - st
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-          - unfoldable
-      quickcheck-combinators:
-        repo: https://github.com/athanclark/purescript-quickcheck-combinators.git
-        version: v0.1.3
-        dependencies:
-          - quickcheck
-          - typelevel
-      quickcheck-laws:
-        repo: https://github.com/purescript-contrib/purescript-quickcheck-laws.git
-        version: v7.0.0
-        dependencies:
-          - enums
-          - quickcheck
-      quickcheck-utf8:
-        repo: https://github.com/openchronology/purescript-quickcheck-utf8.git
-        version: v0.0.0
-        dependencies:
-          - quickcheck
-      quotient:
-        repo: https://github.com/rightfold/purescript-quotient.git
-        version: v3.0.0
-        dependencies:
-          - prelude
-          - quickcheck
-      random:
-        repo: https://github.com/purescript/purescript-random.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - integers
-      rationals:
-        repo: https://github.com/anttih/purescript-rationals.git
-        version: v5.0.0
-        dependencies:
-          - integers
-          - prelude
-      react:
-        repo: https://github.com/purescript-contrib/purescript-react.git
-        version: v10.0.1
-        dependencies:
-          - effect
-          - exceptions
-          - maybe
-          - nullable
-          - prelude
-          - typelevel-prelude
-          - unsafe-coerce
-      react-basic:
-        repo: https://github.com/lumihq/purescript-react-basic.git
-        version: v17.0.0
-        dependencies:
-          - effect
-          - prelude
-          - record
-      react-basic-dom:
-        repo: https://github.com/lumihq/purescript-react-basic-dom.git
-        version: v5.0.0
-        dependencies:
-          - effect
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - nullable
-          - prelude
-          - react-basic
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-file
-          - web-html
-      react-basic-hooks:
-        repo: https://github.com/megamaddu/purescript-react-basic-hooks.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - aff-promise
-          - bifunctors
-          - console
-          - control
-          - datetime
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - functions
-          - indexed-monad
-          - integers
-          - maybe
-          - newtype
-          - now
-          - nullable
-          - ordered-collections
-          - prelude
-          - react-basic
-          - refs
-          - tuples
-          - type-equality
-          - unsafe-coerce
-          - unsafe-reference
-          - web-html
-      react-dom:
-        repo: https://github.com/purescript-contrib/purescript-react-dom.git
-        version: v8.0.0
-        dependencies:
-          - effect
-          - react
-          - web-dom
-      read:
-        repo: https://github.com/truqu/purescript-read.git
-        version: v1.0.1
-        dependencies:
-          - maybe
-          - prelude
-          - strings
-      record:
-        repo: https://github.com/purescript/purescript-record.git
-        version: v4.0.0
-        dependencies:
-          - functions
-          - prelude
-          - unsafe-coerce
-      refined:
-        repo: https://github.com/danieljharvey/purescript-refined.git
-        version: v1.0.0
-        dependencies:
-          - argonaut
-          - effect
-          - prelude
-          - quickcheck
-          - typelevel
-      refs:
-        repo: https://github.com/purescript/purescript-refs.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - prelude
-      remotedata:
-        repo: https://github.com/krisajenkins/purescript-remotedata.git
-        version: v5.0.0
-        dependencies:
-          - bifunctors
-          - either
-          - profunctor-lenses
-      resource:
-        repo: https://github.com/joneshf/purescript-resource.git
-        version: v2.0.1
-        dependencies:
-          - aff
-          - console
-          - control
-          - effect
-          - newtype
-          - prelude
-          - psci-support
-          - refs
-      resourcet:
-        repo: https://github.com/robertdp/purescript-resourcet.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - effect
-          - foldable-traversable
-          - maybe
-          - ordered-collections
-          - parallel
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-      result:
-        repo: https://github.com/ad-si/purescript-result.git
-        version: v1.0.3
-        dependencies:
-          - either
-          - foldable-traversable
-          - prelude
-      return:
-        repo: https://github.com/ursi/purescript-return.git
-        version: v0.2.0
-        dependencies:
-          - foldable-traversable
-          - point-free
-          - prelude
-      ring-modules:
-        repo: https://github.com/f-o-a-m/purescript-ring-modules.git
-        version: v5.0.1
-        dependencies:
-          - prelude
-      routing:
-        repo: https://github.com/purescript-contrib/purescript-routing.git
-        version: v11.0.0
-        dependencies:
-          - aff
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - integers
-          - js-uri
-          - lists
-          - maybe
-          - numbers
-          - partial
-          - prelude
-          - semirings
-          - tuples
-          - validation
-          - web-html
-      routing-duplex:
-        repo: https://github.com/natefaubion/purescript-routing-duplex.git
-        version: v0.6.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - js-uri
-          - lazy
-          - numbers
-          - prelude
-          - profunctor
-          - record
-          - strings
-          - typelevel-prelude
-      run:
-        repo: https://github.com/natefaubion/purescript-run.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - free
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - tailrec
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - variant
-      safe-coerce:
-        repo: https://github.com/purescript/purescript-safe-coerce.git
-        version: v2.0.0
-        dependencies:
-          - unsafe-coerce
-      safely:
-        repo: https://github.com/paf31/purescript-safely.git
-        version: v4.0.1
-        dependencies:
-          - freet
-          - lists
-      selection-foldable:
-        repo: https://github.com/jamieyung/purescript-selection-foldable.git
-        version: v0.2.0
-        dependencies:
-          - filterable
-          - foldable-traversable
-          - maybe
-          - prelude
-      semirings:
-        repo: https://github.com/purescript/purescript-semirings.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - lists
-          - newtype
-          - prelude
-      signal:
-        repo: https://github.com/bodil/purescript-signal.git
-        version: v13.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - foldable-traversable
-          - maybe
-          - prelude
-      simple-emitter:
-        repo: https://github.com/oreshinya/purescript-simple-emitter.git
-        version: v2.0.0
-        dependencies:
-          - ordered-collections
-          - refs
-      sized-matrices:
-        repo: https://github.com/csicar/purescript-sized-matrices.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - distributive
-          - foldable-traversable
-          - maybe
-          - prelude
-          - sized-vectors
-          - strings
-          - typelevel
-          - unfoldable
-          - vectorfield
-      sized-vectors:
-        repo: https://github.com/bodil/purescript-sized-vectors.git
-        version: v5.0.2
-        dependencies:
-          - argonaut
-          - arrays
-          - distributive
-          - foldable-traversable
-          - maybe
-          - prelude
-          - quickcheck
-          - typelevel
-          - unfoldable
-      slug:
-        repo: https://github.com/thomashoneyman/purescript-slug.git
-        version: v3.0.1
-        dependencies:
-          - argonaut-codecs
-          - maybe
-          - prelude
-          - strings
-          - unicode
-      soundfonts:
-        repo: https://github.com/newlandsvalley/purescript-soundfonts.git
-        version: v4.1.0
-        dependencies:
-          - aff
-          - affjax
-          - affjax-web
-          - argonaut-core
-          - arraybuffer-types
-          - arrays
-          - b64
-          - bifunctors
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign-object
-          - http-methods
-          - integers
-          - lists
-          - maybe
-          - midi
-          - ordered-collections
-          - parallel
-          - partial
-          - prelude
-          - strings
-          - transformers
-          - tuples
-      sparse-matrices:
-        repo: https://github.com/Ebmtranceboy/purescript-sparse-matrices.git
-        version: v1.2.1
-        dependencies:
-          - console
-          - effect
-          - prelude
-          - sparse-polynomials
-      sparse-polynomials:
-        repo: https://github.com/Ebmtranceboy/purescript-sparse-polynomials.git
-        version: v1.0.5
-        dependencies:
-          - cartesian
-          - console
-          - effect
-          - ordered-collections
-          - prelude
-          - rationals
-          - tuples
-      spec:
-        repo: https://github.com/purescript-spec/purescript-spec.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - ansi
-          - avar
-          - console
-          - exceptions
-          - foldable-traversable
-          - fork
-          - now
-          - pipes
-          - prelude
-          - strings
-          - transformers
-      spec-discovery:
-        repo: https://github.com/purescript-spec/purescript-spec-discovery.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - aff-promise
-          - arrays
-          - console
-          - effect
-          - foldable-traversable
-          - node-fs
-          - prelude
-          - spec
-      spec-quickcheck:
-        repo: https://github.com/purescript-spec/purescript-spec-quickcheck.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - prelude
-          - quickcheck
-          - random
-          - spec
-      ssrs:
-        repo: https://github.com/PureFunctor/purescript-ssrs.git
-        version: v1.0.0
-        dependencies:
-          - dissect
-          - either
-          - fixed-points
-          - free
-          - lists
-          - prelude
-          - safe-coerce
-          - tailrec
-          - tuples
-          - variant
-      st:
-        repo: https://github.com/purescript/purescript-st.git
-        version: v6.0.0
-        dependencies:
-          - partial
-          - prelude
-          - tailrec
-          - unsafe-coerce
-      strictlypositiveint:
-        repo: https://github.com/jamieyung/purescript-strictlypositiveint.git
-        version: v1.0.1
-        dependencies:
-          - prelude
-      string-parsers:
-        repo: https://github.com/purescript-contrib/purescript-string-parsers.git
-        version: v8.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - prelude
-          - strings
-          - tailrec
-      strings:
-        repo: https://github.com/purescript/purescript-strings.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - enums
-          - foldable-traversable
-          - gen
-          - integers
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-          - unsafe-coerce
-      strings-extra:
-        repo: https://github.com/purescript-contrib/purescript-strings-extra.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - maybe
-          - prelude
-          - strings
-          - unicode
-      stringutils:
-        repo: https://github.com/menelaos/purescript-stringutils.git
-        version: v0.0.12
-        dependencies:
-          - arrays
-          - integers
-          - maybe
-          - partial
-          - prelude
-          - strings
-      substitute:
-        repo: https://github.com/ursi/purescript-substitute.git
-        version: v0.2.3
-        dependencies:
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - prelude
-          - return
-          - strings
-      supply:
-        repo: https://github.com/ajnsit/purescript-supply.git
-        version: v0.2.0
-        dependencies:
-          - console
-          - control
-          - effect
-          - lazy
-          - prelude
-          - refs
-          - tuples
-      tailrec:
-        repo: https://github.com/purescript/purescript-tailrec.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - effect
-          - either
-          - identity
-          - maybe
-          - partial
-          - prelude
-          - refs
-      test-unit:
-        repo: https://github.com/bodil/purescript-test-unit.git
-        version: v17.0.0
-        dependencies:
-          - aff
-          - avar
-          - effect
-          - either
-          - free
-          - js-timers
-          - lists
-          - prelude
-          - quickcheck
-          - strings
-      thermite:
-        repo: https://github.com/paf31/purescript-thermite.git
-        version: v6.3.1
-        dependencies:
-          - aff
-          - coroutines
-          - freet
-          - profunctor-lenses
-          - react
-      thermite-dom:
-        repo: https://github.com/athanclark/purescript-thermite-dom.git
-        version: v0.3.1
-        dependencies:
-          - react
-          - react-dom
-          - thermite
-          - web-html
-      these:
-        repo: https://github.com/purescript-contrib/purescript-these.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - gen
-          - lists
-          - quickcheck
-          - quickcheck-laws
-          - tuples
-      transformers:
-        repo: https://github.com/purescript/purescript-transformers.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - distributive
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - identity
-          - lazy
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      tree-rose:
-        repo: https://github.com/jordanmartinez/purescript-tree-rose.git
-        version: v4.0.2
-        dependencies:
-          - control
-          - foldable-traversable
-          - free
-          - lists
-          - maybe
-          - prelude
-          - tailrec
-      tuples:
-        repo: https://github.com/purescript/purescript-tuples.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - invariant
-          - prelude
-      two-or-more:
-        repo: https://github.com/i-am-the-slime/purescript-two-or-more.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - foldable-traversable
-          - maybe
-          - partial
-          - prelude
-          - psci-support
-          - tuples
-      type-equality:
-        repo: https://github.com/purescript/purescript-type-equality.git
-        version: v4.0.1
-        dependencies: []
-      typelevel:
-        repo: https://github.com/bodil/purescript-typelevel.git
-        version: v6.0.0
-        dependencies:
-          - partial
-          - prelude
-          - tuples
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-lists:
-        repo: https://github.com/PureFunctor/purescript-typelevel-lists.git
-        version: v2.1.0
-        dependencies:
-          - prelude
-          - tuples
-          - typelevel-peano
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-peano:
-        repo: https://github.com/csicar/purescript-typelevel-peano.git
-        version: v1.0.1
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - prelude
-          - psci-support
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-prelude:
-        repo: https://github.com/purescript/purescript-typelevel-prelude.git
-        version: v7.0.0
-        dependencies:
-          - prelude
-          - type-equality
-      typelevel-rows:
-        repo: https://github.com/jordanmartinez/purescript-typelevel-rows.git
-        version: v0.1.0
-        dependencies:
-          - prelude
-      uint:
-        repo: https://github.com/purescript-contrib/purescript-uint.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - enums
-          - gen
-          - maybe
-          - numbers
-          - prelude
-      uncurried-transformers:
-        repo: https://github.com/PureFunctor/purescript-uncurried-transformers.git
-        version: v1.1.0
-        dependencies:
-          - control
-          - effect
-          - either
-          - functions
-          - identity
-          - prelude
-          - safe-coerce
-          - tailrec
-          - transformers
-          - tuples
-      undefined-is-not-a-problem:
-        repo: https://github.com/paluh/purescript-undefined-is-not-a-problem.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - assert
-          - effect
-          - either
-          - foreign
-          - maybe
-          - newtype
-          - prelude
-          - random
-          - tuples
-          - type-equality
-          - unsafe-coerce
-      unfoldable:
-        repo: https://github.com/purescript/purescript-unfoldable.git
-        version: v6.0.0
-        dependencies:
-          - foldable-traversable
-          - maybe
-          - partial
-          - prelude
-          - tuples
-      unicode:
-        repo: https://github.com/purescript-contrib/purescript-unicode.git
-        version: v6.0.0
-        dependencies:
-          - foldable-traversable
-          - maybe
-          - strings
-      unlift:
-        repo: https://github.com/tweag/purescript-unlift.git
-        version: v1.0.1
-        dependencies:
-          - aff
-          - effect
-          - either
-          - freet
-          - identity
-          - lists
-          - maybe
-          - monad-control
-          - prelude
-          - st
-          - transformers
-          - tuples
-      unsafe-coerce:
-        repo: https://github.com/purescript/purescript-unsafe-coerce.git
-        version: v6.0.0
-        dependencies: []
-      unsafe-reference:
-        repo: https://github.com/purescript-contrib/purescript-unsafe-reference.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-      uri:
-        repo: https://github.com/purescript-contrib/purescript-uri.git
-        version: v9.0.0
-        dependencies:
-          - arrays
-          - integers
-          - js-uri
-          - numbers
-          - parsing
-          - prelude
-          - profunctor-lenses
-          - these
-          - transformers
-          - unfoldable
-      validation:
-        repo: https://github.com/purescript/purescript-validation.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - newtype
-          - prelude
-      variant:
-        repo: https://github.com/natefaubion/purescript-variant.git
-        version: v8.0.0
-        dependencies:
-          - enums
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - record
-          - tuples
-          - unsafe-coerce
-      vectorfield:
-        repo: https://github.com/csicar/purescript-vectorfield.git
-        version: v1.0.1
-        dependencies:
-          - console
-          - effect
-          - group
-          - prelude
-          - psci-support
-      versions:
-        repo: https://github.com/hdgarrood/purescript-versions.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - either
-          - foldable-traversable
-          - functions
-          - integers
-          - lists
-          - maybe
-          - orders
-          - parsing
-          - partial
-          - strings
-      web-clipboard:
-        repo: https://github.com/purescript-web/purescript-web-clipboard.git
-        version: v4.0.0
-        dependencies:
-          - web-html
-      web-cssom:
-        repo: https://github.com/purescript-web/purescript-web-cssom.git
-        version: v2.0.0
-        dependencies:
-          - web-dom
-          - web-html
-          - web-uievents
-      web-dom:
-        repo: https://github.com/purescript-web/purescript-web-dom.git
-        version: v6.0.0
-        dependencies:
-          - web-events
-      web-dom-parser:
-        repo: https://github.com/purescript-web/purescript-web-dom-parser.git
-        version: v8.0.0
-        dependencies:
-          - effect
-          - partial
-          - prelude
-          - web-dom
-      web-dom-xpath:
-        repo: https://github.com/purescript-web/purescript-web-dom-xpath.git
-        version: v3.0.0
-        dependencies:
-          - web-dom
-      web-encoding:
-        repo: https://github.com/purescript-web/purescript-web-encoding.git
-        version: v3.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - newtype
-          - prelude
-      web-events:
-        repo: https://github.com/purescript-web/purescript-web-events.git
-        version: v4.0.0
-        dependencies:
-          - datetime
-          - enums
-          - foreign
-          - nullable
-      web-fetch:
-        repo: https://github.com/purescript-web/purescript-web-fetch.git
-        version: v3.0.0
-        dependencies:
-          - effect
-          - foreign-object
-          - http-methods
-          - prelude
-          - record
-          - typelevel-prelude
-          - web-file
-          - web-promise
-          - web-streams
-      web-file:
-        repo: https://github.com/purescript-web/purescript-web-file.git
-        version: v4.0.0
-        dependencies:
-          - foreign
-          - media-types
-          - web-dom
-      web-html:
-        repo: https://github.com/purescript-web/purescript-web-html.git
-        version: v4.0.0
-        dependencies:
-          - js-date
-          - web-dom
-          - web-file
-          - web-storage
-      web-page-visibility:
-        repo: https://git.sr.ht/~toastal/purescript-web-page-visibility
-        version: v2.0.0
-        dependencies:
-          - effect
-          - enums
-          - exceptions
-          - maybe
-          - prelude
-          - strings
-          - web-events
-          - web-html
-      web-pointerevents:
-        repo: https://github.com/purescript-web/purescript-web-pointerevents.git
-        version: v1.0.0
-        dependencies:
-          - effect
-          - maybe
-          - prelude
-          - web-dom
-          - web-uievents
-      web-promise:
-        repo: https://github.com/purescript-web/purescript-web-promise.git
-        version: v3.0.0
-        dependencies:
-          - effect
-          - exceptions
-          - foldable-traversable
-          - functions
-          - maybe
-          - prelude
-      web-socket:
-        repo: https://github.com/purescript-web/purescript-web-socket.git
-        version: v4.0.0
-        dependencies:
-          - arraybuffer-types
-          - web-file
-      web-storage:
-        repo: https://github.com/purescript-web/purescript-web-storage.git
-        version: v5.0.0
-        dependencies:
-          - nullable
-          - web-events
-      web-streams:
-        repo: https://github.com/purescript-web/purescript-web-streams.git
-        version: v3.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - exceptions
-          - nullable
-          - prelude
-          - tuples
-          - web-promise
-      web-touchevents:
-        repo: https://github.com/purescript-web/purescript-web-touchevents.git
-        version: v4.0.0
-        dependencies:
-          - web-uievents
-      web-uievents:
-        repo: https://github.com/purescript-web/purescript-web-uievents.git
-        version: v4.0.0
-        dependencies:
-          - web-html
-      web-workers:
-        repo: https://github.com/gbagan/purescript-web-workers.git
-        version: v1.1.0
-        dependencies:
-          - effect
-          - foreign
-          - maybe
-          - prelude
-          - unsafe-coerce
-          - web-events
-      web-xhr:
-        repo: https://github.com/purescript-web/purescript-web-xhr.git
-        version: v5.0.0
-        dependencies:
-          - arraybuffer-types
-          - datetime
-          - http-methods
-          - web-dom
-          - web-file
-          - web-html
-      yoga-fetch:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-fetch.git
-        version: v1.0.1
-        dependencies:
-          - aff
-          - aff-promise
-          - arraybuffer-types
-          - effect
-          - foreign
-          - foreign-object
-          - newtype
-          - prelude
-          - typelevel-prelude
-          - unsafe-coerce
-      yoga-json:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-json.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - identity
-          - lists
-          - maybe
-          - nullable
-          - partial
-          - prelude
-          - record
-          - transformers
-          - typelevel-prelude
-          - variant
-      yoga-postgres:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-postgres.git
-        version: v6.0.0
-        dependencies:
-          - aff
-          - arrays
-          - datetime
-          - effect
-          - either
-          - enums
-          - foldable-traversable
-          - foreign
-          - integers
-          - maybe
-          - nullable
-          - prelude
-          - transformers
-          - unsafe-coerce
+      abc-parser: 2.0.0
+      ace: 9.0.0
+      aff: 7.1.0
+      aff-bus: 6.0.0
+      aff-coroutines: 9.0.0
+      aff-promise: 4.0.0
+      aff-retry: 2.0.0
+      affjax: 13.0.0
+      affjax-node: 1.0.0
+      affjax-web: 1.0.0
+      ansi: 7.0.0
+      argonaut: 9.0.0
+      argonaut-aeson-generic: 0.4.1
+      argonaut-codecs: 9.1.0
+      argonaut-core: 7.0.0
+      argonaut-generic: 8.0.0
+      argonaut-traversals: 10.0.0
+      argparse-basic: 2.0.0
+      array-builder: 0.1.2
+      arraybuffer: 13.1.1
+      arraybuffer-builder: 3.1.0
+      arraybuffer-types: 3.0.2
+      arrays: 7.1.0
+      arrays-zipper: 2.0.1
+      ask: 1.0.0
+      assert: 6.0.0
+      avar: 5.0.0
+      b64: 0.0.8
+      barbies: 1.0.1
+      barlow-lens: 0.9.0
+      basic-auth: 3.0.1
+      bifunctors: 6.0.0
+      bigints: 7.0.1
+      bolson: 0.3.1
+      bower-json: 3.0.0
+      bucketchain: 1.0.1
+      bucketchain-basic-auth: 1.0.1
+      bucketchain-conditional: 1.0.1
+      bucketchain-cors: 1.0.1
+      bucketchain-csrf: 1.0.1
+      bucketchain-header-utils: 1.0.1
+      bucketchain-health: 1.0.1
+      bucketchain-history-api-fallback: 1.0.1
+      bucketchain-logger: 1.0.1
+      bucketchain-secure: 1.0.1
+      bucketchain-simple-api: 5.0.1
+      bucketchain-sslify: 1.0.1
+      bucketchain-static: 1.0.1
+      call-by-name: 4.0.1
+      canvas: 6.0.0
+      canvas-action: 9.0.0
+      cartesian: 1.0.6
+      catenable-lists: 7.0.0
+      channel: 1.0.0
+      checked-exceptions: 3.1.1
+      classless: 0.1.1
+      classless-arbitrary: 0.1.1
+      classless-decode-json: 0.1.1
+      classless-encode-json: 0.1.3
+      classnames: 2.0.0
+      codec: 6.0.0
+      codec-argonaut: 10.0.0
+      colors: 7.0.1
+      concur-core: 0.5.0
+      concur-react: 0.5.0
+      concurrent-queues: 3.0.0
+      console: 6.0.0
+      const: 6.0.0
+      contravariant: 6.0.0
+      control: 6.0.0
+      convertable-options: 1.0.0
+      coroutines: 7.0.0
+      crypto: 5.0.1
+      css: 6.0.0
+      datetime: 6.1.0
+      datetime-parsing: 0.2.0
+      debug: 6.0.2
+      decimals: 7.1.0
+      default-values: 1.0.1
+      deku: 0.9.9
+      deno: 0.0.5
+      dissect: 1.0.0
+      distributive: 6.0.0
+      dodo-printer: 2.2.1
+      dom-filereader: 7.0.0
+      dom-indexed: 11.0.0
+      dotenv: 3.0.0
+      droplet: 0.5.0
+      dynamic-buffer: 3.0.1
+      echarts-simple: 0.0.1
+      effect: 4.0.0
+      either: 6.1.0
+      elmish: 0.8.3
+      elmish-enzyme: 0.1.1
+      elmish-hooks: 0.9.1
+      elmish-html: 0.7.2
+      elmish-testing-library: 0.3.1
+      email-validate: 7.0.0
+      encoding: 0.0.8
+      enums: 6.0.1
+      error: 2.0.0
+      exceptions: 6.0.0
+      exists: 6.0.0
+      exitcodes: 4.0.0
+      expect-inferred: 3.0.0
+      fahrtwind: 2.0.0
+      fallback: 0.1.0
+      fast-vect: 1.1.0
+      fetch: 1.1.4
+      fetch-argonaut: 1.0.0
+      fetch-core: 4.0.4
+      fetch-yoga-json: 1.1.0
+      filterable: 5.0.0
+      fixed-points: 7.0.0
+      fixed-precision: 5.0.0
+      flame: 1.2.0
+      float32: 2.0.0
+      foldable-traversable: 6.0.0
+      foreign: 7.0.0
+      foreign-object: 4.1.0
+      foreign-readwrite: 3.4.0
+      fork: 6.0.0
+      form-urlencoded: 7.0.0
+      formatters: 7.0.0
+      framer-motion: 1.0.1
+      free: 7.0.0
+      freeap: 7.0.0
+      freer-free: 0.0.1
+      freet: 7.0.0
+      functions: 6.0.0
+      functor1: 3.0.0
+      functors: 5.0.0
+      fuzzy: 0.4.0
+      gen: 4.0.0
+      generate-values: 1.0.1
+      generic-router: 0.0.1
+      geometry-plane: 1.0.3
+      github-actions-toolkit: 0.5.0
+      grain: 3.0.0
+      grain-router: 3.0.0
+      grain-virtualized: 3.0.0
+      graphql-client: 9.3.2
+      graphs: 8.1.0
+      group: 4.1.1
+      halogen: 7.0.0
+      halogen-bootstrap5: 2.1.0
+      halogen-css: 10.0.0
+      halogen-echarts-simple: 0.0.4
+      halogen-formless: 4.0.2
+      halogen-hooks: 0.6.3
+      halogen-hooks-extra: 0.9.0
+      halogen-store: 0.5.4
+      halogen-storybook: 2.0.0
+      halogen-subscriptions: 2.0.0
+      halogen-svg-elems: 7.0.0
+      halogen-vdom: 8.0.0
+      halogen-vdom-string-renderer: 0.5.0
+      heckin: 2.0.1
+      heterogeneous: 0.6.0
+      homogeneous: 0.4.0
+      http-methods: 6.0.0
+      httpure: 0.16.0
+      httpurple: 3.0.1
+      httpurple-argonaut: 1.0.1
+      httpurple-yoga-json: 1.0.0
+      humdrum: 0.0.1
+      hyrule: 2.3.5
+      identity: 6.0.0
+      identy: 4.0.1
+      indexed-monad: 2.1.0
+      int64: 3.0.0
+      integers: 6.0.0
+      interpolate: 5.0.2
+      invariant: 6.0.0
+      jarilo: 1.0.1
+      jelly: 0.9.1
+      jelly-hooks: 0.3.1
+      jelly-router: 0.2.2
+      jelly-signal: 0.3.0
+      jest: 1.0.0
+      js-bigints: 1.2.0
+      js-date: 8.0.0
+      js-fileio: 3.0.0
+      js-promise: 1.0.0
+      js-promise-aff: 1.0.0
+      js-timers: 6.1.0
+      js-uri: 3.1.0
+      justifill: 0.5.0
+      jwt: 0.0.9
+      language-cst-parser: 0.12.1
+      lazy: 6.0.0
+      lazy-joe: 1.0.0
+      lcg: 4.0.0
+      leibniz: 5.0.0
+      linalg: 5.1.0
+      lists: 7.0.0
+      literals: 1.0.2
+      logging: 3.0.0
+      logging-journald: 0.4.0
+      machines: 7.0.0
+      marionette: 1.0.0
+      marionette-commander: 0.1.1
+      marionette-react-basic-hooks: 0.1.1
+      matrices: 5.0.1
+      matryoshka: 1.0.0
+      maybe: 6.0.0
+      mdast-util-from-markdown: 0.2.1
+      media-types: 6.0.0
+      midi: 4.0.0
+      milkis: 9.0.0
+      minibench: 4.0.1
+      mmorph: 7.0.0
+      monad-control: 5.0.0
+      monad-logger: 1.3.1
+      monad-loops: 0.5.0
+      monad-unlift: 1.0.1
+      monoid-extras: 0.0.1
+      monoidal: 0.16.0
+      morello: 0.4.0
+      mote: 3.0.0
+      motsunabe: 2.0.0
+      mysql: 6.0.1
+      n3: 0.1.0
+      nano-id: 1.1.0
+      naturals: 3.0.0
+      nested-functor: 0.2.1
+      newtype: 5.0.0
+      nextui: 0.1.0
+      node-buffer: 8.0.0
+      node-buffer-blob: 1.0.0
+      node-child-process: 9.0.0
+      node-fs: 8.1.1
+      node-fs-aff: 9.1.0
+      node-http: 8.0.0
+      node-net: 4.0.0
+      node-path: 5.0.0
+      node-process: 10.0.0
+      node-readline: 7.0.0
+      node-sqlite3: 8.0.0
+      node-streams: 7.0.0
+      node-streams-aff: 4.0.1
+      node-url: 6.0.0
+      nodemailer: 4.0.1
+      nonempty: 7.0.0
+      now: 6.0.0
+      npm-package-json: 2.0.0
+      nullable: 6.0.0
+      numbers: 9.0.0
+      object-maps: 0.1.1
+      ocarina: 1.5.2
+      open-folds: 6.3.0
+      open-memoize: 6.1.0
+      open-pairing: 6.1.0
+      options: 7.0.0
+      optparse: 5.0.0
+      ordered-collections: 3.0.0
+      ordered-set: 0.4.0
+      orders: 6.0.0
+      pairs: 9.0.0
+      parallel: 6.0.0
+      parsing: 10.2.0
+      parsing-dataview: 3.2.4
+      partial: 4.0.0
+      pathy: 9.0.0
+      pha: 0.9.0
+      phaser: 0.6.0
+      pipes: 8.0.0
+      pirates-charm: 0.0.1
+      point-free: 1.0.0
+      pointed-list: 0.5.1
+      polymorphic-vectors: 4.0.0
+      posix-types: 6.0.0
+      precise: 6.0.0
+      precise-datetime: 7.0.0
+      prelude: 6.0.1
+      prettier-printer: 3.0.0
+      profunctor: 6.0.0
+      profunctor-lenses: 8.0.0
+      protobuf: 4.2.0
+      ps-cst: 1.2.0
+      psa-utils: 8.0.0
+      psc-ide: 19.0.0
+      psci-support: 6.0.0
+      qualified-do: 2.2.0
+      quantities: 12.1.0
+      quickcheck: 8.0.1
+      quickcheck-combinators: 0.1.3
+      quickcheck-laws: 7.0.0
+      quickcheck-utf8: 0.0.0
+      random: 6.0.0
+      rationals: 5.0.1
+      rdf: 0.1.0
+      react: 10.0.1
+      react-aria: 0.2.0
+      react-basic: 17.0.0
+      react-basic-classic: 3.0.0
+      react-basic-dnd: 10.1.0
+      react-basic-dom: 6.0.0
+      react-basic-emotion: 7.1.0
+      react-basic-hooks: 8.1.2
+      react-basic-storybook: 2.0.0
+      react-dom: 8.0.0
+      react-halo: 3.0.0
+      react-icons: 1.0.8
+      react-testing-library: 4.0.1
+      react-virtuoso: 1.0.0
+      read: 1.0.1
+      record: 4.0.0
+      record-extra: 5.0.1
+      record-studio: 1.0.4
+      refs: 6.0.0
+      remotedata: 5.0.0
+      resource: 2.0.1
+      resourcet: 1.0.0
+      result: 1.0.3
+      return: 0.2.0
+      ring-modules: 5.0.1
+      rito: 0.3.2
+      routing: 11.0.0
+      routing-duplex: 0.7.0
+      run: 5.0.0
+      safe-coerce: 2.0.0
+      safely: 4.0.1
+      school-of-music: 1.3.0
+      selection-foldable: 0.2.0
+      semirings: 7.0.0
+      signal: 13.0.0
+      simple-emitter: 3.0.1
+      simple-i18n: 2.0.1
+      simple-json: 9.0.0
+      simple-jwt: 4.0.1
+      simple-ulid: 3.0.0
+      sized-matrices: 1.0.0
+      sized-vectors: 5.0.2
+      slug: 3.0.8
+      small-ffi: 4.0.1
+      soundfonts: 4.1.0
+      sparse-matrices: 1.2.1
+      sparse-polynomials: 1.0.5
+      spec: 7.2.0
+      spec-discovery: 8.0.1
+      spec-quickcheck: 5.0.0
+      splitmix: 2.1.0
+      ssrs: 1.0.0
+      st: 6.2.0
+      strictlypositiveint: 1.0.1
+      string-parsers: 8.0.0
+      strings: 6.0.1
+      strings-extra: 4.0.0
+      stringutils: 0.0.12
+      substitute: 0.2.3
+      sunde: 3.0.0
+      supply: 0.2.0
+      svg-parser: 3.0.0
+      systemd-journald: 0.3.0
+      tagged: 4.0.2
+      tailrec: 6.1.0
+      tecton: 0.1.6
+      tecton-halogen: 0.1.3
+      test-unit: 17.0.0
+      thermite: 6.3.1
+      thermite-dom: 0.3.1
+      these: 6.0.0
+      toppokki: 4.0.0
+      transformers: 6.0.0
+      tree-rose: 4.0.2
+      tuples: 7.0.0
+      two-or-more: 1.0.0
+      type-equality: 4.0.1
+      typelevel: 6.0.0
+      typelevel-lists: 2.1.0
+      typelevel-peano: 1.0.1
+      typelevel-prelude: 7.0.0
+      typelevel-rows: 0.1.0
+      uint: 7.0.0
+      ulid: 3.0.1
+      uncurried-transformers: 1.1.0
+      undefined: 2.0.0
+      undefined-is-not-a-problem: 1.1.0
+      unfoldable: 6.0.0
+      unicode: 6.0.0
+      unlift: 1.0.1
+      unordered-collections: 3.0.1
+      unsafe-coerce: 6.0.0
+      unsafe-reference: 5.0.0
+      untagged-to-tagged: 0.1.4
+      untagged-union: 1.0.0
+      uri: 9.0.0
+      uuid: 9.0.0
+      uuidv4: 1.0.0
+      validation: 6.0.0
+      variant: 8.0.0
+      vectorfield: 1.0.1
+      vectors: 2.1.0
+      versions: 7.0.0
+      visx: 0.0.2
+      web-clipboard: 5.0.0
+      web-cssom: 2.0.0
+      web-dom: 6.0.0
+      web-dom-parser: 8.0.0
+      web-dom-xpath: 3.0.0
+      web-encoding: 3.0.0
+      web-events: 4.0.0
+      web-fetch: 3.0.0
+      web-file: 4.0.0
+      web-html: 4.1.0
+      web-pointerevents: 1.0.0
+      web-proletarian: 1.0.0
+      web-promise: 3.1.0
+      web-resize-observer: 2.0.0
+      web-router: 1.0.0
+      web-socket: 4.0.0
+      web-storage: 5.0.0
+      web-streams: 3.0.0
+      web-touchevents: 4.0.0
+      web-uievents: 4.0.0
+      web-url: 2.0.0
+      web-workers: 1.1.0
+      web-xhr: 5.0.0
+      which: 2.0.0
+      yoga-fetch: 1.0.1
+      yoga-json: 4.0.1
+      yoga-om: 0.1.0
+      yoga-postgres: 6.0.0
+      yoga-tree: 1.0.0
   extra_packages: {}
 packages:
   arrays:
-    type: git
-    url: https://github.com/purescript/purescript-arrays.git
-    rev: d20bae2f76db6cf29b7b75e26e82b8a54c32295e
+    type: registry
+    version: 7.1.0
+    integrity: sha256-Rvb3AVLal0ZLpmpABgOPIUeYHa4M+c5GwcUP5rQ2trA=
     dependencies:
       - bifunctors
       - control
@@ -3499,15 +499,16 @@ packages:
       - nonempty
       - partial
       - prelude
+      - safe-coerce
       - st
       - tailrec
       - tuples
       - unfoldable
       - unsafe-coerce
   bifunctors:
-    type: git
-    url: https://github.com/purescript/purescript-bifunctors.git
-    rev: 16ba2fb6dd7f05528ebd9e2f9ca3a068b325e5b3
+    type: registry
+    version: 6.0.0
+    integrity: sha256-/gZwC9YhNxZNQpnHa5BIYerCGM2jeX9ukZiEvYxm5Nw=
     dependencies:
       - const
       - either
@@ -3515,9 +516,9 @@ packages:
       - prelude
       - tuples
   catenable-lists:
-    type: git
-    url: https://github.com/purescript/purescript-catenable-lists.git
-    rev: 09abe1f4888bc00841ad2b59e56a9e7ce7ebd4ab
+    type: registry
+    version: 7.0.0
+    integrity: sha256-76vYENhwF4BWTBsjeLuErCH2jqVT4M3R1HX+4RwSftA=
     dependencies:
       - control
       - foldable-traversable
@@ -3527,24 +528,24 @@ packages:
       - tuples
       - unfoldable
   console:
-    type: git
-    url: https://github.com/purescript/purescript-console.git
-    rev: 3b83d7b792d03872afeea5e62b4f686ab0f09842
+    type: registry
+    version: 6.0.0
+    integrity: sha256-gJpJ53fCDAL8BiCiJXH0HNAJ9K3gJtLo8GDaCK6hA5U=
     dependencies:
       - effect
       - prelude
   const:
-    type: git
-    url: https://github.com/purescript/purescript-const.git
-    rev: ab9570cf2b6e67f7e441178211db1231cfd75c37
+    type: registry
+    version: 6.0.0
+    integrity: sha256-tNrxDW8D8H4jdHE2HiPzpLy08zkzJMmGHdRqt5BQuTc=
     dependencies:
       - invariant
       - newtype
       - prelude
   contravariant:
-    type: git
-    url: https://github.com/purescript/purescript-contravariant.git
-    rev: 9ad3e105b8855bcc25f4e0893c784789d05a58de
+    type: registry
+    version: 6.0.0
+    integrity: sha256-TP+ooAp3vvmdjfQsQJSichF5B4BPDHp3wAJoWchip6c=
     dependencies:
       - const
       - either
@@ -3552,16 +553,16 @@ packages:
       - prelude
       - tuples
   control:
-    type: git
-    url: https://github.com/purescript/purescript-control.git
-    rev: a6033808790879a17b2729e73747a9ed3fb2264e
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sH7Pg9E96JCPF9PIA6oQ8+BjTyO/BH1ZuE/bOcyj4Jk=
     dependencies:
       - newtype
       - prelude
   distributive:
-    type: git
-    url: https://github.com/purescript/purescript-distributive.git
-    rev: 6005e513642e855ebf6f884d24a35c2803ca252a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-HTDdmEnzigMl+02SJB88j+gAXDx9VKsbvR4MJGDPbOQ=
     dependencies:
       - identity
       - newtype
@@ -3569,24 +570,24 @@ packages:
       - tuples
       - type-equality
   effect:
-    type: git
-    url: https://github.com/purescript/purescript-effect.git
-    rev: a192ddb923027d426d6ea3d8deb030c9aa7c7dda
+    type: registry
+    version: 4.0.0
+    integrity: sha256-eBtZu+HZcMa5HilvI6kaDyVX3ji8p0W9MGKy2K4T6+M=
     dependencies:
       - prelude
   either:
-    type: git
-    url: https://github.com/purescript/purescript-either.git
-    rev: af655a04ed2fd694b6688af39ee20d7907ad0763
+    type: registry
+    version: 6.1.0
+    integrity: sha256-6hgTPisnMWVwQivOu2PKYcH8uqjEOOqDyaDQVUchTpY=
     dependencies:
       - control
       - invariant
       - maybe
       - prelude
   enums:
-    type: git
-    url: https://github.com/purescript/purescript-enums.git
-    rev: bae47961d401f9acf88da38f32e87403e5f0cf2f
+    type: registry
+    version: 6.0.1
+    integrity: sha256-HWaD73JFLorc4A6trKIRUeDMdzE+GpkJaEOM1nTNkC8=
     dependencies:
       - control
       - either
@@ -3599,24 +600,24 @@ packages:
       - tuples
       - unfoldable
   exceptions:
-    type: git
-    url: https://github.com/purescript/purescript-exceptions.git
-    rev: afab3c07c820bb49b6c5be50049db46a964a6161
+    type: registry
+    version: 6.0.0
+    integrity: sha256-y/xTAEIZIARCE+50/u1di0ncebJ+CIwNOLswyOWzMTw=
     dependencies:
       - effect
       - either
       - maybe
       - prelude
   exists:
-    type: git
-    url: https://github.com/purescript/purescript-exists.git
-    rev: f765b4ace7869c27b9c05949e18c843881f9173b
+    type: registry
+    version: 6.0.0
+    integrity: sha256-A0JQHpTfo1dNOj9U5/Fd3xndlRSE0g2IQWOGor2yXn8=
     dependencies:
       - unsafe-coerce
   foldable-traversable:
-    type: git
-    url: https://github.com/purescript/purescript-foldable-traversable.git
-    rev: b3926f870532d287ea59e2d5cd3873b81ef2a93a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-fLeqRYM4jUrZD5H4WqcwUgzU7XfYkzO4zhgtNc3jcWM=
     dependencies:
       - bifunctors
       - const
@@ -3630,9 +631,9 @@ packages:
       - prelude
       - tuples
   free:
-    type: git
-    url: https://github.com/purescript/purescript-free.git
-    rev: e2d8fa8023a864363857834e11393483bced5e38
+    type: registry
+    version: 7.0.0
+    integrity: sha256-72auTIZAG6fhz4F94rxyDwgfnHwp+/89rujZpZWrV0w=
     dependencies:
       - catenable-lists
       - control
@@ -3649,15 +650,15 @@ packages:
       - tuples
       - unsafe-coerce
   functions:
-    type: git
-    url: https://github.com/purescript/purescript-functions.git
-    rev: f626f20580483977c5b27a01aac6471e28aff367
+    type: registry
+    version: 6.0.0
+    integrity: sha256-adMyJNEnhGde2unHHAP79gPtlNjNqzgLB8arEOn9hLI=
     dependencies:
       - prelude
   functors:
-    type: git
-    url: https://github.com/purescript/purescript-functors.git
-    rev: 022ffd7a2a7ec12080314f3d217b400674a247b4
+    type: registry
+    version: 5.0.0
+    integrity: sha256-zfPWWYisbD84MqwpJSZFlvM6v86McM68ob8p9s27ywU=
     dependencies:
       - bifunctors
       - const
@@ -3673,9 +674,9 @@ packages:
       - tuples
       - unsafe-coerce
   gen:
-    type: git
-    url: https://github.com/purescript/purescript-gen.git
-    rev: 9fbcc2a1261c32e30d79c5418edef4d96fe76931
+    type: registry
+    version: 4.0.0
+    integrity: sha256-f7yzAXWwr+xnaqEOcvyO3ezKdoes8+WXWdXIHDBCAPI=
     dependencies:
       - either
       - foldable-traversable
@@ -3688,42 +689,42 @@ packages:
       - tuples
       - unfoldable
   identity:
-    type: git
-    url: https://github.com/purescript/purescript-identity.git
-    rev: ef6768f8a52ab0bc943a85f5761ba07c257f639f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-4wY0XZbAksjY6UAg99WkuKyJlQlWAfTi2ssadH0wVMY=
     dependencies:
       - control
       - invariant
       - newtype
       - prelude
   integers:
-    type: git
-    url: https://github.com/purescript/purescript-integers.git
-    rev: 54d712b25c594833083d15dc9ff2418eb9c52822
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sf+sK26R1hzwl3NhXR7WAu9zCDjQnfoXwcyGoseX158=
     dependencies:
       - maybe
       - numbers
       - prelude
   invariant:
-    type: git
-    url: https://github.com/purescript/purescript-invariant.git
-    rev: 1d2a196d51e90623adb88496c2cfd759c6736894
+    type: registry
+    version: 6.0.0
+    integrity: sha256-RGWWyYrz0Hs1KjPDA+87Kia67ZFBhfJ5lMGOMCEFoLo=
     dependencies:
       - control
       - prelude
   lazy:
-    type: git
-    url: https://github.com/purescript/purescript-lazy.git
-    rev: 48347841226b27af5205a1a8ec71e27a93ce86fd
+    type: registry
+    version: 6.0.0
+    integrity: sha256-lMsfFOnlqfe4KzRRiW8ot5ge6HtcU3Eyh2XkXcP5IgU=
     dependencies:
       - control
       - foldable-traversable
       - invariant
       - prelude
   lists:
-    type: git
-    url: https://github.com/purescript/purescript-lists.git
-    rev: b113451e5b41cad87d669a3165f955c71cd863e2
+    type: registry
+    version: 7.0.0
+    integrity: sha256-EKF15qYqucuXP2lT/xPxhqy58f0FFT6KHdIB/yBOayI=
     dependencies:
       - bifunctors
       - control
@@ -3738,25 +739,25 @@ packages:
       - tuples
       - unfoldable
   maybe:
-    type: git
-    url: https://github.com/purescript/purescript-maybe.git
-    rev: c6f98ac1088766287106c5d9c8e30e7648d36786
+    type: registry
+    version: 6.0.0
+    integrity: sha256-5cCIb0wPwbat2PRkQhUeZO0jcAmf8jCt2qE0wbC3v2Q=
     dependencies:
       - control
       - invariant
       - newtype
       - prelude
   newtype:
-    type: git
-    url: https://github.com/purescript/purescript-newtype.git
-    rev: 29d8e6dd77aec2c975c948364ec3faf26e14ee7b
+    type: registry
+    version: 5.0.0
+    integrity: sha256-gdrQu8oGe9eZE6L3wOI8ql/igOg+zEGB5ITh2g+uttw=
     dependencies:
       - prelude
       - safe-coerce
   nonempty:
-    type: git
-    url: https://github.com/purescript/purescript-nonempty.git
-    rev: 28150ecc7419238b187abd609a92a645273348bb
+    type: registry
+    version: 7.0.0
+    integrity: sha256-54ablJZUHGvvlTJzi3oXyPCuvY6zsrWJuH/dMJ/MFLs=
     dependencies:
       - control
       - foldable-traversable
@@ -3765,33 +766,33 @@ packages:
       - tuples
       - unfoldable
   numbers:
-    type: git
-    url: https://github.com/purescript/purescript-numbers.git
-    rev: 2a53528f18f9415334bae28e7bb3cf3be86342c2
+    type: registry
+    version: 9.0.0
+    integrity: sha256-fDKXExFxMRFgy+v+kbjVbGBIOOQkWGnmm0vtnE3zWRE=
     dependencies:
       - functions
       - maybe
   orders:
-    type: git
-    url: https://github.com/purescript/purescript-orders.git
-    rev: f86db621ec5eef1274145f8b1fd8ebbfe0ed4a2c
+    type: registry
+    version: 6.0.0
+    integrity: sha256-nBA0g3/ai0euH8q9pSbGqk53W2q6agm/dECZTHcoink=
     dependencies:
       - newtype
       - prelude
   partial:
-    type: git
-    url: https://github.com/purescript/purescript-partial.git
-    rev: 0fa0646f5ea1ec5f0c46dcbd770c705a6c9ad3ec
+    type: registry
+    version: 4.0.0
+    integrity: sha256-fwXerld6Xw1VkReh8yeQsdtLVrjfGiVuC5bA1Wyo/J4=
     dependencies: []
   prelude:
-    type: git
-    url: https://github.com/purescript/purescript-prelude.git
-    rev: 32787f4399c92459c41602131a5858559eb868c5
+    type: registry
+    version: 6.0.1
+    integrity: sha256-o8p6SLYmVPqzXZhQFd2hGAWEwBoXl1swxLG/scpJ0V0=
     dependencies: []
   profunctor:
-    type: git
-    url: https://github.com/purescript/purescript-profunctor.git
-    rev: 0a966a14e7b0c827d44657dc1710cdc712d2e034
+    type: registry
+    version: 6.0.0
+    integrity: sha256-99NzxFgTr4CGlCSRYG1kShL+JhYbihhHtbOk1/0R5zI=
     dependencies:
       - control
       - distributive
@@ -3802,31 +803,31 @@ packages:
       - prelude
       - tuples
   refs:
-    type: git
-    url: https://github.com/purescript/purescript-refs.git
-    rev: f8e6216da4cb9309fde1f20cd6f69ac3a3b7f9e8
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Vgwne7jIbD3ZMoLNNETLT8Litw6lIYo3MfYNdtYWj9s=
     dependencies:
       - effect
       - prelude
   safe-coerce:
-    type: git
-    url: https://github.com/purescript/purescript-safe-coerce.git
-    rev: 7fa799ae80a38b8d948efcb52608e58e198b3da7
+    type: registry
+    version: 2.0.0
+    integrity: sha256-a1ibQkiUcbODbLE/WAq7Ttbbh9ex+x33VCQ7GngKudU=
     dependencies:
       - unsafe-coerce
   st:
-    type: git
-    url: https://github.com/purescript/purescript-st.git
-    rev: 2cc7ae1c3318a303378c4a9f3fa0f10ee7cc3589
+    type: registry
+    version: 6.2.0
+    integrity: sha256-z9X0WsOUlPwNx9GlCC+YccCyz8MejC8Wb0C4+9fiBRY=
     dependencies:
       - partial
       - prelude
       - tailrec
       - unsafe-coerce
   strings:
-    type: git
-    url: https://github.com/purescript/purescript-strings.git
-    rev: 4bc6954448d056f8aa7a659695a6ad60ad4fdf19
+    type: registry
+    version: 6.0.1
+    integrity: sha256-WssD3DbX4OPzxSdjvRMX0yvc9+pS7n5gyPv5I2Trb7k=
     dependencies:
       - arrays
       - control
@@ -3845,9 +846,9 @@ packages:
       - unfoldable
       - unsafe-coerce
   tailrec:
-    type: git
-    url: https://github.com/purescript/purescript-tailrec.git
-    rev: 5e2104aa734b31a17074cc805bf087d72b65afd1
+    type: registry
+    version: 6.1.0
+    integrity: sha256-Xx19ECVDRrDWpz9D2GxQHHV89vd61dnXxQm0IcYQHGk=
     dependencies:
       - bifunctors
       - effect
@@ -3858,9 +859,9 @@ packages:
       - prelude
       - refs
   transformers:
-    type: git
-    url: https://github.com/purescript/purescript-transformers.git
-    rev: be72ab52357d9a665cbf93d73ba1c07c4b0957ee
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Pzw40HjthX77tdPAYzjx43LK3X5Bb7ZspYAp27wksFA=
     dependencies:
       - control
       - distributive
@@ -3877,22 +878,22 @@ packages:
       - tuples
       - unfoldable
   tuples:
-    type: git
-    url: https://github.com/purescript/purescript-tuples.git
-    rev: 4f52da2729b448c8564369378f1232d8d2dc1d8b
+    type: registry
+    version: 7.0.0
+    integrity: sha256-1rXgTomes9105BjgXqIw0FL6Fz1lqqUTLWOumhWec1M=
     dependencies:
       - control
       - invariant
       - prelude
   type-equality:
-    type: git
-    url: https://github.com/purescript/purescript-type-equality.git
-    rev: 0525b7d39e0fbd81b4209518139fb8ab02695774
+    type: registry
+    version: 4.0.1
+    integrity: sha256-Hs9D6Y71zFi/b+qu5NSbuadUQXe5iv5iWx0226vOHUw=
     dependencies: []
   unfoldable:
-    type: git
-    url: https://github.com/purescript/purescript-unfoldable.git
-    rev: 493dfe04ed590e20d8f69079df2f58486882748d
+    type: registry
+    version: 6.0.0
+    integrity: sha256-JtikvJdktRap7vr/K4ITlxUX1QexpnqBq0G/InLr6eg=
     dependencies:
       - foldable-traversable
       - maybe
@@ -3900,7 +901,7 @@ packages:
       - prelude
       - tuples
   unsafe-coerce:
-    type: git
-    url: https://github.com/purescript/purescript-unsafe-coerce.git
-    rev: ab956f82e66e633f647fb3098e8ddd3ec58d689f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-IqIYW4Vkevn8sI+6aUwRGvd87tVL36BBeOr0cGAE7t0=
     dependencies: []

--- a/exercises/chapter14/spago.lock
+++ b/exercises/chapter14/spago.lock
@@ -1,0 +1,3906 @@
+workspace:
+  packages:
+    my-project:
+      path: ./
+      dependencies:
+        - arrays
+        - console
+        - effect
+        - foldable-traversable
+        - free
+        - maybe
+        - prelude
+        - strings
+        - transformers
+      test_dependencies: []
+      build_plan:
+        - arrays
+        - bifunctors
+        - catenable-lists
+        - console
+        - const
+        - contravariant
+        - control
+        - distributive
+        - effect
+        - either
+        - enums
+        - exceptions
+        - exists
+        - foldable-traversable
+        - free
+        - functions
+        - functors
+        - gen
+        - identity
+        - integers
+        - invariant
+        - lazy
+        - lists
+        - maybe
+        - newtype
+        - nonempty
+        - numbers
+        - orders
+        - partial
+        - prelude
+        - profunctor
+        - refs
+        - safe-coerce
+        - st
+        - strings
+        - tailrec
+        - transformers
+        - tuples
+        - type-equality
+        - unfoldable
+        - unsafe-coerce
+  package_set:
+    address:
+      url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
+    compiler: ">=0.15.0 <0.16.0"
+    content:
+      ace:
+        repo: https://github.com/purescript-contrib/purescript-ace.git
+        version: v9.0.0
+        dependencies:
+          - arrays
+          - effect
+          - foreign
+          - nullable
+          - prelude
+          - web-html
+          - web-uievents
+      aff:
+        repo: https://github.com/purescript-contrib/purescript-aff.git
+        version: v7.0.0
+        dependencies:
+          - datetime
+          - effect
+          - exceptions
+          - functions
+          - parallel
+          - transformers
+          - unsafe-coerce
+      aff-bus:
+        repo: https://github.com/purescript-contrib/purescript-aff-bus.git
+        version: v6.0.0
+        dependencies:
+          - aff
+          - avar
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - lists
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+      aff-coroutines:
+        repo: https://github.com/purescript-contrib/purescript-aff-coroutines.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - avar
+          - coroutines
+          - effect
+      aff-promise:
+        repo: https://github.com/nwolverson/purescript-aff-promise.git
+        version: v4.0.0
+        dependencies:
+          - aff
+          - foreign
+      aff-retry:
+        repo: https://github.com/Unisay/purescript-aff-retry.git
+        version: v2.0.0
+        dependencies:
+          - aff
+          - arrays
+          - datetime
+          - effect
+          - either
+          - exceptions
+          - integers
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - random
+          - transformers
+      affjax:
+        repo: https://github.com/purescript-contrib/purescript-affjax.git
+        version: v13.0.0
+        dependencies:
+          - aff
+          - argonaut-core
+          - arraybuffer-types
+          - foreign
+          - form-urlencoded
+          - http-methods
+          - integers
+          - media-types
+          - nullable
+          - refs
+          - unsafe-coerce
+          - web-xhr
+      affjax-node:
+        repo: https://github.com/purescript-contrib/purescript-affjax-node.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - affjax
+          - either
+          - maybe
+          - prelude
+      affjax-web:
+        repo: https://github.com/purescript-contrib/purescript-affjax-web.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - affjax
+          - either
+          - maybe
+          - prelude
+      ansi:
+        repo: https://github.com/hdgarrood/purescript-ansi.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - lists
+          - strings
+      argonaut:
+        repo: https://github.com/purescript-contrib/purescript-argonaut.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - argonaut-traversals
+      argonaut-codecs:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-codecs.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-core
+          - arrays
+          - effect
+          - foreign-object
+          - identity
+          - integers
+          - maybe
+          - nonempty
+          - ordered-collections
+          - prelude
+          - record
+      argonaut-core:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-core.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - foreign-object
+          - functions
+          - gen
+          - maybe
+          - nonempty
+          - prelude
+          - strings
+          - tailrec
+      argonaut-generic:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-generic.git
+        version: v8.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - prelude
+          - record
+      argonaut-traversals:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-traversals.git
+        version: v10.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - profunctor-lenses
+      argparse-basic:
+        repo: https://github.com/natefaubion/purescript-argparse-basic.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - record
+          - strings
+          - tuples
+          - unfoldable
+      arraybuffer:
+        repo: https://github.com/purescript-contrib/purescript-arraybuffer.git
+        version: v13.0.0
+        dependencies:
+          - arraybuffer-types
+          - arrays
+          - effect
+          - float32
+          - functions
+          - gen
+          - maybe
+          - nullable
+          - prelude
+          - tailrec
+          - uint
+          - unfoldable
+      arraybuffer-builder:
+        repo: https://github.com/jamesdbrock/purescript-arraybuffer-builder.git
+        version: v3.0.1
+        dependencies:
+          - arraybuffer
+          - arraybuffer-types
+          - effect
+          - float32
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - transformers
+          - uint
+      arraybuffer-types:
+        repo: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
+        version: v3.0.2
+        dependencies: []
+      arrays:
+        repo: https://github.com/purescript/purescript-arrays.git
+        version: v7.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - foldable-traversable
+          - maybe
+          - nonempty
+          - partial
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - unfoldable
+          - unsafe-coerce
+      arrays-zipper:
+        repo: https://github.com/JordanMartinez/purescript-arrays-zipper.git
+        version: v2.0.1
+        dependencies:
+          - arrays
+          - control
+          - quickcheck
+      ask:
+        repo: https://github.com/Mateiadrielrafael/purescript-ask.git
+        version: v1.0.0
+        dependencies:
+          - unsafe-coerce
+      assert:
+        repo: https://github.com/purescript/purescript-assert.git
+        version: v6.0.0
+        dependencies:
+          - console
+          - effect
+          - prelude
+      avar:
+        repo: https://github.com/purescript-contrib/purescript-avar.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - exceptions
+          - functions
+          - maybe
+      b64:
+        repo: https://github.com/menelaos/purescript-b64.git
+        version: v0.0.8
+        dependencies:
+          - arraybuffer-types
+          - either
+          - encoding
+          - enums
+          - exceptions
+          - functions
+          - partial
+          - prelude
+          - strings
+      barlow-lens:
+        repo: https://github.com/sigma-andex/purescript-barlow-lens.git
+        version: v0.9.0
+        dependencies:
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - profunctor-lenses
+          - tuples
+          - typelevel-prelude
+      bifunctors:
+        repo: https://github.com/purescript/purescript-bifunctors.git
+        version: v6.0.0
+        dependencies:
+          - const
+          - either
+          - newtype
+          - prelude
+          - tuples
+      bigints:
+        repo: https://github.com/sharkdp/purescript-bigints.git
+        version: v7.0.1
+        dependencies:
+          - integers
+          - maybe
+          - strings
+      bower-json:
+        repo: https://github.com/klntsky/purescript-bower-json.git
+        version: v3.0.0
+        dependencies:
+          - argonaut-codecs
+          - arrays
+          - either
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - newtype
+          - prelude
+          - tuples
+      call-by-name:
+        repo: https://github.com/natefaubion/purescript-call-by-name.git
+        version: v4.0.1
+        dependencies:
+          - control
+          - either
+          - lazy
+          - maybe
+          - unsafe-coerce
+      canvas:
+        repo: https://github.com/purescript-web/purescript-canvas.git
+        version: v6.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - exceptions
+          - functions
+          - maybe
+      canvas-action:
+        repo: https://github.com/artemisSystem/purescript-canvas-action.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - arrays
+          - canvas
+          - colors
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - maybe
+          - numbers
+          - polymorphic-vectors
+          - prelude
+          - refs
+          - run
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-html
+      cartesian:
+        repo: https://github.com/Ebmtranceboy/purescript-cartesian.git
+        version: v1.0.6
+        dependencies:
+          - console
+          - effect
+          - integers
+          - psci-support
+      catenable-lists:
+        repo: https://github.com/purescript/purescript-catenable-lists.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - lists
+          - maybe
+          - prelude
+          - tuples
+          - unfoldable
+      channel:
+        repo: https://github.com/ConnorDillon/purescript-channel.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - assert
+          - avar
+          - console
+          - contravariant
+          - control
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - lazy
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      checked-exceptions:
+        repo: https://github.com/natefaubion/purescript-checked-exceptions.git
+        version: v3.1.1
+        dependencies:
+          - prelude
+          - transformers
+          - variant
+      codec:
+        repo: https://github.com/garyb/purescript-codec.git
+        version: v5.0.0
+        dependencies:
+          - profunctor
+          - transformers
+      codec-argonaut:
+        repo: https://github.com/garyb/purescript-codec-argonaut.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-core
+          - codec
+          - ordered-collections
+          - type-equality
+          - variant
+      colors:
+        repo: https://github.com/purescript-contrib/purescript-colors.git
+        version: v7.0.1
+        dependencies:
+          - arrays
+          - integers
+          - lists
+          - numbers
+          - partial
+          - strings
+      concurrent-queues:
+        repo: https://github.com/purescript-contrib/purescript-concurrent-queues.git
+        version: v3.0.0
+        dependencies:
+          - aff
+          - avar
+          - effect
+      console:
+        repo: https://github.com/purescript/purescript-console.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - prelude
+      const:
+        repo: https://github.com/purescript/purescript-const.git
+        version: v6.0.0
+        dependencies:
+          - invariant
+          - newtype
+          - prelude
+      contravariant:
+        repo: https://github.com/purescript/purescript-contravariant.git
+        version: v6.0.0
+        dependencies:
+          - const
+          - either
+          - newtype
+          - prelude
+          - tuples
+      control:
+        repo: https://github.com/purescript/purescript-control.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      convertable-options:
+        repo: https://github.com/natefaubion/purescript-convertable-options.git
+        version: v1.0.0
+        dependencies:
+          - console
+          - effect
+          - maybe
+          - record
+      coroutines:
+        repo: https://github.com/purescript-contrib/purescript-coroutines.git
+        version: v7.0.0
+        dependencies:
+          - freet
+          - parallel
+          - profunctor
+      css:
+        repo: https://github.com/purescript-contrib/purescript-css.git
+        version: v6.0.0
+        dependencies:
+          - colors
+          - console
+          - effect
+          - nonempty
+          - profunctor
+          - strings
+          - these
+          - transformers
+      datetime:
+        repo: https://github.com/purescript/purescript-datetime.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - either
+          - enums
+          - foldable-traversable
+          - functions
+          - gen
+          - integers
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - ordered-collections
+          - partial
+          - prelude
+          - tuples
+      datetime-parsing:
+        repo: https://github.com/flounders/purescript-datetime-parsing.git
+        version: v0.2.0
+        dependencies:
+          - arrays
+          - datetime
+          - either
+          - enums
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - numbers
+          - parsing
+          - prelude
+          - strings
+          - unicode
+      debug:
+        repo: https://github.com/garyb/purescript-debug.git
+        version: v6.0.0
+        dependencies:
+          - functions
+          - prelude
+      decimals:
+        repo: https://github.com/sharkdp/purescript-decimals.git
+        version: v7.0.0
+        dependencies:
+          - maybe
+      dissect:
+        repo: https://github.com/PureFunctor/purescript-dissect.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - foreign-object
+          - functors
+          - newtype
+          - partial
+          - prelude
+          - tailrec
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - variant
+      distributive:
+        repo: https://github.com/purescript/purescript-distributive.git
+        version: v6.0.0
+        dependencies:
+          - identity
+          - newtype
+          - prelude
+          - tuples
+          - type-equality
+      dodo-printer:
+        repo: https://github.com/natefaubion/purescript-dodo-printer.git
+        version: v2.2.0
+        dependencies:
+          - aff
+          - ansi
+          - avar
+          - console
+          - effect
+          - foldable-traversable
+          - lists
+          - maybe
+          - minibench
+          - node-child-process
+          - node-fs-aff
+          - node-process
+          - psci-support
+          - strings
+      dom-indexed:
+        repo: https://github.com/purescript-halogen/purescript-dom-indexed.git
+        version: v11.0.0
+        dependencies:
+          - media-types
+          - prelude
+          - web-clipboard
+          - web-pointerevents
+          - web-touchevents
+      droplet:
+        repo: https://github.com/easafe/purescript-droplet.git
+        version: v0.4.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - bigints
+          - datetime
+          - debug
+          - effect
+          - either
+          - enums
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - integers
+          - maybe
+          - newtype
+          - nullable
+          - ordered-collections
+          - partial
+          - prelude
+          - profunctor
+          - record
+          - spec
+          - strings
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+      dynamic-buffer:
+        repo: https://github.com/kritzcreek/purescript-dynamic-buffer.git
+        version: v3.0.1
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - refs
+      effect:
+        repo: https://github.com/purescript/purescript-effect.git
+        version: v4.0.0
+        dependencies:
+          - prelude
+      either:
+        repo: https://github.com/purescript/purescript-either.git
+        version: v6.1.0
+        dependencies:
+          - control
+          - invariant
+          - maybe
+          - prelude
+      elmish:
+        repo: https://github.com/collegevine/purescript-elmish.git
+        version: v0.8.1
+        dependencies:
+          - aff
+          - argonaut-core
+          - arrays
+          - bifunctors
+          - console
+          - debug
+          - effect
+          - either
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - functions
+          - integers
+          - js-date
+          - maybe
+          - nullable
+          - partial
+          - prelude
+          - refs
+          - typelevel-prelude
+          - undefined-is-not-a-problem
+          - unsafe-coerce
+          - web-dom
+          - web-html
+      elmish-enzyme:
+        repo: https://github.com/collegevine/purescript-elmish-enzyme.git
+        version: v0.1.1
+        dependencies:
+          - aff
+          - aff-promise
+          - arrays
+          - console
+          - debug
+          - effect
+          - elmish
+          - foldable-traversable
+          - foreign
+          - functions
+          - prelude
+          - transformers
+          - unsafe-coerce
+      elmish-hooks:
+        repo: https://github.com/collegevine/purescript-elmish-hooks.git
+        version: v0.8.2
+        dependencies:
+          - aff
+          - debug
+          - elmish
+          - maybe
+          - prelude
+          - tuples
+          - undefined-is-not-a-problem
+      elmish-html:
+        repo: https://github.com/collegevine/purescript-elmish-html.git
+        version: v0.7.1
+        dependencies:
+          - effect
+          - elmish
+          - foreign
+          - foreign-object
+          - prelude
+          - record
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-html
+      email-validate:
+        repo: https://github.com/cdepillabout/purescript-email-validate.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - string-parsers
+          - transformers
+      encoding:
+        repo: https://github.com/menelaos/purescript-encoding.git
+        version: v0.0.8
+        dependencies:
+          - arraybuffer-types
+          - either
+          - exceptions
+          - functions
+          - prelude
+      enums:
+        repo: https://github.com/purescript/purescript-enums.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - either
+          - gen
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tuples
+          - unfoldable
+      exceptions:
+        repo: https://github.com/purescript/purescript-exceptions.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - either
+          - maybe
+          - prelude
+      exists:
+        repo: https://github.com/purescript/purescript-exists.git
+        version: v6.0.0
+        dependencies:
+          - unsafe-coerce
+      exitcodes:
+        repo: https://github.com/Risto-Stevcev/purescript-exitcodes.git
+        version: v4.0.0
+        dependencies:
+          - enums
+      expect-inferred:
+        repo: https://github.com/justinwoo/purescript-expect-inferred.git
+        version: v3.0.0
+        dependencies:
+          - prelude
+          - typelevel-prelude
+      fast-vect:
+        repo: https://github.com/sigma-andex/purescript-fast-vect.git
+        version: v0.7.0
+        dependencies:
+          - arrays
+          - filterable
+          - foldable-traversable
+          - lists
+          - maybe
+          - ordered-collections
+          - prelude
+          - profunctor
+          - tuples
+          - unfoldable
+      filterable:
+        repo: https://github.com/purescript/purescript-filterable.git
+        version: v5.0.0
+        dependencies:
+          - arrays
+          - either
+          - foldable-traversable
+          - identity
+          - lists
+          - ordered-collections
+      fixed-points:
+        repo: https://github.com/purescript-contrib/purescript-fixed-points.git
+        version: v7.0.0
+        dependencies:
+          - exists
+          - newtype
+          - prelude
+          - transformers
+      fixed-precision:
+        repo: https://github.com/lumihq/purescript-fixed-precision.git
+        version: v5.0.0
+        dependencies:
+          - arrays
+          - bigints
+          - control
+          - integers
+          - maybe
+          - numbers
+          - partial
+          - prelude
+          - strings
+      flame:
+        repo: https://github.com/easafe/purescript-flame.git
+        version: v1.2.0
+        dependencies:
+          - aff
+          - argonaut-codecs
+          - argonaut-core
+          - argonaut-generic
+          - arrays
+          - bifunctors
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - maybe
+          - newtype
+          - nullable
+          - partial
+          - prelude
+          - random
+          - refs
+          - spec
+          - strings
+          - tuples
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-html
+          - web-uievents
+      float32:
+        repo: https://github.com/purescript-contrib/purescript-float32.git
+        version: v2.0.0
+        dependencies:
+          - gen
+          - maybe
+          - prelude
+      foldable-traversable:
+        repo: https://github.com/purescript/purescript-foldable-traversable.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - const
+          - control
+          - either
+          - functors
+          - identity
+          - maybe
+          - newtype
+          - orders
+          - prelude
+          - tuples
+      foreign:
+        repo: https://github.com/purescript/purescript-foreign.git
+        version: v7.0.0
+        dependencies:
+          - either
+          - functions
+          - identity
+          - integers
+          - lists
+          - maybe
+          - prelude
+          - strings
+          - transformers
+      foreign-object:
+        repo: https://github.com/purescript/purescript-foreign-object.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - functions
+          - gen
+          - lists
+          - maybe
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - typelevel-prelude
+          - unfoldable
+      foreign-readwrite:
+        repo: https://github.com/artemisSystem/purescript-foreign-readwrite.git
+        version: v3.0.0
+        dependencies:
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - record
+          - safe-coerce
+          - transformers
+          - unsafe-coerce
+      fork:
+        repo: https://github.com/purescript-contrib/purescript-fork.git
+        version: v6.0.0
+        dependencies:
+          - aff
+      form-urlencoded:
+        repo: https://github.com/purescript-contrib/purescript-form-urlencoded.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - js-uri
+          - maybe
+          - newtype
+          - prelude
+          - strings
+          - tuples
+      formatters:
+        repo: https://github.com/purescript-contrib/purescript-formatters.git
+        version: v7.0.0
+        dependencies:
+          - datetime
+          - fixed-points
+          - lists
+          - numbers
+          - parsing
+          - prelude
+          - transformers
+      free:
+        repo: https://github.com/purescript/purescript-free.git
+        version: v7.0.0
+        dependencies:
+          - catenable-lists
+          - control
+          - distributive
+          - either
+          - exists
+          - foldable-traversable
+          - invariant
+          - lazy
+          - maybe
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+      freeap:
+        repo: https://github.com/ethul/purescript-freeap.git
+        version: v7.0.0
+        dependencies:
+          - const
+          - exists
+          - gen
+          - lists
+      freet:
+        repo: https://github.com/purescript-contrib/purescript-freet.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - bifunctors
+          - effect
+          - either
+          - exists
+          - free
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      functions:
+        repo: https://github.com/purescript/purescript-functions.git
+        version: v6.0.0
+        dependencies:
+          - prelude
+      functors:
+        repo: https://github.com/purescript/purescript-functors.git
+        version: v5.0.0
+        dependencies:
+          - bifunctors
+          - const
+          - contravariant
+          - control
+          - distributive
+          - either
+          - invariant
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - tuples
+          - unsafe-coerce
+      fuzzy:
+        repo: https://github.com/citizennet/purescript-fuzzy.git
+        version: v0.4.0
+        dependencies:
+          - foldable-traversable
+          - foreign-object
+          - newtype
+          - ordered-collections
+          - prelude
+          - rationals
+          - strings
+          - tuples
+      gen:
+        repo: https://github.com/purescript/purescript-gen.git
+        version: v4.0.0
+        dependencies:
+          - either
+          - foldable-traversable
+          - identity
+          - maybe
+          - newtype
+          - nonempty
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      generate-values:
+        repo: https://github.com/jordanmartinez/purescript-generate-values.git
+        version: v1.0.1
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - enums
+          - foldable-traversable
+          - gen
+          - identity
+          - integers
+          - lcg
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - partial
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      geometry-plane:
+        repo: https://github.com/Ebmtranceboy/purescript-geometry-plane.git
+        version: v1.0.3
+        dependencies:
+          - console
+          - effect
+          - psci-support
+          - sparse-polynomials
+      github-actions-toolkit:
+        repo: https://github.com/purescript-contrib/purescript-github-actions-toolkit.git
+        version: v0.5.0
+        dependencies:
+          - aff
+          - aff-promise
+          - effect
+          - foreign-object
+          - node-buffer
+          - node-path
+          - node-streams
+          - nullable
+          - transformers
+      graphs:
+        repo: https://github.com/purescript/purescript-graphs.git
+        version: v8.0.0
+        dependencies:
+          - catenable-lists
+          - ordered-collections
+      group:
+        repo: https://github.com/morganthomas/purescript-group.git
+        version: v4.1.1
+        dependencies:
+          - lists
+      halogen:
+        repo: https://github.com/purescript-halogen/purescript-halogen.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - avar
+          - console
+          - const
+          - dom-indexed
+          - effect
+          - foreign
+          - fork
+          - free
+          - freeap
+          - halogen-subscriptions
+          - halogen-vdom
+          - media-types
+          - nullable
+          - ordered-collections
+          - parallel
+          - profunctor
+          - transformers
+          - unsafe-coerce
+          - unsafe-reference
+          - web-file
+          - web-uievents
+      halogen-css:
+        repo: https://github.com/purescript-halogen/purescript-halogen-css.git
+        version: v10.0.0
+        dependencies:
+          - css
+          - halogen
+      halogen-formless:
+        repo: https://github.com/thomashoneyman/purescript-halogen-formless.git
+        version: v4.0.0
+        dependencies:
+          - convertable-options
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - halogen
+          - heterogeneous
+          - maybe
+          - prelude
+          - record
+          - safe-coerce
+          - type-equality
+          - unsafe-coerce
+          - unsafe-reference
+          - variant
+          - web-events
+          - web-uievents
+      halogen-hooks:
+        repo: https://github.com/thomashoneyman/purescript-halogen-hooks.git
+        version: v0.6.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - effect
+          - exceptions
+          - foldable-traversable
+          - foreign-object
+          - free
+          - freeap
+          - halogen
+          - halogen-subscriptions
+          - maybe
+          - newtype
+          - ordered-collections
+          - parallel
+          - partial
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+          - unsafe-reference
+          - web-dom
+          - web-html
+      halogen-hooks-extra:
+        repo: https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git
+        version: v0.9.0
+        dependencies:
+          - halogen-hooks
+      halogen-store:
+        repo: https://github.com/thomashoneyman/purescript-halogen-store.git
+        version: v0.5.0
+        dependencies:
+          - aff
+          - distributive
+          - effect
+          - fork
+          - halogen
+          - halogen-hooks
+          - halogen-subscriptions
+          - maybe
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-reference
+      halogen-storybook:
+        repo: https://github.com/rnons/purescript-halogen-storybook.git
+        version: v2.0.0
+        dependencies:
+          - foreign-object
+          - halogen
+          - prelude
+          - routing
+      halogen-subscriptions:
+        repo: https://github.com/purescript-halogen/purescript-halogen-subscriptions.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - effect
+          - foldable-traversable
+          - functors
+          - refs
+          - safe-coerce
+          - unsafe-reference
+      halogen-svg-elems:
+        repo: https://github.com/JordanMartinez/purescript-halogen-svg-elems.git
+        version: v6.0.0
+        dependencies:
+          - halogen
+      halogen-vdom:
+        repo: https://github.com/purescript-halogen/purescript-halogen-vdom.git
+        version: v8.0.0
+        dependencies:
+          - bifunctors
+          - effect
+          - foreign
+          - foreign-object
+          - maybe
+          - prelude
+          - refs
+          - tuples
+          - unsafe-coerce
+          - web-html
+      halogen-vdom-string-renderer:
+        repo: https://github.com/purescript-halogen/purescript-halogen-vdom-string-renderer.git
+        version: v0.5.0
+        dependencies:
+          - foreign
+          - halogen-vdom
+          - ordered-collections
+          - prelude
+      heckin:
+        repo: https://github.com/maxdeviant/purescript-heckin.git
+        version: v2.0.1
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - maybe
+          - prelude
+          - strings
+          - transformers
+          - tuples
+          - unicode
+      heterogeneous:
+        repo: https://github.com/natefaubion/purescript-heterogeneous.git
+        version: v0.6.0
+        dependencies:
+          - either
+          - functors
+          - prelude
+          - record
+          - tuples
+          - variant
+      heterogeneous-extrablatt:
+        repo: https://github.com/sigma-andex/purescript-heterogeneous-extrablatt.git
+        version: v0.2.1
+        dependencies:
+          - heterogeneous
+          - prelude
+          - record
+      http-methods:
+        repo: https://github.com/purescript-contrib/purescript-http-methods.git
+        version: v6.0.0
+        dependencies:
+          - either
+          - prelude
+          - strings
+      httpure:
+        repo: https://github.com/citizennet/purescript-httpure.git
+        version: v0.15.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - js-uri
+          - maybe
+          - newtype
+          - node-buffer
+          - node-fs
+          - node-http
+          - node-streams
+          - options
+          - ordered-collections
+          - prelude
+          - refs
+          - strings
+          - tuples
+          - type-equality
+      httpurple:
+        repo: https://github.com/sigma-andex/purescript-httpurple.git
+        version: v1.3.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - js-uri
+          - justifill
+          - maybe
+          - newtype
+          - node-buffer
+          - node-fs
+          - node-http
+          - node-net
+          - node-process
+          - node-streams
+          - options
+          - ordered-collections
+          - posix-types
+          - prelude
+          - profunctor
+          - record
+          - refs
+          - routing-duplex
+          - strings
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+      httpurple-argonaut:
+        repo: https://github.com/sigma-andex/purescript-httpurple-argonaut.git
+        version: v1.0.1
+        dependencies:
+          - argonaut
+          - console
+          - effect
+          - either
+          - httpurple
+          - prelude
+      httpurple-yoga-json:
+        repo: https://github.com/sigma-andex/purescript-httpurple-yoga-json.git
+        version: v1.0.0
+        dependencies:
+          - console
+          - effect
+          - either
+          - foreign
+          - httpurple
+          - lists
+          - prelude
+          - yoga-json
+      identity:
+        repo: https://github.com/purescript/purescript-identity.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - invariant
+          - newtype
+          - prelude
+      indexed-monad:
+        repo: https://github.com/garyb/purescript-indexed-monad.git
+        version: v2.1.0
+        dependencies:
+          - control
+          - newtype
+      int64:
+        repo: https://github.com/purescript-contrib/purescript-int64.git
+        version: v2.0.0
+        dependencies:
+          - effect
+          - foreign
+          - functions
+          - integers
+          - maybe
+          - nullable
+          - prelude
+          - quickcheck
+      integers:
+        repo: https://github.com/purescript/purescript-integers.git
+        version: v6.0.0
+        dependencies:
+          - maybe
+          - numbers
+          - prelude
+      interpolate:
+        repo: https://github.com/jordanmartinez/purescript-interpolate.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+      invariant:
+        repo: https://github.com/purescript/purescript-invariant.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - prelude
+      js-date:
+        repo: https://github.com/purescript-contrib/purescript-js-date.git
+        version: v8.0.0
+        dependencies:
+          - datetime
+          - effect
+          - exceptions
+          - foreign
+          - integers
+          - now
+      js-fileio:
+        repo: https://github.com/newlandsvalley/purescript-js-fileio.git
+        version: v3.0.0
+        dependencies:
+          - aff
+          - effect
+          - prelude
+      js-timers:
+        repo: https://github.com/purescript-contrib/purescript-js-timers.git
+        version: v6.1.0
+        dependencies:
+          - effect
+      js-uri:
+        repo: https://github.com/purescript-contrib/purescript-js-uri.git
+        version: v3.0.0
+        dependencies:
+          - functions
+          - maybe
+      justifill:
+        repo: https://github.com/i-am-the-slime/purescript-justifill.git
+        version: v0.5.0
+        dependencies:
+          - maybe
+          - prelude
+          - record
+          - typelevel-prelude
+      jwt:
+        repo: https://github.com/menelaos/purescript-jwt.git
+        version: v0.0.9
+        dependencies:
+          - argonaut-core
+          - arrays
+          - b64
+          - either
+          - exceptions
+          - prelude
+          - profunctor-lenses
+          - strings
+      language-cst-parser:
+        repo: https://github.com/natefaubion/purescript-language-cst-parser.git
+        version: v0.12.0
+        dependencies:
+          - arrays
+          - const
+          - control
+          - either
+          - foldable-traversable
+          - free
+          - functions
+          - functors
+          - identity
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - ordered-collections
+          - partial
+          - prelude
+          - st
+          - strings
+          - transformers
+          - tuples
+          - typelevel-prelude
+          - unfoldable
+          - unsafe-coerce
+      lazy:
+        repo: https://github.com/purescript/purescript-lazy.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - invariant
+          - prelude
+      lcg:
+        repo: https://github.com/purescript/purescript-lcg.git
+        version: v4.0.0
+        dependencies:
+          - effect
+          - integers
+          - maybe
+          - partial
+          - prelude
+          - random
+      leibniz:
+        repo: https://github.com/paf31/purescript-leibniz.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+          - unsafe-coerce
+      linalg:
+        repo: https://github.com/gbagan/purescript-linalg.git
+        version: v5.1.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - functions
+          - maybe
+          - prelude
+          - tuples
+      lists:
+        repo: https://github.com/purescript/purescript-lists.git
+        version: v7.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - foldable-traversable
+          - lazy
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      logging:
+        repo: https://github.com/rightfold/purescript-logging.git
+        version: v3.0.0
+        dependencies:
+          - console
+          - contravariant
+          - effect
+          - either
+          - prelude
+          - transformers
+          - tuples
+      machines:
+        repo: https://github.com/purescript-contrib/purescript-machines.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - lists
+          - maybe
+          - prelude
+          - profunctor
+          - tuples
+          - unfoldable
+      matrices:
+        repo: https://github.com/kRITZCREEK/purescript-matrices.git
+        version: v5.0.1
+        dependencies:
+          - arrays
+          - strings
+      matryoshka:
+        repo: https://github.com/purescript-contrib/purescript-matryoshka.git
+        version: v1.0.0
+        dependencies:
+          - fixed-points
+          - free
+          - prelude
+          - profunctor
+          - transformers
+      maybe:
+        repo: https://github.com/purescript/purescript-maybe.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - invariant
+          - newtype
+          - prelude
+      media-types:
+        repo: https://github.com/purescript-contrib/purescript-media-types.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      metadata:
+        repo: https://github.com/purescript/purescript-metadata.git
+        version: v0.15.0
+        dependencies: []
+      midi:
+        repo: https://github.com/newlandsvalley/purescript-midi.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - ordered-collections
+          - prelude
+          - signal
+          - string-parsers
+          - strings
+          - tuples
+          - unfoldable
+      minibench:
+        repo: https://github.com/purescript/purescript-minibench.git
+        version: v4.0.0
+        dependencies:
+          - console
+          - effect
+          - integers
+          - numbers
+          - partial
+          - prelude
+          - refs
+      mmorph:
+        repo: https://github.com/Thimoteus/purescript-mmorph.git
+        version: v7.0.0
+        dependencies:
+          - free
+          - functors
+          - transformers
+      monad-control:
+        repo: https://github.com/athanclark/purescript-monad-control.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - freet
+          - identity
+          - lists
+      monad-logger:
+        repo: https://github.com/cprussin/purescript-monad-logger.git
+        version: v1.3.1
+        dependencies:
+          - aff
+          - ansi
+          - argonaut
+          - arrays
+          - console
+          - control
+          - effect
+          - foldable-traversable
+          - foreign-object
+          - integers
+          - js-date
+          - maybe
+          - newtype
+          - ordered-collections
+          - prelude
+          - strings
+          - transformers
+          - tuples
+      monad-loops:
+        repo: https://github.com/mlang/purescript-monad-loops.git
+        version: v0.5.0
+        dependencies:
+          - lists
+          - maybe
+          - prelude
+          - tailrec
+          - tuples
+      monad-unlift:
+        repo: https://github.com/athanclark/purescript-monad-unlift.git
+        version: v1.0.1
+        dependencies:
+          - monad-control
+      monoidal:
+        repo: https://github.com/mcneissue/purescript-monoidal.git
+        version: v0.16.0
+        dependencies:
+          - either
+          - profunctor
+          - these
+          - tuples
+      morello:
+        repo: https://github.com/sigma-andex/purescript-morello.git
+        version: v0.3.2
+        dependencies:
+          - arrays
+          - barlow-lens
+          - foldable-traversable
+          - heterogeneous
+          - heterogeneous-extrablatt
+          - newtype
+          - prelude
+          - profunctor
+          - profunctor-lenses
+          - record
+          - tuples
+          - typelevel-prelude
+          - validation
+      motsunabe:
+        repo: https://github.com/justinwoo/purescript-motsunabe.git
+        version: v2.0.0
+        dependencies:
+          - lists
+          - strings
+      nano-id:
+        repo: https://github.com/eikooc/nano-id.git
+        version: v1.1.0
+        dependencies:
+          - aff
+          - effect
+          - lists
+          - maybe
+          - prelude
+          - random
+          - spec
+          - strings
+          - stringutils
+      naturals:
+        repo: https://github.com/LiamGoodacre/purescript-naturals.git
+        version: v3.0.0
+        dependencies:
+          - enums
+          - maybe
+          - prelude
+      nested-functor:
+        repo: https://github.com/acple/purescript-nested-functor.git
+        version: v0.2.1
+        dependencies:
+          - prelude
+          - type-equality
+      newtype:
+        repo: https://github.com/purescript/purescript-newtype.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+          - safe-coerce
+      node-buffer:
+        repo: https://github.com/purescript-node/purescript-node-buffer.git
+        version: v8.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - maybe
+          - st
+          - unsafe-coerce
+      node-buffer-blob:
+        repo: https://github.com/purescript-node/purescript-node-buffer-blob.git
+        version: v1.0.0
+        dependencies:
+          - aff-promise
+          - arraybuffer-types
+          - arrays
+          - console
+          - effect
+          - maybe
+          - media-types
+          - newtype
+          - node-buffer
+          - nullable
+          - prelude
+          - web-streams
+      node-child-process:
+        repo: https://github.com/purescript-node/purescript-node-child-process.git
+        version: v9.0.0
+        dependencies:
+          - exceptions
+          - foreign
+          - foreign-object
+          - functions
+          - node-fs
+          - node-streams
+          - nullable
+          - posix-types
+          - unsafe-coerce
+      node-fs:
+        repo: https://github.com/purescript-node/purescript-node-fs.git
+        version: v8.0.0
+        dependencies:
+          - datetime
+          - effect
+          - either
+          - enums
+          - exceptions
+          - functions
+          - integers
+          - js-date
+          - maybe
+          - node-buffer
+          - node-path
+          - node-streams
+          - nullable
+          - partial
+          - prelude
+          - strings
+          - unsafe-coerce
+      node-fs-aff:
+        repo: https://github.com/purescript-node/purescript-node-fs-aff.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - either
+          - node-fs
+          - node-path
+      node-http:
+        repo: https://github.com/purescript-node/purescript-node-http.git
+        version: v8.0.0
+        dependencies:
+          - arraybuffer-types
+          - contravariant
+          - effect
+          - foreign
+          - foreign-object
+          - maybe
+          - node-buffer
+          - node-net
+          - node-streams
+          - node-url
+          - nullable
+          - options
+          - prelude
+          - unsafe-coerce
+      node-net:
+        repo: https://github.com/purescript-node/purescript-node-net.git
+        version: v4.0.0
+        dependencies:
+          - effect
+          - either
+          - exceptions
+          - foreign
+          - maybe
+          - node-buffer
+          - node-fs
+          - nullable
+          - options
+          - prelude
+          - transformers
+      node-path:
+        repo: https://github.com/purescript-node/purescript-node-path.git
+        version: v5.0.0
+        dependencies:
+          - effect
+      node-process:
+        repo: https://github.com/purescript-node/purescript-node-process.git
+        version: v10.0.0
+        dependencies:
+          - effect
+          - foreign-object
+          - maybe
+          - node-streams
+          - posix-types
+          - prelude
+          - unsafe-coerce
+      node-readline:
+        repo: https://github.com/purescript-node/purescript-node-readline.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - foreign
+          - node-process
+          - node-streams
+          - options
+          - prelude
+      node-streams:
+        repo: https://github.com/purescript-node/purescript-node-streams.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - either
+          - exceptions
+          - node-buffer
+          - nullable
+          - prelude
+      node-streams-aff:
+        repo: https://github.com/jamesdbrock/purescript-node-streams-aff.git
+        version: v2.0.0
+        dependencies:
+          - aff
+          - arrays
+          - effect
+          - either
+          - exceptions
+          - maybe
+          - node-buffer
+          - node-streams
+          - prelude
+          - st
+          - tuples
+      node-url:
+        repo: https://github.com/purescript-node/purescript-node-url.git
+        version: v6.0.0
+        dependencies:
+          - nullable
+      nonempty:
+        repo: https://github.com/purescript/purescript-nonempty.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - maybe
+          - prelude
+          - tuples
+          - unfoldable
+      now:
+        repo: https://github.com/purescript-contrib/purescript-now.git
+        version: v6.0.0
+        dependencies:
+          - datetime
+          - effect
+      npm-package-json:
+        repo: https://github.com/maxdeviant/purescript-npm-package-json.git
+        version: v2.0.0
+        dependencies:
+          - argonaut
+          - control
+          - either
+          - foreign-object
+          - maybe
+          - ordered-collections
+          - prelude
+      nullable:
+        repo: https://github.com/purescript-contrib/purescript-nullable.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - functions
+          - maybe
+      numbers:
+        repo: https://github.com/purescript/purescript-numbers.git
+        version: v9.0.0
+        dependencies:
+          - functions
+          - maybe
+      open-folds:
+        repo: https://github.com/purescript-open-community/purescript-open-folds.git
+        version: v6.3.0
+        dependencies:
+          - bifunctors
+          - console
+          - control
+          - distributive
+          - effect
+          - either
+          - foldable-traversable
+          - identity
+          - invariant
+          - maybe
+          - newtype
+          - ordered-collections
+          - prelude
+          - profunctor
+          - psci-support
+          - tuples
+      open-memoize:
+        repo: https://github.com/purescript-open-community/purescript-open-memoize.git
+        version: v6.1.0
+        dependencies:
+          - console
+          - effect
+          - either
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - psci-support
+          - strings
+          - tuples
+      open-pairing:
+        repo: https://github.com/purescript-open-community/purescript-open-pairing.git
+        version: v6.1.0
+        dependencies:
+          - console
+          - control
+          - effect
+          - either
+          - free
+          - functors
+          - identity
+          - newtype
+          - prelude
+          - psci-support
+          - transformers
+          - tuples
+      options:
+        repo: https://github.com/purescript-contrib/purescript-options.git
+        version: v7.0.0
+        dependencies:
+          - contravariant
+          - foreign
+          - foreign-object
+          - maybe
+          - tuples
+      optparse:
+        repo: https://github.com/f-o-a-m/purescript-optparse.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - control
+          - effect
+          - either
+          - enums
+          - exists
+          - exitcodes
+          - foldable-traversable
+          - free
+          - gen
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - newtype
+          - node-buffer
+          - node-process
+          - node-streams
+          - nonempty
+          - numbers
+          - open-memoize
+          - partial
+          - prelude
+          - quickcheck
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+      ordered-collections:
+        repo: https://github.com/purescript/purescript-ordered-collections.git
+        version: v3.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - gen
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - unfoldable
+      ordered-set:
+        repo: https://github.com/flip111/purescript-ordered-set.git
+        version: v0.4.0
+        dependencies:
+          - argonaut-codecs
+          - arrays
+          - partial
+          - prelude
+          - unfoldable
+      orders:
+        repo: https://github.com/purescript/purescript-orders.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      pairs:
+        repo: https://github.com/sharkdp/purescript-pairs.git
+        version: v9.0.0
+        dependencies:
+          - console
+          - distributive
+          - foldable-traversable
+          - quickcheck
+      parallel:
+        repo: https://github.com/purescript/purescript-parallel.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - functors
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - refs
+          - transformers
+      parsing:
+        repo: https://github.com/purescript-contrib/purescript-parsing.git
+        version: v9.1.0
+        dependencies:
+          - arrays
+          - either
+          - foldable-traversable
+          - identity
+          - integers
+          - lists
+          - maybe
+          - nullable
+          - prelude
+          - strings
+          - transformers
+          - unicode
+      parsing-dataview:
+        repo: https://github.com/jamesdbrock/purescript-parsing-dataview.git
+        version: v3.1.0
+        dependencies:
+          - arraybuffer
+          - arraybuffer-types
+          - effect
+          - float32
+          - maybe
+          - parsing
+          - prelude
+          - transformers
+          - tuples
+          - uint
+      partial:
+        repo: https://github.com/purescript/purescript-partial.git
+        version: v4.0.0
+        dependencies: []
+      pathy:
+        repo: https://github.com/purescript-contrib/purescript-pathy.git
+        version: v9.0.0
+        dependencies:
+          - console
+          - exceptions
+          - lists
+          - partial
+          - profunctor
+          - strings
+          - transformers
+          - typelevel-prelude
+          - unsafe-coerce
+      pha:
+        repo: https://github.com/gbagan/purescript-pha.git
+        version: v0.9.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - datetime
+          - effect
+          - foldable-traversable
+          - free
+          - integers
+          - maybe
+          - prelude
+          - profunctor-lenses
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+          - unsafe-reference
+          - web-dom
+          - web-events
+          - web-html
+          - web-pointerevents
+          - web-uievents
+      phaser:
+        repo: https://github.com/lfarroco/purescript-phaser.git
+        version: v0.6.0
+        dependencies:
+          - canvas
+          - console
+          - effect
+          - maybe
+          - nullable
+          - options
+          - prelude
+          - web-html
+      pipes:
+        repo: https://github.com/felixschl/purescript-pipes.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - lists
+          - mmorph
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      point-free:
+        repo: https://github.com/ursi/purescript-point-free.git
+        version: v1.0.0
+        dependencies:
+          - prelude
+      polymorphic-vectors:
+        repo: https://github.com/artemisSystem/purescript-polymorphic-vectors.git
+        version: v4.0.0
+        dependencies:
+          - distributive
+          - foldable-traversable
+          - numbers
+          - prelude
+          - record
+          - safe-coerce
+          - type-equality
+          - typelevel-prelude
+      posix-types:
+        repo: https://github.com/purescript-node/purescript-posix-types.git
+        version: v6.0.0
+        dependencies:
+          - maybe
+          - prelude
+      precise:
+        repo: https://github.com/purescript-contrib/purescript-precise.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - exceptions
+          - gen
+          - integers
+          - lists
+          - numbers
+          - prelude
+          - strings
+      precise-datetime:
+        repo: https://github.com/awakesecurity/purescript-precise-datetime.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - datetime
+          - decimals
+          - either
+          - enums
+          - foldable-traversable
+          - formatters
+          - integers
+          - js-date
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - strings
+          - tuples
+          - unicode
+      prelude:
+        repo: https://github.com/purescript/purescript-prelude.git
+        version: v6.0.0
+        dependencies: []
+      prettier-printer:
+        repo: https://github.com/paulyoung/purescript-prettier-printer.git
+        version: v3.0.0
+        dependencies:
+          - console
+          - lists
+          - prelude
+          - strings
+          - tuples
+      profunctor:
+        repo: https://github.com/purescript/purescript-profunctor.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - distributive
+          - either
+          - exists
+          - invariant
+          - newtype
+          - prelude
+          - tuples
+      profunctor-lenses:
+        repo: https://github.com/purescript-contrib/purescript-profunctor-lenses.git
+        version: v8.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - const
+          - control
+          - distributive
+          - either
+          - foldable-traversable
+          - foreign-object
+          - functors
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - ordered-collections
+          - partial
+          - prelude
+          - profunctor
+          - record
+          - transformers
+          - tuples
+      protobuf:
+        repo: https://github.com/xc-jp/purescript-protobuf.git
+        version: v4.0.0
+        dependencies:
+          - arraybuffer
+          - arraybuffer-builder
+          - arraybuffer-types
+          - arrays
+          - control
+          - effect
+          - either
+          - enums
+          - exceptions
+          - float32
+          - foldable-traversable
+          - functions
+          - int64
+          - maybe
+          - newtype
+          - parsing
+          - parsing-dataview
+          - prelude
+          - record
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+          - uint
+          - web-encoding
+      ps-cst:
+        repo: https://github.com/purescript-codegen/purescript-ps-cst.git
+        version: v1.2.0
+        dependencies:
+          - ansi
+          - console
+          - dodo-printer
+          - effect
+          - node-fs-aff
+          - node-path
+          - psci-support
+          - record
+          - strings
+      psa-utils:
+        repo: https://github.com/natefaubion/purescript-psa-utils.git
+        version: v8.0.0
+        dependencies:
+          - ansi
+          - argonaut-codecs
+          - argonaut-core
+          - arrays
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - maybe
+          - node-path
+          - ordered-collections
+          - prelude
+          - strings
+          - tuples
+          - unsafe-coerce
+      psc-ide:
+        repo: https://github.com/kRITZCREEK/purescript-psc-ide.git
+        version: v19.0.0
+        dependencies:
+          - aff
+          - argonaut
+          - arrays
+          - console
+          - maybe
+          - node-child-process
+          - node-fs
+          - parallel
+          - random
+      psci-support:
+        repo: https://github.com/purescript/purescript-psci-support.git
+        version: v6.0.0
+        dependencies:
+          - console
+          - effect
+          - prelude
+      qualified-do:
+        repo: https://github.com/artemisSystem/purescript-qualified-do.git
+        version: v2.2.0
+        dependencies:
+          - arrays
+          - control
+          - foldable-traversable
+          - parallel
+          - prelude
+          - unfoldable
+      quantities:
+        repo: https://github.com/sharkdp/purescript-quantities.git
+        version: v12.0.1
+        dependencies:
+          - decimals
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - newtype
+          - nonempty
+          - numbers
+          - pairs
+          - prelude
+          - tuples
+      quickcheck:
+        repo: https://github.com/purescript/purescript-quickcheck.git
+        version: v8.0.1
+        dependencies:
+          - arrays
+          - console
+          - control
+          - effect
+          - either
+          - enums
+          - exceptions
+          - foldable-traversable
+          - gen
+          - identity
+          - integers
+          - lazy
+          - lcg
+          - lists
+          - maybe
+          - newtype
+          - nonempty
+          - numbers
+          - partial
+          - prelude
+          - record
+          - st
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+          - unfoldable
+      quickcheck-combinators:
+        repo: https://github.com/athanclark/purescript-quickcheck-combinators.git
+        version: v0.1.3
+        dependencies:
+          - quickcheck
+          - typelevel
+      quickcheck-laws:
+        repo: https://github.com/purescript-contrib/purescript-quickcheck-laws.git
+        version: v7.0.0
+        dependencies:
+          - enums
+          - quickcheck
+      quickcheck-utf8:
+        repo: https://github.com/openchronology/purescript-quickcheck-utf8.git
+        version: v0.0.0
+        dependencies:
+          - quickcheck
+      quotient:
+        repo: https://github.com/rightfold/purescript-quotient.git
+        version: v3.0.0
+        dependencies:
+          - prelude
+          - quickcheck
+      random:
+        repo: https://github.com/purescript/purescript-random.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - integers
+      rationals:
+        repo: https://github.com/anttih/purescript-rationals.git
+        version: v5.0.0
+        dependencies:
+          - integers
+          - prelude
+      react:
+        repo: https://github.com/purescript-contrib/purescript-react.git
+        version: v10.0.1
+        dependencies:
+          - effect
+          - exceptions
+          - maybe
+          - nullable
+          - prelude
+          - typelevel-prelude
+          - unsafe-coerce
+      react-basic:
+        repo: https://github.com/lumihq/purescript-react-basic.git
+        version: v17.0.0
+        dependencies:
+          - effect
+          - prelude
+          - record
+      react-basic-dom:
+        repo: https://github.com/lumihq/purescript-react-basic-dom.git
+        version: v5.0.0
+        dependencies:
+          - effect
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - nullable
+          - prelude
+          - react-basic
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-file
+          - web-html
+      react-basic-hooks:
+        repo: https://github.com/megamaddu/purescript-react-basic-hooks.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - aff-promise
+          - bifunctors
+          - console
+          - control
+          - datetime
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - functions
+          - indexed-monad
+          - integers
+          - maybe
+          - newtype
+          - now
+          - nullable
+          - ordered-collections
+          - prelude
+          - react-basic
+          - refs
+          - tuples
+          - type-equality
+          - unsafe-coerce
+          - unsafe-reference
+          - web-html
+      react-dom:
+        repo: https://github.com/purescript-contrib/purescript-react-dom.git
+        version: v8.0.0
+        dependencies:
+          - effect
+          - react
+          - web-dom
+      read:
+        repo: https://github.com/truqu/purescript-read.git
+        version: v1.0.1
+        dependencies:
+          - maybe
+          - prelude
+          - strings
+      record:
+        repo: https://github.com/purescript/purescript-record.git
+        version: v4.0.0
+        dependencies:
+          - functions
+          - prelude
+          - unsafe-coerce
+      refined:
+        repo: https://github.com/danieljharvey/purescript-refined.git
+        version: v1.0.0
+        dependencies:
+          - argonaut
+          - effect
+          - prelude
+          - quickcheck
+          - typelevel
+      refs:
+        repo: https://github.com/purescript/purescript-refs.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - prelude
+      remotedata:
+        repo: https://github.com/krisajenkins/purescript-remotedata.git
+        version: v5.0.0
+        dependencies:
+          - bifunctors
+          - either
+          - profunctor-lenses
+      resource:
+        repo: https://github.com/joneshf/purescript-resource.git
+        version: v2.0.1
+        dependencies:
+          - aff
+          - console
+          - control
+          - effect
+          - newtype
+          - prelude
+          - psci-support
+          - refs
+      resourcet:
+        repo: https://github.com/robertdp/purescript-resourcet.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - effect
+          - foldable-traversable
+          - maybe
+          - ordered-collections
+          - parallel
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+      result:
+        repo: https://github.com/ad-si/purescript-result.git
+        version: v1.0.3
+        dependencies:
+          - either
+          - foldable-traversable
+          - prelude
+      return:
+        repo: https://github.com/ursi/purescript-return.git
+        version: v0.2.0
+        dependencies:
+          - foldable-traversable
+          - point-free
+          - prelude
+      ring-modules:
+        repo: https://github.com/f-o-a-m/purescript-ring-modules.git
+        version: v5.0.1
+        dependencies:
+          - prelude
+      routing:
+        repo: https://github.com/purescript-contrib/purescript-routing.git
+        version: v11.0.0
+        dependencies:
+          - aff
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - integers
+          - js-uri
+          - lists
+          - maybe
+          - numbers
+          - partial
+          - prelude
+          - semirings
+          - tuples
+          - validation
+          - web-html
+      routing-duplex:
+        repo: https://github.com/natefaubion/purescript-routing-duplex.git
+        version: v0.6.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - js-uri
+          - lazy
+          - numbers
+          - prelude
+          - profunctor
+          - record
+          - strings
+          - typelevel-prelude
+      run:
+        repo: https://github.com/natefaubion/purescript-run.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - free
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - tailrec
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - variant
+      safe-coerce:
+        repo: https://github.com/purescript/purescript-safe-coerce.git
+        version: v2.0.0
+        dependencies:
+          - unsafe-coerce
+      safely:
+        repo: https://github.com/paf31/purescript-safely.git
+        version: v4.0.1
+        dependencies:
+          - freet
+          - lists
+      selection-foldable:
+        repo: https://github.com/jamieyung/purescript-selection-foldable.git
+        version: v0.2.0
+        dependencies:
+          - filterable
+          - foldable-traversable
+          - maybe
+          - prelude
+      semirings:
+        repo: https://github.com/purescript/purescript-semirings.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - lists
+          - newtype
+          - prelude
+      signal:
+        repo: https://github.com/bodil/purescript-signal.git
+        version: v13.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - foldable-traversable
+          - maybe
+          - prelude
+      simple-emitter:
+        repo: https://github.com/oreshinya/purescript-simple-emitter.git
+        version: v2.0.0
+        dependencies:
+          - ordered-collections
+          - refs
+      sized-matrices:
+        repo: https://github.com/csicar/purescript-sized-matrices.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - distributive
+          - foldable-traversable
+          - maybe
+          - prelude
+          - sized-vectors
+          - strings
+          - typelevel
+          - unfoldable
+          - vectorfield
+      sized-vectors:
+        repo: https://github.com/bodil/purescript-sized-vectors.git
+        version: v5.0.2
+        dependencies:
+          - argonaut
+          - arrays
+          - distributive
+          - foldable-traversable
+          - maybe
+          - prelude
+          - quickcheck
+          - typelevel
+          - unfoldable
+      slug:
+        repo: https://github.com/thomashoneyman/purescript-slug.git
+        version: v3.0.1
+        dependencies:
+          - argonaut-codecs
+          - maybe
+          - prelude
+          - strings
+          - unicode
+      soundfonts:
+        repo: https://github.com/newlandsvalley/purescript-soundfonts.git
+        version: v4.1.0
+        dependencies:
+          - aff
+          - affjax
+          - affjax-web
+          - argonaut-core
+          - arraybuffer-types
+          - arrays
+          - b64
+          - bifunctors
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign-object
+          - http-methods
+          - integers
+          - lists
+          - maybe
+          - midi
+          - ordered-collections
+          - parallel
+          - partial
+          - prelude
+          - strings
+          - transformers
+          - tuples
+      sparse-matrices:
+        repo: https://github.com/Ebmtranceboy/purescript-sparse-matrices.git
+        version: v1.2.1
+        dependencies:
+          - console
+          - effect
+          - prelude
+          - sparse-polynomials
+      sparse-polynomials:
+        repo: https://github.com/Ebmtranceboy/purescript-sparse-polynomials.git
+        version: v1.0.5
+        dependencies:
+          - cartesian
+          - console
+          - effect
+          - ordered-collections
+          - prelude
+          - rationals
+          - tuples
+      spec:
+        repo: https://github.com/purescript-spec/purescript-spec.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - ansi
+          - avar
+          - console
+          - exceptions
+          - foldable-traversable
+          - fork
+          - now
+          - pipes
+          - prelude
+          - strings
+          - transformers
+      spec-discovery:
+        repo: https://github.com/purescript-spec/purescript-spec-discovery.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - aff-promise
+          - arrays
+          - console
+          - effect
+          - foldable-traversable
+          - node-fs
+          - prelude
+          - spec
+      spec-quickcheck:
+        repo: https://github.com/purescript-spec/purescript-spec-quickcheck.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - prelude
+          - quickcheck
+          - random
+          - spec
+      ssrs:
+        repo: https://github.com/PureFunctor/purescript-ssrs.git
+        version: v1.0.0
+        dependencies:
+          - dissect
+          - either
+          - fixed-points
+          - free
+          - lists
+          - prelude
+          - safe-coerce
+          - tailrec
+          - tuples
+          - variant
+      st:
+        repo: https://github.com/purescript/purescript-st.git
+        version: v6.0.0
+        dependencies:
+          - partial
+          - prelude
+          - tailrec
+          - unsafe-coerce
+      strictlypositiveint:
+        repo: https://github.com/jamieyung/purescript-strictlypositiveint.git
+        version: v1.0.1
+        dependencies:
+          - prelude
+      string-parsers:
+        repo: https://github.com/purescript-contrib/purescript-string-parsers.git
+        version: v8.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - prelude
+          - strings
+          - tailrec
+      strings:
+        repo: https://github.com/purescript/purescript-strings.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - enums
+          - foldable-traversable
+          - gen
+          - integers
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+          - unsafe-coerce
+      strings-extra:
+        repo: https://github.com/purescript-contrib/purescript-strings-extra.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - maybe
+          - prelude
+          - strings
+          - unicode
+      stringutils:
+        repo: https://github.com/menelaos/purescript-stringutils.git
+        version: v0.0.12
+        dependencies:
+          - arrays
+          - integers
+          - maybe
+          - partial
+          - prelude
+          - strings
+      substitute:
+        repo: https://github.com/ursi/purescript-substitute.git
+        version: v0.2.3
+        dependencies:
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - prelude
+          - return
+          - strings
+      supply:
+        repo: https://github.com/ajnsit/purescript-supply.git
+        version: v0.2.0
+        dependencies:
+          - console
+          - control
+          - effect
+          - lazy
+          - prelude
+          - refs
+          - tuples
+      tailrec:
+        repo: https://github.com/purescript/purescript-tailrec.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - effect
+          - either
+          - identity
+          - maybe
+          - partial
+          - prelude
+          - refs
+      test-unit:
+        repo: https://github.com/bodil/purescript-test-unit.git
+        version: v17.0.0
+        dependencies:
+          - aff
+          - avar
+          - effect
+          - either
+          - free
+          - js-timers
+          - lists
+          - prelude
+          - quickcheck
+          - strings
+      thermite:
+        repo: https://github.com/paf31/purescript-thermite.git
+        version: v6.3.1
+        dependencies:
+          - aff
+          - coroutines
+          - freet
+          - profunctor-lenses
+          - react
+      thermite-dom:
+        repo: https://github.com/athanclark/purescript-thermite-dom.git
+        version: v0.3.1
+        dependencies:
+          - react
+          - react-dom
+          - thermite
+          - web-html
+      these:
+        repo: https://github.com/purescript-contrib/purescript-these.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - gen
+          - lists
+          - quickcheck
+          - quickcheck-laws
+          - tuples
+      transformers:
+        repo: https://github.com/purescript/purescript-transformers.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - distributive
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - identity
+          - lazy
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      tree-rose:
+        repo: https://github.com/jordanmartinez/purescript-tree-rose.git
+        version: v4.0.2
+        dependencies:
+          - control
+          - foldable-traversable
+          - free
+          - lists
+          - maybe
+          - prelude
+          - tailrec
+      tuples:
+        repo: https://github.com/purescript/purescript-tuples.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - invariant
+          - prelude
+      two-or-more:
+        repo: https://github.com/i-am-the-slime/purescript-two-or-more.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - foldable-traversable
+          - maybe
+          - partial
+          - prelude
+          - psci-support
+          - tuples
+      type-equality:
+        repo: https://github.com/purescript/purescript-type-equality.git
+        version: v4.0.1
+        dependencies: []
+      typelevel:
+        repo: https://github.com/bodil/purescript-typelevel.git
+        version: v6.0.0
+        dependencies:
+          - partial
+          - prelude
+          - tuples
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-lists:
+        repo: https://github.com/PureFunctor/purescript-typelevel-lists.git
+        version: v2.1.0
+        dependencies:
+          - prelude
+          - tuples
+          - typelevel-peano
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-peano:
+        repo: https://github.com/csicar/purescript-typelevel-peano.git
+        version: v1.0.1
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - prelude
+          - psci-support
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-prelude:
+        repo: https://github.com/purescript/purescript-typelevel-prelude.git
+        version: v7.0.0
+        dependencies:
+          - prelude
+          - type-equality
+      typelevel-rows:
+        repo: https://github.com/jordanmartinez/purescript-typelevel-rows.git
+        version: v0.1.0
+        dependencies:
+          - prelude
+      uint:
+        repo: https://github.com/purescript-contrib/purescript-uint.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - enums
+          - gen
+          - maybe
+          - numbers
+          - prelude
+      uncurried-transformers:
+        repo: https://github.com/PureFunctor/purescript-uncurried-transformers.git
+        version: v1.1.0
+        dependencies:
+          - control
+          - effect
+          - either
+          - functions
+          - identity
+          - prelude
+          - safe-coerce
+          - tailrec
+          - transformers
+          - tuples
+      undefined-is-not-a-problem:
+        repo: https://github.com/paluh/purescript-undefined-is-not-a-problem.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - assert
+          - effect
+          - either
+          - foreign
+          - maybe
+          - newtype
+          - prelude
+          - random
+          - tuples
+          - type-equality
+          - unsafe-coerce
+      unfoldable:
+        repo: https://github.com/purescript/purescript-unfoldable.git
+        version: v6.0.0
+        dependencies:
+          - foldable-traversable
+          - maybe
+          - partial
+          - prelude
+          - tuples
+      unicode:
+        repo: https://github.com/purescript-contrib/purescript-unicode.git
+        version: v6.0.0
+        dependencies:
+          - foldable-traversable
+          - maybe
+          - strings
+      unlift:
+        repo: https://github.com/tweag/purescript-unlift.git
+        version: v1.0.1
+        dependencies:
+          - aff
+          - effect
+          - either
+          - freet
+          - identity
+          - lists
+          - maybe
+          - monad-control
+          - prelude
+          - st
+          - transformers
+          - tuples
+      unsafe-coerce:
+        repo: https://github.com/purescript/purescript-unsafe-coerce.git
+        version: v6.0.0
+        dependencies: []
+      unsafe-reference:
+        repo: https://github.com/purescript-contrib/purescript-unsafe-reference.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+      uri:
+        repo: https://github.com/purescript-contrib/purescript-uri.git
+        version: v9.0.0
+        dependencies:
+          - arrays
+          - integers
+          - js-uri
+          - numbers
+          - parsing
+          - prelude
+          - profunctor-lenses
+          - these
+          - transformers
+          - unfoldable
+      validation:
+        repo: https://github.com/purescript/purescript-validation.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - newtype
+          - prelude
+      variant:
+        repo: https://github.com/natefaubion/purescript-variant.git
+        version: v8.0.0
+        dependencies:
+          - enums
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - record
+          - tuples
+          - unsafe-coerce
+      vectorfield:
+        repo: https://github.com/csicar/purescript-vectorfield.git
+        version: v1.0.1
+        dependencies:
+          - console
+          - effect
+          - group
+          - prelude
+          - psci-support
+      versions:
+        repo: https://github.com/hdgarrood/purescript-versions.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - either
+          - foldable-traversable
+          - functions
+          - integers
+          - lists
+          - maybe
+          - orders
+          - parsing
+          - partial
+          - strings
+      web-clipboard:
+        repo: https://github.com/purescript-web/purescript-web-clipboard.git
+        version: v4.0.0
+        dependencies:
+          - web-html
+      web-cssom:
+        repo: https://github.com/purescript-web/purescript-web-cssom.git
+        version: v2.0.0
+        dependencies:
+          - web-dom
+          - web-html
+          - web-uievents
+      web-dom:
+        repo: https://github.com/purescript-web/purescript-web-dom.git
+        version: v6.0.0
+        dependencies:
+          - web-events
+      web-dom-parser:
+        repo: https://github.com/purescript-web/purescript-web-dom-parser.git
+        version: v8.0.0
+        dependencies:
+          - effect
+          - partial
+          - prelude
+          - web-dom
+      web-dom-xpath:
+        repo: https://github.com/purescript-web/purescript-web-dom-xpath.git
+        version: v3.0.0
+        dependencies:
+          - web-dom
+      web-encoding:
+        repo: https://github.com/purescript-web/purescript-web-encoding.git
+        version: v3.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - newtype
+          - prelude
+      web-events:
+        repo: https://github.com/purescript-web/purescript-web-events.git
+        version: v4.0.0
+        dependencies:
+          - datetime
+          - enums
+          - foreign
+          - nullable
+      web-fetch:
+        repo: https://github.com/purescript-web/purescript-web-fetch.git
+        version: v3.0.0
+        dependencies:
+          - effect
+          - foreign-object
+          - http-methods
+          - prelude
+          - record
+          - typelevel-prelude
+          - web-file
+          - web-promise
+          - web-streams
+      web-file:
+        repo: https://github.com/purescript-web/purescript-web-file.git
+        version: v4.0.0
+        dependencies:
+          - foreign
+          - media-types
+          - web-dom
+      web-html:
+        repo: https://github.com/purescript-web/purescript-web-html.git
+        version: v4.0.0
+        dependencies:
+          - js-date
+          - web-dom
+          - web-file
+          - web-storage
+      web-page-visibility:
+        repo: https://git.sr.ht/~toastal/purescript-web-page-visibility
+        version: v2.0.0
+        dependencies:
+          - effect
+          - enums
+          - exceptions
+          - maybe
+          - prelude
+          - strings
+          - web-events
+          - web-html
+      web-pointerevents:
+        repo: https://github.com/purescript-web/purescript-web-pointerevents.git
+        version: v1.0.0
+        dependencies:
+          - effect
+          - maybe
+          - prelude
+          - web-dom
+          - web-uievents
+      web-promise:
+        repo: https://github.com/purescript-web/purescript-web-promise.git
+        version: v3.0.0
+        dependencies:
+          - effect
+          - exceptions
+          - foldable-traversable
+          - functions
+          - maybe
+          - prelude
+      web-socket:
+        repo: https://github.com/purescript-web/purescript-web-socket.git
+        version: v4.0.0
+        dependencies:
+          - arraybuffer-types
+          - web-file
+      web-storage:
+        repo: https://github.com/purescript-web/purescript-web-storage.git
+        version: v5.0.0
+        dependencies:
+          - nullable
+          - web-events
+      web-streams:
+        repo: https://github.com/purescript-web/purescript-web-streams.git
+        version: v3.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - exceptions
+          - nullable
+          - prelude
+          - tuples
+          - web-promise
+      web-touchevents:
+        repo: https://github.com/purescript-web/purescript-web-touchevents.git
+        version: v4.0.0
+        dependencies:
+          - web-uievents
+      web-uievents:
+        repo: https://github.com/purescript-web/purescript-web-uievents.git
+        version: v4.0.0
+        dependencies:
+          - web-html
+      web-workers:
+        repo: https://github.com/gbagan/purescript-web-workers.git
+        version: v1.1.0
+        dependencies:
+          - effect
+          - foreign
+          - maybe
+          - prelude
+          - unsafe-coerce
+          - web-events
+      web-xhr:
+        repo: https://github.com/purescript-web/purescript-web-xhr.git
+        version: v5.0.0
+        dependencies:
+          - arraybuffer-types
+          - datetime
+          - http-methods
+          - web-dom
+          - web-file
+          - web-html
+      yoga-fetch:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-fetch.git
+        version: v1.0.1
+        dependencies:
+          - aff
+          - aff-promise
+          - arraybuffer-types
+          - effect
+          - foreign
+          - foreign-object
+          - newtype
+          - prelude
+          - typelevel-prelude
+          - unsafe-coerce
+      yoga-json:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-json.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - identity
+          - lists
+          - maybe
+          - nullable
+          - partial
+          - prelude
+          - record
+          - transformers
+          - typelevel-prelude
+          - variant
+      yoga-postgres:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-postgres.git
+        version: v6.0.0
+        dependencies:
+          - aff
+          - arrays
+          - datetime
+          - effect
+          - either
+          - enums
+          - foldable-traversable
+          - foreign
+          - integers
+          - maybe
+          - nullable
+          - prelude
+          - transformers
+          - unsafe-coerce
+  extra_packages: {}
+packages:
+  arrays:
+    type: git
+    url: https://github.com/purescript/purescript-arrays.git
+    rev: d20bae2f76db6cf29b7b75e26e82b8a54c32295e
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - maybe
+      - nonempty
+      - partial
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  bifunctors:
+    type: git
+    url: https://github.com/purescript/purescript-bifunctors.git
+    rev: 16ba2fb6dd7f05528ebd9e2f9ca3a068b325e5b3
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  catenable-lists:
+    type: git
+    url: https://github.com/purescript/purescript-catenable-lists.git
+    rev: 09abe1f4888bc00841ad2b59e56a9e7ce7ebd4ab
+    dependencies:
+      - control
+      - foldable-traversable
+      - lists
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  console:
+    type: git
+    url: https://github.com/purescript/purescript-console.git
+    rev: 3b83d7b792d03872afeea5e62b4f686ab0f09842
+    dependencies:
+      - effect
+      - prelude
+  const:
+    type: git
+    url: https://github.com/purescript/purescript-const.git
+    rev: ab9570cf2b6e67f7e441178211db1231cfd75c37
+    dependencies:
+      - invariant
+      - newtype
+      - prelude
+  contravariant:
+    type: git
+    url: https://github.com/purescript/purescript-contravariant.git
+    rev: 9ad3e105b8855bcc25f4e0893c784789d05a58de
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  control:
+    type: git
+    url: https://github.com/purescript/purescript-control.git
+    rev: a6033808790879a17b2729e73747a9ed3fb2264e
+    dependencies:
+      - newtype
+      - prelude
+  distributive:
+    type: git
+    url: https://github.com/purescript/purescript-distributive.git
+    rev: 6005e513642e855ebf6f884d24a35c2803ca252a
+    dependencies:
+      - identity
+      - newtype
+      - prelude
+      - tuples
+      - type-equality
+  effect:
+    type: git
+    url: https://github.com/purescript/purescript-effect.git
+    rev: a192ddb923027d426d6ea3d8deb030c9aa7c7dda
+    dependencies:
+      - prelude
+  either:
+    type: git
+    url: https://github.com/purescript/purescript-either.git
+    rev: af655a04ed2fd694b6688af39ee20d7907ad0763
+    dependencies:
+      - control
+      - invariant
+      - maybe
+      - prelude
+  enums:
+    type: git
+    url: https://github.com/purescript/purescript-enums.git
+    rev: bae47961d401f9acf88da38f32e87403e5f0cf2f
+    dependencies:
+      - control
+      - either
+      - gen
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tuples
+      - unfoldable
+  exceptions:
+    type: git
+    url: https://github.com/purescript/purescript-exceptions.git
+    rev: afab3c07c820bb49b6c5be50049db46a964a6161
+    dependencies:
+      - effect
+      - either
+      - maybe
+      - prelude
+  exists:
+    type: git
+    url: https://github.com/purescript/purescript-exists.git
+    rev: f765b4ace7869c27b9c05949e18c843881f9173b
+    dependencies:
+      - unsafe-coerce
+  foldable-traversable:
+    type: git
+    url: https://github.com/purescript/purescript-foldable-traversable.git
+    rev: b3926f870532d287ea59e2d5cd3873b81ef2a93a
+    dependencies:
+      - bifunctors
+      - const
+      - control
+      - either
+      - functors
+      - identity
+      - maybe
+      - newtype
+      - orders
+      - prelude
+      - tuples
+  free:
+    type: git
+    url: https://github.com/purescript/purescript-free.git
+    rev: e2d8fa8023a864363857834e11393483bced5e38
+    dependencies:
+      - catenable-lists
+      - control
+      - distributive
+      - either
+      - exists
+      - foldable-traversable
+      - invariant
+      - lazy
+      - maybe
+      - prelude
+      - tailrec
+      - transformers
+      - tuples
+      - unsafe-coerce
+  functions:
+    type: git
+    url: https://github.com/purescript/purescript-functions.git
+    rev: f626f20580483977c5b27a01aac6471e28aff367
+    dependencies:
+      - prelude
+  functors:
+    type: git
+    url: https://github.com/purescript/purescript-functors.git
+    rev: 022ffd7a2a7ec12080314f3d217b400674a247b4
+    dependencies:
+      - bifunctors
+      - const
+      - contravariant
+      - control
+      - distributive
+      - either
+      - invariant
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - tuples
+      - unsafe-coerce
+  gen:
+    type: git
+    url: https://github.com/purescript/purescript-gen.git
+    rev: 9fbcc2a1261c32e30d79c5418edef4d96fe76931
+    dependencies:
+      - either
+      - foldable-traversable
+      - identity
+      - maybe
+      - newtype
+      - nonempty
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  identity:
+    type: git
+    url: https://github.com/purescript/purescript-identity.git
+    rev: ef6768f8a52ab0bc943a85f5761ba07c257f639f
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  integers:
+    type: git
+    url: https://github.com/purescript/purescript-integers.git
+    rev: 54d712b25c594833083d15dc9ff2418eb9c52822
+    dependencies:
+      - maybe
+      - numbers
+      - prelude
+  invariant:
+    type: git
+    url: https://github.com/purescript/purescript-invariant.git
+    rev: 1d2a196d51e90623adb88496c2cfd759c6736894
+    dependencies:
+      - control
+      - prelude
+  lazy:
+    type: git
+    url: https://github.com/purescript/purescript-lazy.git
+    rev: 48347841226b27af5205a1a8ec71e27a93ce86fd
+    dependencies:
+      - control
+      - foldable-traversable
+      - invariant
+      - prelude
+  lists:
+    type: git
+    url: https://github.com/purescript/purescript-lists.git
+    rev: b113451e5b41cad87d669a3165f955c71cd863e2
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - lazy
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  maybe:
+    type: git
+    url: https://github.com/purescript/purescript-maybe.git
+    rev: c6f98ac1088766287106c5d9c8e30e7648d36786
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  newtype:
+    type: git
+    url: https://github.com/purescript/purescript-newtype.git
+    rev: 29d8e6dd77aec2c975c948364ec3faf26e14ee7b
+    dependencies:
+      - prelude
+      - safe-coerce
+  nonempty:
+    type: git
+    url: https://github.com/purescript/purescript-nonempty.git
+    rev: 28150ecc7419238b187abd609a92a645273348bb
+    dependencies:
+      - control
+      - foldable-traversable
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  numbers:
+    type: git
+    url: https://github.com/purescript/purescript-numbers.git
+    rev: 2a53528f18f9415334bae28e7bb3cf3be86342c2
+    dependencies:
+      - functions
+      - maybe
+  orders:
+    type: git
+    url: https://github.com/purescript/purescript-orders.git
+    rev: f86db621ec5eef1274145f8b1fd8ebbfe0ed4a2c
+    dependencies:
+      - newtype
+      - prelude
+  partial:
+    type: git
+    url: https://github.com/purescript/purescript-partial.git
+    rev: 0fa0646f5ea1ec5f0c46dcbd770c705a6c9ad3ec
+    dependencies: []
+  prelude:
+    type: git
+    url: https://github.com/purescript/purescript-prelude.git
+    rev: 32787f4399c92459c41602131a5858559eb868c5
+    dependencies: []
+  profunctor:
+    type: git
+    url: https://github.com/purescript/purescript-profunctor.git
+    rev: 0a966a14e7b0c827d44657dc1710cdc712d2e034
+    dependencies:
+      - control
+      - distributive
+      - either
+      - exists
+      - invariant
+      - newtype
+      - prelude
+      - tuples
+  refs:
+    type: git
+    url: https://github.com/purescript/purescript-refs.git
+    rev: f8e6216da4cb9309fde1f20cd6f69ac3a3b7f9e8
+    dependencies:
+      - effect
+      - prelude
+  safe-coerce:
+    type: git
+    url: https://github.com/purescript/purescript-safe-coerce.git
+    rev: 7fa799ae80a38b8d948efcb52608e58e198b3da7
+    dependencies:
+      - unsafe-coerce
+  st:
+    type: git
+    url: https://github.com/purescript/purescript-st.git
+    rev: 2cc7ae1c3318a303378c4a9f3fa0f10ee7cc3589
+    dependencies:
+      - partial
+      - prelude
+      - tailrec
+      - unsafe-coerce
+  strings:
+    type: git
+    url: https://github.com/purescript/purescript-strings.git
+    rev: 4bc6954448d056f8aa7a659695a6ad60ad4fdf19
+    dependencies:
+      - arrays
+      - control
+      - either
+      - enums
+      - foldable-traversable
+      - gen
+      - integers
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  tailrec:
+    type: git
+    url: https://github.com/purescript/purescript-tailrec.git
+    rev: 5e2104aa734b31a17074cc805bf087d72b65afd1
+    dependencies:
+      - bifunctors
+      - effect
+      - either
+      - identity
+      - maybe
+      - partial
+      - prelude
+      - refs
+  transformers:
+    type: git
+    url: https://github.com/purescript/purescript-transformers.git
+    rev: be72ab52357d9a665cbf93d73ba1c07c4b0957ee
+    dependencies:
+      - control
+      - distributive
+      - effect
+      - either
+      - exceptions
+      - foldable-traversable
+      - identity
+      - lazy
+      - maybe
+      - newtype
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  tuples:
+    type: git
+    url: https://github.com/purescript/purescript-tuples.git
+    rev: 4f52da2729b448c8564369378f1232d8d2dc1d8b
+    dependencies:
+      - control
+      - invariant
+      - prelude
+  type-equality:
+    type: git
+    url: https://github.com/purescript/purescript-type-equality.git
+    rev: 0525b7d39e0fbd81b4209518139fb8ab02695774
+    dependencies: []
+  unfoldable:
+    type: git
+    url: https://github.com/purescript/purescript-unfoldable.git
+    rev: 493dfe04ed590e20d8f69079df2f58486882748d
+    dependencies:
+      - foldable-traversable
+      - maybe
+      - partial
+      - prelude
+      - tuples
+  unsafe-coerce:
+    type: git
+    url: https://github.com/purescript/purescript-unsafe-coerce.git
+    rev: ab956f82e66e633f647fb3098e8ddd3ec58d689f
+    dependencies: []

--- a/exercises/chapter14/spago.yaml
+++ b/exercises/chapter14/spago.yaml
@@ -1,0 +1,19 @@
+package:
+  dependencies:
+    - arrays
+    - console
+    - effect
+    - foldable-traversable
+    - free
+    - maybe
+    - prelude
+    - strings
+    - transformers
+  name: my-project
+workspace:
+  extraPackages: {}
+  packageSet:
+    url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
+
+
+cd chapter3 && spago test --migrate && cd .. && cd chapter2 && spago test --migrate && cd ..

--- a/exercises/chapter14/spago.yaml
+++ b/exercises/chapter14/spago.yaml
@@ -13,7 +13,4 @@ package:
 workspace:
   extraPackages: {}
   packageSet:
-    url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
-
-
-cd chapter3 && spago test --migrate && cd .. && cd chapter2 && spago test --migrate && cd ..
+    registry: 10.0.0

--- a/exercises/chapter2/spago.lock
+++ b/exercises/chapter2/spago.lock
@@ -67,3452 +67,462 @@ workspace:
         - unsafe-coerce
   package_set:
     address:
-      url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
-    compiler: ">=0.15.0 <0.16.0"
+      registry: 10.0.0
+    compiler: ">=0.15.4 <0.16.0"
     content:
-      ace:
-        repo: https://github.com/purescript-contrib/purescript-ace.git
-        version: v9.0.0
-        dependencies:
-          - arrays
-          - effect
-          - foreign
-          - nullable
-          - prelude
-          - web-html
-          - web-uievents
-      aff:
-        repo: https://github.com/purescript-contrib/purescript-aff.git
-        version: v7.0.0
-        dependencies:
-          - datetime
-          - effect
-          - exceptions
-          - functions
-          - parallel
-          - transformers
-          - unsafe-coerce
-      aff-bus:
-        repo: https://github.com/purescript-contrib/purescript-aff-bus.git
-        version: v6.0.0
-        dependencies:
-          - aff
-          - avar
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - lists
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-      aff-coroutines:
-        repo: https://github.com/purescript-contrib/purescript-aff-coroutines.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - avar
-          - coroutines
-          - effect
-      aff-promise:
-        repo: https://github.com/nwolverson/purescript-aff-promise.git
-        version: v4.0.0
-        dependencies:
-          - aff
-          - foreign
-      aff-retry:
-        repo: https://github.com/Unisay/purescript-aff-retry.git
-        version: v2.0.0
-        dependencies:
-          - aff
-          - arrays
-          - datetime
-          - effect
-          - either
-          - exceptions
-          - integers
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - random
-          - transformers
-      affjax:
-        repo: https://github.com/purescript-contrib/purescript-affjax.git
-        version: v13.0.0
-        dependencies:
-          - aff
-          - argonaut-core
-          - arraybuffer-types
-          - foreign
-          - form-urlencoded
-          - http-methods
-          - integers
-          - media-types
-          - nullable
-          - refs
-          - unsafe-coerce
-          - web-xhr
-      affjax-node:
-        repo: https://github.com/purescript-contrib/purescript-affjax-node.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - affjax
-          - either
-          - maybe
-          - prelude
-      affjax-web:
-        repo: https://github.com/purescript-contrib/purescript-affjax-web.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - affjax
-          - either
-          - maybe
-          - prelude
-      ansi:
-        repo: https://github.com/hdgarrood/purescript-ansi.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - lists
-          - strings
-      argonaut:
-        repo: https://github.com/purescript-contrib/purescript-argonaut.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - argonaut-traversals
-      argonaut-codecs:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-codecs.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-core
-          - arrays
-          - effect
-          - foreign-object
-          - identity
-          - integers
-          - maybe
-          - nonempty
-          - ordered-collections
-          - prelude
-          - record
-      argonaut-core:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-core.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - foreign-object
-          - functions
-          - gen
-          - maybe
-          - nonempty
-          - prelude
-          - strings
-          - tailrec
-      argonaut-generic:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-generic.git
-        version: v8.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - prelude
-          - record
-      argonaut-traversals:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-traversals.git
-        version: v10.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - profunctor-lenses
-      argparse-basic:
-        repo: https://github.com/natefaubion/purescript-argparse-basic.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - record
-          - strings
-          - tuples
-          - unfoldable
-      arraybuffer:
-        repo: https://github.com/purescript-contrib/purescript-arraybuffer.git
-        version: v13.0.0
-        dependencies:
-          - arraybuffer-types
-          - arrays
-          - effect
-          - float32
-          - functions
-          - gen
-          - maybe
-          - nullable
-          - prelude
-          - tailrec
-          - uint
-          - unfoldable
-      arraybuffer-builder:
-        repo: https://github.com/jamesdbrock/purescript-arraybuffer-builder.git
-        version: v3.0.1
-        dependencies:
-          - arraybuffer
-          - arraybuffer-types
-          - effect
-          - float32
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - transformers
-          - uint
-      arraybuffer-types:
-        repo: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
-        version: v3.0.2
-        dependencies: []
-      arrays:
-        repo: https://github.com/purescript/purescript-arrays.git
-        version: v7.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - foldable-traversable
-          - maybe
-          - nonempty
-          - partial
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - unfoldable
-          - unsafe-coerce
-      arrays-zipper:
-        repo: https://github.com/JordanMartinez/purescript-arrays-zipper.git
-        version: v2.0.1
-        dependencies:
-          - arrays
-          - control
-          - quickcheck
-      ask:
-        repo: https://github.com/Mateiadrielrafael/purescript-ask.git
-        version: v1.0.0
-        dependencies:
-          - unsafe-coerce
-      assert:
-        repo: https://github.com/purescript/purescript-assert.git
-        version: v6.0.0
-        dependencies:
-          - console
-          - effect
-          - prelude
-      avar:
-        repo: https://github.com/purescript-contrib/purescript-avar.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - exceptions
-          - functions
-          - maybe
-      b64:
-        repo: https://github.com/menelaos/purescript-b64.git
-        version: v0.0.8
-        dependencies:
-          - arraybuffer-types
-          - either
-          - encoding
-          - enums
-          - exceptions
-          - functions
-          - partial
-          - prelude
-          - strings
-      barlow-lens:
-        repo: https://github.com/sigma-andex/purescript-barlow-lens.git
-        version: v0.9.0
-        dependencies:
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - profunctor-lenses
-          - tuples
-          - typelevel-prelude
-      bifunctors:
-        repo: https://github.com/purescript/purescript-bifunctors.git
-        version: v6.0.0
-        dependencies:
-          - const
-          - either
-          - newtype
-          - prelude
-          - tuples
-      bigints:
-        repo: https://github.com/sharkdp/purescript-bigints.git
-        version: v7.0.1
-        dependencies:
-          - integers
-          - maybe
-          - strings
-      bower-json:
-        repo: https://github.com/klntsky/purescript-bower-json.git
-        version: v3.0.0
-        dependencies:
-          - argonaut-codecs
-          - arrays
-          - either
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - newtype
-          - prelude
-          - tuples
-      call-by-name:
-        repo: https://github.com/natefaubion/purescript-call-by-name.git
-        version: v4.0.1
-        dependencies:
-          - control
-          - either
-          - lazy
-          - maybe
-          - unsafe-coerce
-      canvas:
-        repo: https://github.com/purescript-web/purescript-canvas.git
-        version: v6.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - exceptions
-          - functions
-          - maybe
-      canvas-action:
-        repo: https://github.com/artemisSystem/purescript-canvas-action.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - arrays
-          - canvas
-          - colors
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - maybe
-          - numbers
-          - polymorphic-vectors
-          - prelude
-          - refs
-          - run
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-html
-      cartesian:
-        repo: https://github.com/Ebmtranceboy/purescript-cartesian.git
-        version: v1.0.6
-        dependencies:
-          - console
-          - effect
-          - integers
-          - psci-support
-      catenable-lists:
-        repo: https://github.com/purescript/purescript-catenable-lists.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - lists
-          - maybe
-          - prelude
-          - tuples
-          - unfoldable
-      channel:
-        repo: https://github.com/ConnorDillon/purescript-channel.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - assert
-          - avar
-          - console
-          - contravariant
-          - control
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - lazy
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      checked-exceptions:
-        repo: https://github.com/natefaubion/purescript-checked-exceptions.git
-        version: v3.1.1
-        dependencies:
-          - prelude
-          - transformers
-          - variant
-      codec:
-        repo: https://github.com/garyb/purescript-codec.git
-        version: v5.0.0
-        dependencies:
-          - profunctor
-          - transformers
-      codec-argonaut:
-        repo: https://github.com/garyb/purescript-codec-argonaut.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-core
-          - codec
-          - ordered-collections
-          - type-equality
-          - variant
-      colors:
-        repo: https://github.com/purescript-contrib/purescript-colors.git
-        version: v7.0.1
-        dependencies:
-          - arrays
-          - integers
-          - lists
-          - numbers
-          - partial
-          - strings
-      concurrent-queues:
-        repo: https://github.com/purescript-contrib/purescript-concurrent-queues.git
-        version: v3.0.0
-        dependencies:
-          - aff
-          - avar
-          - effect
-      console:
-        repo: https://github.com/purescript/purescript-console.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - prelude
-      const:
-        repo: https://github.com/purescript/purescript-const.git
-        version: v6.0.0
-        dependencies:
-          - invariant
-          - newtype
-          - prelude
-      contravariant:
-        repo: https://github.com/purescript/purescript-contravariant.git
-        version: v6.0.0
-        dependencies:
-          - const
-          - either
-          - newtype
-          - prelude
-          - tuples
-      control:
-        repo: https://github.com/purescript/purescript-control.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      convertable-options:
-        repo: https://github.com/natefaubion/purescript-convertable-options.git
-        version: v1.0.0
-        dependencies:
-          - console
-          - effect
-          - maybe
-          - record
-      coroutines:
-        repo: https://github.com/purescript-contrib/purescript-coroutines.git
-        version: v7.0.0
-        dependencies:
-          - freet
-          - parallel
-          - profunctor
-      css:
-        repo: https://github.com/purescript-contrib/purescript-css.git
-        version: v6.0.0
-        dependencies:
-          - colors
-          - console
-          - effect
-          - nonempty
-          - profunctor
-          - strings
-          - these
-          - transformers
-      datetime:
-        repo: https://github.com/purescript/purescript-datetime.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - either
-          - enums
-          - foldable-traversable
-          - functions
-          - gen
-          - integers
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - ordered-collections
-          - partial
-          - prelude
-          - tuples
-      datetime-parsing:
-        repo: https://github.com/flounders/purescript-datetime-parsing.git
-        version: v0.2.0
-        dependencies:
-          - arrays
-          - datetime
-          - either
-          - enums
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - numbers
-          - parsing
-          - prelude
-          - strings
-          - unicode
-      debug:
-        repo: https://github.com/garyb/purescript-debug.git
-        version: v6.0.0
-        dependencies:
-          - functions
-          - prelude
-      decimals:
-        repo: https://github.com/sharkdp/purescript-decimals.git
-        version: v7.0.0
-        dependencies:
-          - maybe
-      dissect:
-        repo: https://github.com/PureFunctor/purescript-dissect.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - foreign-object
-          - functors
-          - newtype
-          - partial
-          - prelude
-          - tailrec
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - variant
-      distributive:
-        repo: https://github.com/purescript/purescript-distributive.git
-        version: v6.0.0
-        dependencies:
-          - identity
-          - newtype
-          - prelude
-          - tuples
-          - type-equality
-      dodo-printer:
-        repo: https://github.com/natefaubion/purescript-dodo-printer.git
-        version: v2.2.0
-        dependencies:
-          - aff
-          - ansi
-          - avar
-          - console
-          - effect
-          - foldable-traversable
-          - lists
-          - maybe
-          - minibench
-          - node-child-process
-          - node-fs-aff
-          - node-process
-          - psci-support
-          - strings
-      dom-indexed:
-        repo: https://github.com/purescript-halogen/purescript-dom-indexed.git
-        version: v11.0.0
-        dependencies:
-          - media-types
-          - prelude
-          - web-clipboard
-          - web-pointerevents
-          - web-touchevents
-      droplet:
-        repo: https://github.com/easafe/purescript-droplet.git
-        version: v0.4.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - bigints
-          - datetime
-          - debug
-          - effect
-          - either
-          - enums
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - integers
-          - maybe
-          - newtype
-          - nullable
-          - ordered-collections
-          - partial
-          - prelude
-          - profunctor
-          - record
-          - spec
-          - strings
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-      dynamic-buffer:
-        repo: https://github.com/kritzcreek/purescript-dynamic-buffer.git
-        version: v3.0.1
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - refs
-      effect:
-        repo: https://github.com/purescript/purescript-effect.git
-        version: v4.0.0
-        dependencies:
-          - prelude
-      either:
-        repo: https://github.com/purescript/purescript-either.git
-        version: v6.1.0
-        dependencies:
-          - control
-          - invariant
-          - maybe
-          - prelude
-      elmish:
-        repo: https://github.com/collegevine/purescript-elmish.git
-        version: v0.8.1
-        dependencies:
-          - aff
-          - argonaut-core
-          - arrays
-          - bifunctors
-          - console
-          - debug
-          - effect
-          - either
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - functions
-          - integers
-          - js-date
-          - maybe
-          - nullable
-          - partial
-          - prelude
-          - refs
-          - typelevel-prelude
-          - undefined-is-not-a-problem
-          - unsafe-coerce
-          - web-dom
-          - web-html
-      elmish-enzyme:
-        repo: https://github.com/collegevine/purescript-elmish-enzyme.git
-        version: v0.1.1
-        dependencies:
-          - aff
-          - aff-promise
-          - arrays
-          - console
-          - debug
-          - effect
-          - elmish
-          - foldable-traversable
-          - foreign
-          - functions
-          - prelude
-          - transformers
-          - unsafe-coerce
-      elmish-hooks:
-        repo: https://github.com/collegevine/purescript-elmish-hooks.git
-        version: v0.8.2
-        dependencies:
-          - aff
-          - debug
-          - elmish
-          - maybe
-          - prelude
-          - tuples
-          - undefined-is-not-a-problem
-      elmish-html:
-        repo: https://github.com/collegevine/purescript-elmish-html.git
-        version: v0.7.1
-        dependencies:
-          - effect
-          - elmish
-          - foreign
-          - foreign-object
-          - prelude
-          - record
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-html
-      email-validate:
-        repo: https://github.com/cdepillabout/purescript-email-validate.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - string-parsers
-          - transformers
-      encoding:
-        repo: https://github.com/menelaos/purescript-encoding.git
-        version: v0.0.8
-        dependencies:
-          - arraybuffer-types
-          - either
-          - exceptions
-          - functions
-          - prelude
-      enums:
-        repo: https://github.com/purescript/purescript-enums.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - either
-          - gen
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tuples
-          - unfoldable
-      exceptions:
-        repo: https://github.com/purescript/purescript-exceptions.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - either
-          - maybe
-          - prelude
-      exists:
-        repo: https://github.com/purescript/purescript-exists.git
-        version: v6.0.0
-        dependencies:
-          - unsafe-coerce
-      exitcodes:
-        repo: https://github.com/Risto-Stevcev/purescript-exitcodes.git
-        version: v4.0.0
-        dependencies:
-          - enums
-      expect-inferred:
-        repo: https://github.com/justinwoo/purescript-expect-inferred.git
-        version: v3.0.0
-        dependencies:
-          - prelude
-          - typelevel-prelude
-      fast-vect:
-        repo: https://github.com/sigma-andex/purescript-fast-vect.git
-        version: v0.7.0
-        dependencies:
-          - arrays
-          - filterable
-          - foldable-traversable
-          - lists
-          - maybe
-          - ordered-collections
-          - prelude
-          - profunctor
-          - tuples
-          - unfoldable
-      filterable:
-        repo: https://github.com/purescript/purescript-filterable.git
-        version: v5.0.0
-        dependencies:
-          - arrays
-          - either
-          - foldable-traversable
-          - identity
-          - lists
-          - ordered-collections
-      fixed-points:
-        repo: https://github.com/purescript-contrib/purescript-fixed-points.git
-        version: v7.0.0
-        dependencies:
-          - exists
-          - newtype
-          - prelude
-          - transformers
-      fixed-precision:
-        repo: https://github.com/lumihq/purescript-fixed-precision.git
-        version: v5.0.0
-        dependencies:
-          - arrays
-          - bigints
-          - control
-          - integers
-          - maybe
-          - numbers
-          - partial
-          - prelude
-          - strings
-      flame:
-        repo: https://github.com/easafe/purescript-flame.git
-        version: v1.2.0
-        dependencies:
-          - aff
-          - argonaut-codecs
-          - argonaut-core
-          - argonaut-generic
-          - arrays
-          - bifunctors
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - maybe
-          - newtype
-          - nullable
-          - partial
-          - prelude
-          - random
-          - refs
-          - spec
-          - strings
-          - tuples
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-html
-          - web-uievents
-      float32:
-        repo: https://github.com/purescript-contrib/purescript-float32.git
-        version: v2.0.0
-        dependencies:
-          - gen
-          - maybe
-          - prelude
-      foldable-traversable:
-        repo: https://github.com/purescript/purescript-foldable-traversable.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - const
-          - control
-          - either
-          - functors
-          - identity
-          - maybe
-          - newtype
-          - orders
-          - prelude
-          - tuples
-      foreign:
-        repo: https://github.com/purescript/purescript-foreign.git
-        version: v7.0.0
-        dependencies:
-          - either
-          - functions
-          - identity
-          - integers
-          - lists
-          - maybe
-          - prelude
-          - strings
-          - transformers
-      foreign-object:
-        repo: https://github.com/purescript/purescript-foreign-object.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - functions
-          - gen
-          - lists
-          - maybe
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - typelevel-prelude
-          - unfoldable
-      foreign-readwrite:
-        repo: https://github.com/artemisSystem/purescript-foreign-readwrite.git
-        version: v3.0.0
-        dependencies:
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - record
-          - safe-coerce
-          - transformers
-          - unsafe-coerce
-      fork:
-        repo: https://github.com/purescript-contrib/purescript-fork.git
-        version: v6.0.0
-        dependencies:
-          - aff
-      form-urlencoded:
-        repo: https://github.com/purescript-contrib/purescript-form-urlencoded.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - js-uri
-          - maybe
-          - newtype
-          - prelude
-          - strings
-          - tuples
-      formatters:
-        repo: https://github.com/purescript-contrib/purescript-formatters.git
-        version: v7.0.0
-        dependencies:
-          - datetime
-          - fixed-points
-          - lists
-          - numbers
-          - parsing
-          - prelude
-          - transformers
-      free:
-        repo: https://github.com/purescript/purescript-free.git
-        version: v7.0.0
-        dependencies:
-          - catenable-lists
-          - control
-          - distributive
-          - either
-          - exists
-          - foldable-traversable
-          - invariant
-          - lazy
-          - maybe
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-      freeap:
-        repo: https://github.com/ethul/purescript-freeap.git
-        version: v7.0.0
-        dependencies:
-          - const
-          - exists
-          - gen
-          - lists
-      freet:
-        repo: https://github.com/purescript-contrib/purescript-freet.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - bifunctors
-          - effect
-          - either
-          - exists
-          - free
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      functions:
-        repo: https://github.com/purescript/purescript-functions.git
-        version: v6.0.0
-        dependencies:
-          - prelude
-      functors:
-        repo: https://github.com/purescript/purescript-functors.git
-        version: v5.0.0
-        dependencies:
-          - bifunctors
-          - const
-          - contravariant
-          - control
-          - distributive
-          - either
-          - invariant
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - tuples
-          - unsafe-coerce
-      fuzzy:
-        repo: https://github.com/citizennet/purescript-fuzzy.git
-        version: v0.4.0
-        dependencies:
-          - foldable-traversable
-          - foreign-object
-          - newtype
-          - ordered-collections
-          - prelude
-          - rationals
-          - strings
-          - tuples
-      gen:
-        repo: https://github.com/purescript/purescript-gen.git
-        version: v4.0.0
-        dependencies:
-          - either
-          - foldable-traversable
-          - identity
-          - maybe
-          - newtype
-          - nonempty
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      generate-values:
-        repo: https://github.com/jordanmartinez/purescript-generate-values.git
-        version: v1.0.1
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - enums
-          - foldable-traversable
-          - gen
-          - identity
-          - integers
-          - lcg
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - partial
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      geometry-plane:
-        repo: https://github.com/Ebmtranceboy/purescript-geometry-plane.git
-        version: v1.0.3
-        dependencies:
-          - console
-          - effect
-          - psci-support
-          - sparse-polynomials
-      github-actions-toolkit:
-        repo: https://github.com/purescript-contrib/purescript-github-actions-toolkit.git
-        version: v0.5.0
-        dependencies:
-          - aff
-          - aff-promise
-          - effect
-          - foreign-object
-          - node-buffer
-          - node-path
-          - node-streams
-          - nullable
-          - transformers
-      graphs:
-        repo: https://github.com/purescript/purescript-graphs.git
-        version: v8.0.0
-        dependencies:
-          - catenable-lists
-          - ordered-collections
-      group:
-        repo: https://github.com/morganthomas/purescript-group.git
-        version: v4.1.1
-        dependencies:
-          - lists
-      halogen:
-        repo: https://github.com/purescript-halogen/purescript-halogen.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - avar
-          - console
-          - const
-          - dom-indexed
-          - effect
-          - foreign
-          - fork
-          - free
-          - freeap
-          - halogen-subscriptions
-          - halogen-vdom
-          - media-types
-          - nullable
-          - ordered-collections
-          - parallel
-          - profunctor
-          - transformers
-          - unsafe-coerce
-          - unsafe-reference
-          - web-file
-          - web-uievents
-      halogen-css:
-        repo: https://github.com/purescript-halogen/purescript-halogen-css.git
-        version: v10.0.0
-        dependencies:
-          - css
-          - halogen
-      halogen-formless:
-        repo: https://github.com/thomashoneyman/purescript-halogen-formless.git
-        version: v4.0.0
-        dependencies:
-          - convertable-options
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - halogen
-          - heterogeneous
-          - maybe
-          - prelude
-          - record
-          - safe-coerce
-          - type-equality
-          - unsafe-coerce
-          - unsafe-reference
-          - variant
-          - web-events
-          - web-uievents
-      halogen-hooks:
-        repo: https://github.com/thomashoneyman/purescript-halogen-hooks.git
-        version: v0.6.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - effect
-          - exceptions
-          - foldable-traversable
-          - foreign-object
-          - free
-          - freeap
-          - halogen
-          - halogen-subscriptions
-          - maybe
-          - newtype
-          - ordered-collections
-          - parallel
-          - partial
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-          - unsafe-reference
-          - web-dom
-          - web-html
-      halogen-hooks-extra:
-        repo: https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git
-        version: v0.9.0
-        dependencies:
-          - halogen-hooks
-      halogen-store:
-        repo: https://github.com/thomashoneyman/purescript-halogen-store.git
-        version: v0.5.0
-        dependencies:
-          - aff
-          - distributive
-          - effect
-          - fork
-          - halogen
-          - halogen-hooks
-          - halogen-subscriptions
-          - maybe
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-reference
-      halogen-storybook:
-        repo: https://github.com/rnons/purescript-halogen-storybook.git
-        version: v2.0.0
-        dependencies:
-          - foreign-object
-          - halogen
-          - prelude
-          - routing
-      halogen-subscriptions:
-        repo: https://github.com/purescript-halogen/purescript-halogen-subscriptions.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - effect
-          - foldable-traversable
-          - functors
-          - refs
-          - safe-coerce
-          - unsafe-reference
-      halogen-svg-elems:
-        repo: https://github.com/JordanMartinez/purescript-halogen-svg-elems.git
-        version: v6.0.0
-        dependencies:
-          - halogen
-      halogen-vdom:
-        repo: https://github.com/purescript-halogen/purescript-halogen-vdom.git
-        version: v8.0.0
-        dependencies:
-          - bifunctors
-          - effect
-          - foreign
-          - foreign-object
-          - maybe
-          - prelude
-          - refs
-          - tuples
-          - unsafe-coerce
-          - web-html
-      halogen-vdom-string-renderer:
-        repo: https://github.com/purescript-halogen/purescript-halogen-vdom-string-renderer.git
-        version: v0.5.0
-        dependencies:
-          - foreign
-          - halogen-vdom
-          - ordered-collections
-          - prelude
-      heckin:
-        repo: https://github.com/maxdeviant/purescript-heckin.git
-        version: v2.0.1
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - maybe
-          - prelude
-          - strings
-          - transformers
-          - tuples
-          - unicode
-      heterogeneous:
-        repo: https://github.com/natefaubion/purescript-heterogeneous.git
-        version: v0.6.0
-        dependencies:
-          - either
-          - functors
-          - prelude
-          - record
-          - tuples
-          - variant
-      heterogeneous-extrablatt:
-        repo: https://github.com/sigma-andex/purescript-heterogeneous-extrablatt.git
-        version: v0.2.1
-        dependencies:
-          - heterogeneous
-          - prelude
-          - record
-      http-methods:
-        repo: https://github.com/purescript-contrib/purescript-http-methods.git
-        version: v6.0.0
-        dependencies:
-          - either
-          - prelude
-          - strings
-      httpure:
-        repo: https://github.com/citizennet/purescript-httpure.git
-        version: v0.15.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - js-uri
-          - maybe
-          - newtype
-          - node-buffer
-          - node-fs
-          - node-http
-          - node-streams
-          - options
-          - ordered-collections
-          - prelude
-          - refs
-          - strings
-          - tuples
-          - type-equality
-      httpurple:
-        repo: https://github.com/sigma-andex/purescript-httpurple.git
-        version: v1.3.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - js-uri
-          - justifill
-          - maybe
-          - newtype
-          - node-buffer
-          - node-fs
-          - node-http
-          - node-net
-          - node-process
-          - node-streams
-          - options
-          - ordered-collections
-          - posix-types
-          - prelude
-          - profunctor
-          - record
-          - refs
-          - routing-duplex
-          - strings
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-      httpurple-argonaut:
-        repo: https://github.com/sigma-andex/purescript-httpurple-argonaut.git
-        version: v1.0.1
-        dependencies:
-          - argonaut
-          - console
-          - effect
-          - either
-          - httpurple
-          - prelude
-      httpurple-yoga-json:
-        repo: https://github.com/sigma-andex/purescript-httpurple-yoga-json.git
-        version: v1.0.0
-        dependencies:
-          - console
-          - effect
-          - either
-          - foreign
-          - httpurple
-          - lists
-          - prelude
-          - yoga-json
-      identity:
-        repo: https://github.com/purescript/purescript-identity.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - invariant
-          - newtype
-          - prelude
-      indexed-monad:
-        repo: https://github.com/garyb/purescript-indexed-monad.git
-        version: v2.1.0
-        dependencies:
-          - control
-          - newtype
-      int64:
-        repo: https://github.com/purescript-contrib/purescript-int64.git
-        version: v2.0.0
-        dependencies:
-          - effect
-          - foreign
-          - functions
-          - integers
-          - maybe
-          - nullable
-          - prelude
-          - quickcheck
-      integers:
-        repo: https://github.com/purescript/purescript-integers.git
-        version: v6.0.0
-        dependencies:
-          - maybe
-          - numbers
-          - prelude
-      interpolate:
-        repo: https://github.com/jordanmartinez/purescript-interpolate.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-      invariant:
-        repo: https://github.com/purescript/purescript-invariant.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - prelude
-      js-date:
-        repo: https://github.com/purescript-contrib/purescript-js-date.git
-        version: v8.0.0
-        dependencies:
-          - datetime
-          - effect
-          - exceptions
-          - foreign
-          - integers
-          - now
-      js-fileio:
-        repo: https://github.com/newlandsvalley/purescript-js-fileio.git
-        version: v3.0.0
-        dependencies:
-          - aff
-          - effect
-          - prelude
-      js-timers:
-        repo: https://github.com/purescript-contrib/purescript-js-timers.git
-        version: v6.1.0
-        dependencies:
-          - effect
-      js-uri:
-        repo: https://github.com/purescript-contrib/purescript-js-uri.git
-        version: v3.0.0
-        dependencies:
-          - functions
-          - maybe
-      justifill:
-        repo: https://github.com/i-am-the-slime/purescript-justifill.git
-        version: v0.5.0
-        dependencies:
-          - maybe
-          - prelude
-          - record
-          - typelevel-prelude
-      jwt:
-        repo: https://github.com/menelaos/purescript-jwt.git
-        version: v0.0.9
-        dependencies:
-          - argonaut-core
-          - arrays
-          - b64
-          - either
-          - exceptions
-          - prelude
-          - profunctor-lenses
-          - strings
-      language-cst-parser:
-        repo: https://github.com/natefaubion/purescript-language-cst-parser.git
-        version: v0.12.0
-        dependencies:
-          - arrays
-          - const
-          - control
-          - either
-          - foldable-traversable
-          - free
-          - functions
-          - functors
-          - identity
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - ordered-collections
-          - partial
-          - prelude
-          - st
-          - strings
-          - transformers
-          - tuples
-          - typelevel-prelude
-          - unfoldable
-          - unsafe-coerce
-      lazy:
-        repo: https://github.com/purescript/purescript-lazy.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - invariant
-          - prelude
-      lcg:
-        repo: https://github.com/purescript/purescript-lcg.git
-        version: v4.0.0
-        dependencies:
-          - effect
-          - integers
-          - maybe
-          - partial
-          - prelude
-          - random
-      leibniz:
-        repo: https://github.com/paf31/purescript-leibniz.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-          - unsafe-coerce
-      linalg:
-        repo: https://github.com/gbagan/purescript-linalg.git
-        version: v5.1.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - functions
-          - maybe
-          - prelude
-          - tuples
-      lists:
-        repo: https://github.com/purescript/purescript-lists.git
-        version: v7.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - foldable-traversable
-          - lazy
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      logging:
-        repo: https://github.com/rightfold/purescript-logging.git
-        version: v3.0.0
-        dependencies:
-          - console
-          - contravariant
-          - effect
-          - either
-          - prelude
-          - transformers
-          - tuples
-      machines:
-        repo: https://github.com/purescript-contrib/purescript-machines.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - lists
-          - maybe
-          - prelude
-          - profunctor
-          - tuples
-          - unfoldable
-      matrices:
-        repo: https://github.com/kRITZCREEK/purescript-matrices.git
-        version: v5.0.1
-        dependencies:
-          - arrays
-          - strings
-      matryoshka:
-        repo: https://github.com/purescript-contrib/purescript-matryoshka.git
-        version: v1.0.0
-        dependencies:
-          - fixed-points
-          - free
-          - prelude
-          - profunctor
-          - transformers
-      maybe:
-        repo: https://github.com/purescript/purescript-maybe.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - invariant
-          - newtype
-          - prelude
-      media-types:
-        repo: https://github.com/purescript-contrib/purescript-media-types.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      metadata:
-        repo: https://github.com/purescript/purescript-metadata.git
-        version: v0.15.0
-        dependencies: []
-      midi:
-        repo: https://github.com/newlandsvalley/purescript-midi.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - ordered-collections
-          - prelude
-          - signal
-          - string-parsers
-          - strings
-          - tuples
-          - unfoldable
-      minibench:
-        repo: https://github.com/purescript/purescript-minibench.git
-        version: v4.0.0
-        dependencies:
-          - console
-          - effect
-          - integers
-          - numbers
-          - partial
-          - prelude
-          - refs
-      mmorph:
-        repo: https://github.com/Thimoteus/purescript-mmorph.git
-        version: v7.0.0
-        dependencies:
-          - free
-          - functors
-          - transformers
-      monad-control:
-        repo: https://github.com/athanclark/purescript-monad-control.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - freet
-          - identity
-          - lists
-      monad-logger:
-        repo: https://github.com/cprussin/purescript-monad-logger.git
-        version: v1.3.1
-        dependencies:
-          - aff
-          - ansi
-          - argonaut
-          - arrays
-          - console
-          - control
-          - effect
-          - foldable-traversable
-          - foreign-object
-          - integers
-          - js-date
-          - maybe
-          - newtype
-          - ordered-collections
-          - prelude
-          - strings
-          - transformers
-          - tuples
-      monad-loops:
-        repo: https://github.com/mlang/purescript-monad-loops.git
-        version: v0.5.0
-        dependencies:
-          - lists
-          - maybe
-          - prelude
-          - tailrec
-          - tuples
-      monad-unlift:
-        repo: https://github.com/athanclark/purescript-monad-unlift.git
-        version: v1.0.1
-        dependencies:
-          - monad-control
-      monoidal:
-        repo: https://github.com/mcneissue/purescript-monoidal.git
-        version: v0.16.0
-        dependencies:
-          - either
-          - profunctor
-          - these
-          - tuples
-      morello:
-        repo: https://github.com/sigma-andex/purescript-morello.git
-        version: v0.3.2
-        dependencies:
-          - arrays
-          - barlow-lens
-          - foldable-traversable
-          - heterogeneous
-          - heterogeneous-extrablatt
-          - newtype
-          - prelude
-          - profunctor
-          - profunctor-lenses
-          - record
-          - tuples
-          - typelevel-prelude
-          - validation
-      motsunabe:
-        repo: https://github.com/justinwoo/purescript-motsunabe.git
-        version: v2.0.0
-        dependencies:
-          - lists
-          - strings
-      nano-id:
-        repo: https://github.com/eikooc/nano-id.git
-        version: v1.1.0
-        dependencies:
-          - aff
-          - effect
-          - lists
-          - maybe
-          - prelude
-          - random
-          - spec
-          - strings
-          - stringutils
-      naturals:
-        repo: https://github.com/LiamGoodacre/purescript-naturals.git
-        version: v3.0.0
-        dependencies:
-          - enums
-          - maybe
-          - prelude
-      nested-functor:
-        repo: https://github.com/acple/purescript-nested-functor.git
-        version: v0.2.1
-        dependencies:
-          - prelude
-          - type-equality
-      newtype:
-        repo: https://github.com/purescript/purescript-newtype.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-          - safe-coerce
-      node-buffer:
-        repo: https://github.com/purescript-node/purescript-node-buffer.git
-        version: v8.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - maybe
-          - st
-          - unsafe-coerce
-      node-buffer-blob:
-        repo: https://github.com/purescript-node/purescript-node-buffer-blob.git
-        version: v1.0.0
-        dependencies:
-          - aff-promise
-          - arraybuffer-types
-          - arrays
-          - console
-          - effect
-          - maybe
-          - media-types
-          - newtype
-          - node-buffer
-          - nullable
-          - prelude
-          - web-streams
-      node-child-process:
-        repo: https://github.com/purescript-node/purescript-node-child-process.git
-        version: v9.0.0
-        dependencies:
-          - exceptions
-          - foreign
-          - foreign-object
-          - functions
-          - node-fs
-          - node-streams
-          - nullable
-          - posix-types
-          - unsafe-coerce
-      node-fs:
-        repo: https://github.com/purescript-node/purescript-node-fs.git
-        version: v8.0.0
-        dependencies:
-          - datetime
-          - effect
-          - either
-          - enums
-          - exceptions
-          - functions
-          - integers
-          - js-date
-          - maybe
-          - node-buffer
-          - node-path
-          - node-streams
-          - nullable
-          - partial
-          - prelude
-          - strings
-          - unsafe-coerce
-      node-fs-aff:
-        repo: https://github.com/purescript-node/purescript-node-fs-aff.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - either
-          - node-fs
-          - node-path
-      node-http:
-        repo: https://github.com/purescript-node/purescript-node-http.git
-        version: v8.0.0
-        dependencies:
-          - arraybuffer-types
-          - contravariant
-          - effect
-          - foreign
-          - foreign-object
-          - maybe
-          - node-buffer
-          - node-net
-          - node-streams
-          - node-url
-          - nullable
-          - options
-          - prelude
-          - unsafe-coerce
-      node-net:
-        repo: https://github.com/purescript-node/purescript-node-net.git
-        version: v4.0.0
-        dependencies:
-          - effect
-          - either
-          - exceptions
-          - foreign
-          - maybe
-          - node-buffer
-          - node-fs
-          - nullable
-          - options
-          - prelude
-          - transformers
-      node-path:
-        repo: https://github.com/purescript-node/purescript-node-path.git
-        version: v5.0.0
-        dependencies:
-          - effect
-      node-process:
-        repo: https://github.com/purescript-node/purescript-node-process.git
-        version: v10.0.0
-        dependencies:
-          - effect
-          - foreign-object
-          - maybe
-          - node-streams
-          - posix-types
-          - prelude
-          - unsafe-coerce
-      node-readline:
-        repo: https://github.com/purescript-node/purescript-node-readline.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - foreign
-          - node-process
-          - node-streams
-          - options
-          - prelude
-      node-streams:
-        repo: https://github.com/purescript-node/purescript-node-streams.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - either
-          - exceptions
-          - node-buffer
-          - nullable
-          - prelude
-      node-streams-aff:
-        repo: https://github.com/jamesdbrock/purescript-node-streams-aff.git
-        version: v2.0.0
-        dependencies:
-          - aff
-          - arrays
-          - effect
-          - either
-          - exceptions
-          - maybe
-          - node-buffer
-          - node-streams
-          - prelude
-          - st
-          - tuples
-      node-url:
-        repo: https://github.com/purescript-node/purescript-node-url.git
-        version: v6.0.0
-        dependencies:
-          - nullable
-      nonempty:
-        repo: https://github.com/purescript/purescript-nonempty.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - maybe
-          - prelude
-          - tuples
-          - unfoldable
-      now:
-        repo: https://github.com/purescript-contrib/purescript-now.git
-        version: v6.0.0
-        dependencies:
-          - datetime
-          - effect
-      npm-package-json:
-        repo: https://github.com/maxdeviant/purescript-npm-package-json.git
-        version: v2.0.0
-        dependencies:
-          - argonaut
-          - control
-          - either
-          - foreign-object
-          - maybe
-          - ordered-collections
-          - prelude
-      nullable:
-        repo: https://github.com/purescript-contrib/purescript-nullable.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - functions
-          - maybe
-      numbers:
-        repo: https://github.com/purescript/purescript-numbers.git
-        version: v9.0.0
-        dependencies:
-          - functions
-          - maybe
-      open-folds:
-        repo: https://github.com/purescript-open-community/purescript-open-folds.git
-        version: v6.3.0
-        dependencies:
-          - bifunctors
-          - console
-          - control
-          - distributive
-          - effect
-          - either
-          - foldable-traversable
-          - identity
-          - invariant
-          - maybe
-          - newtype
-          - ordered-collections
-          - prelude
-          - profunctor
-          - psci-support
-          - tuples
-      open-memoize:
-        repo: https://github.com/purescript-open-community/purescript-open-memoize.git
-        version: v6.1.0
-        dependencies:
-          - console
-          - effect
-          - either
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - psci-support
-          - strings
-          - tuples
-      open-pairing:
-        repo: https://github.com/purescript-open-community/purescript-open-pairing.git
-        version: v6.1.0
-        dependencies:
-          - console
-          - control
-          - effect
-          - either
-          - free
-          - functors
-          - identity
-          - newtype
-          - prelude
-          - psci-support
-          - transformers
-          - tuples
-      options:
-        repo: https://github.com/purescript-contrib/purescript-options.git
-        version: v7.0.0
-        dependencies:
-          - contravariant
-          - foreign
-          - foreign-object
-          - maybe
-          - tuples
-      optparse:
-        repo: https://github.com/f-o-a-m/purescript-optparse.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - control
-          - effect
-          - either
-          - enums
-          - exists
-          - exitcodes
-          - foldable-traversable
-          - free
-          - gen
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - newtype
-          - node-buffer
-          - node-process
-          - node-streams
-          - nonempty
-          - numbers
-          - open-memoize
-          - partial
-          - prelude
-          - quickcheck
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-      ordered-collections:
-        repo: https://github.com/purescript/purescript-ordered-collections.git
-        version: v3.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - gen
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - unfoldable
-      ordered-set:
-        repo: https://github.com/flip111/purescript-ordered-set.git
-        version: v0.4.0
-        dependencies:
-          - argonaut-codecs
-          - arrays
-          - partial
-          - prelude
-          - unfoldable
-      orders:
-        repo: https://github.com/purescript/purescript-orders.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      pairs:
-        repo: https://github.com/sharkdp/purescript-pairs.git
-        version: v9.0.0
-        dependencies:
-          - console
-          - distributive
-          - foldable-traversable
-          - quickcheck
-      parallel:
-        repo: https://github.com/purescript/purescript-parallel.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - functors
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - refs
-          - transformers
-      parsing:
-        repo: https://github.com/purescript-contrib/purescript-parsing.git
-        version: v9.1.0
-        dependencies:
-          - arrays
-          - either
-          - foldable-traversable
-          - identity
-          - integers
-          - lists
-          - maybe
-          - nullable
-          - prelude
-          - strings
-          - transformers
-          - unicode
-      parsing-dataview:
-        repo: https://github.com/jamesdbrock/purescript-parsing-dataview.git
-        version: v3.1.0
-        dependencies:
-          - arraybuffer
-          - arraybuffer-types
-          - effect
-          - float32
-          - maybe
-          - parsing
-          - prelude
-          - transformers
-          - tuples
-          - uint
-      partial:
-        repo: https://github.com/purescript/purescript-partial.git
-        version: v4.0.0
-        dependencies: []
-      pathy:
-        repo: https://github.com/purescript-contrib/purescript-pathy.git
-        version: v9.0.0
-        dependencies:
-          - console
-          - exceptions
-          - lists
-          - partial
-          - profunctor
-          - strings
-          - transformers
-          - typelevel-prelude
-          - unsafe-coerce
-      pha:
-        repo: https://github.com/gbagan/purescript-pha.git
-        version: v0.9.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - datetime
-          - effect
-          - foldable-traversable
-          - free
-          - integers
-          - maybe
-          - prelude
-          - profunctor-lenses
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-          - unsafe-reference
-          - web-dom
-          - web-events
-          - web-html
-          - web-pointerevents
-          - web-uievents
-      phaser:
-        repo: https://github.com/lfarroco/purescript-phaser.git
-        version: v0.6.0
-        dependencies:
-          - canvas
-          - console
-          - effect
-          - maybe
-          - nullable
-          - options
-          - prelude
-          - web-html
-      pipes:
-        repo: https://github.com/felixschl/purescript-pipes.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - lists
-          - mmorph
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      point-free:
-        repo: https://github.com/ursi/purescript-point-free.git
-        version: v1.0.0
-        dependencies:
-          - prelude
-      polymorphic-vectors:
-        repo: https://github.com/artemisSystem/purescript-polymorphic-vectors.git
-        version: v4.0.0
-        dependencies:
-          - distributive
-          - foldable-traversable
-          - numbers
-          - prelude
-          - record
-          - safe-coerce
-          - type-equality
-          - typelevel-prelude
-      posix-types:
-        repo: https://github.com/purescript-node/purescript-posix-types.git
-        version: v6.0.0
-        dependencies:
-          - maybe
-          - prelude
-      precise:
-        repo: https://github.com/purescript-contrib/purescript-precise.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - exceptions
-          - gen
-          - integers
-          - lists
-          - numbers
-          - prelude
-          - strings
-      precise-datetime:
-        repo: https://github.com/awakesecurity/purescript-precise-datetime.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - datetime
-          - decimals
-          - either
-          - enums
-          - foldable-traversable
-          - formatters
-          - integers
-          - js-date
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - strings
-          - tuples
-          - unicode
-      prelude:
-        repo: https://github.com/purescript/purescript-prelude.git
-        version: v6.0.0
-        dependencies: []
-      prettier-printer:
-        repo: https://github.com/paulyoung/purescript-prettier-printer.git
-        version: v3.0.0
-        dependencies:
-          - console
-          - lists
-          - prelude
-          - strings
-          - tuples
-      profunctor:
-        repo: https://github.com/purescript/purescript-profunctor.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - distributive
-          - either
-          - exists
-          - invariant
-          - newtype
-          - prelude
-          - tuples
-      profunctor-lenses:
-        repo: https://github.com/purescript-contrib/purescript-profunctor-lenses.git
-        version: v8.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - const
-          - control
-          - distributive
-          - either
-          - foldable-traversable
-          - foreign-object
-          - functors
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - ordered-collections
-          - partial
-          - prelude
-          - profunctor
-          - record
-          - transformers
-          - tuples
-      protobuf:
-        repo: https://github.com/xc-jp/purescript-protobuf.git
-        version: v4.0.0
-        dependencies:
-          - arraybuffer
-          - arraybuffer-builder
-          - arraybuffer-types
-          - arrays
-          - control
-          - effect
-          - either
-          - enums
-          - exceptions
-          - float32
-          - foldable-traversable
-          - functions
-          - int64
-          - maybe
-          - newtype
-          - parsing
-          - parsing-dataview
-          - prelude
-          - record
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-          - uint
-          - web-encoding
-      ps-cst:
-        repo: https://github.com/purescript-codegen/purescript-ps-cst.git
-        version: v1.2.0
-        dependencies:
-          - ansi
-          - console
-          - dodo-printer
-          - effect
-          - node-fs-aff
-          - node-path
-          - psci-support
-          - record
-          - strings
-      psa-utils:
-        repo: https://github.com/natefaubion/purescript-psa-utils.git
-        version: v8.0.0
-        dependencies:
-          - ansi
-          - argonaut-codecs
-          - argonaut-core
-          - arrays
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - maybe
-          - node-path
-          - ordered-collections
-          - prelude
-          - strings
-          - tuples
-          - unsafe-coerce
-      psc-ide:
-        repo: https://github.com/kRITZCREEK/purescript-psc-ide.git
-        version: v19.0.0
-        dependencies:
-          - aff
-          - argonaut
-          - arrays
-          - console
-          - maybe
-          - node-child-process
-          - node-fs
-          - parallel
-          - random
-      psci-support:
-        repo: https://github.com/purescript/purescript-psci-support.git
-        version: v6.0.0
-        dependencies:
-          - console
-          - effect
-          - prelude
-      qualified-do:
-        repo: https://github.com/artemisSystem/purescript-qualified-do.git
-        version: v2.2.0
-        dependencies:
-          - arrays
-          - control
-          - foldable-traversable
-          - parallel
-          - prelude
-          - unfoldable
-      quantities:
-        repo: https://github.com/sharkdp/purescript-quantities.git
-        version: v12.0.1
-        dependencies:
-          - decimals
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - newtype
-          - nonempty
-          - numbers
-          - pairs
-          - prelude
-          - tuples
-      quickcheck:
-        repo: https://github.com/purescript/purescript-quickcheck.git
-        version: v8.0.1
-        dependencies:
-          - arrays
-          - console
-          - control
-          - effect
-          - either
-          - enums
-          - exceptions
-          - foldable-traversable
-          - gen
-          - identity
-          - integers
-          - lazy
-          - lcg
-          - lists
-          - maybe
-          - newtype
-          - nonempty
-          - numbers
-          - partial
-          - prelude
-          - record
-          - st
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-          - unfoldable
-      quickcheck-combinators:
-        repo: https://github.com/athanclark/purescript-quickcheck-combinators.git
-        version: v0.1.3
-        dependencies:
-          - quickcheck
-          - typelevel
-      quickcheck-laws:
-        repo: https://github.com/purescript-contrib/purescript-quickcheck-laws.git
-        version: v7.0.0
-        dependencies:
-          - enums
-          - quickcheck
-      quickcheck-utf8:
-        repo: https://github.com/openchronology/purescript-quickcheck-utf8.git
-        version: v0.0.0
-        dependencies:
-          - quickcheck
-      quotient:
-        repo: https://github.com/rightfold/purescript-quotient.git
-        version: v3.0.0
-        dependencies:
-          - prelude
-          - quickcheck
-      random:
-        repo: https://github.com/purescript/purescript-random.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - integers
-      rationals:
-        repo: https://github.com/anttih/purescript-rationals.git
-        version: v5.0.0
-        dependencies:
-          - integers
-          - prelude
-      react:
-        repo: https://github.com/purescript-contrib/purescript-react.git
-        version: v10.0.1
-        dependencies:
-          - effect
-          - exceptions
-          - maybe
-          - nullable
-          - prelude
-          - typelevel-prelude
-          - unsafe-coerce
-      react-basic:
-        repo: https://github.com/lumihq/purescript-react-basic.git
-        version: v17.0.0
-        dependencies:
-          - effect
-          - prelude
-          - record
-      react-basic-dom:
-        repo: https://github.com/lumihq/purescript-react-basic-dom.git
-        version: v5.0.0
-        dependencies:
-          - effect
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - nullable
-          - prelude
-          - react-basic
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-file
-          - web-html
-      react-basic-hooks:
-        repo: https://github.com/megamaddu/purescript-react-basic-hooks.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - aff-promise
-          - bifunctors
-          - console
-          - control
-          - datetime
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - functions
-          - indexed-monad
-          - integers
-          - maybe
-          - newtype
-          - now
-          - nullable
-          - ordered-collections
-          - prelude
-          - react-basic
-          - refs
-          - tuples
-          - type-equality
-          - unsafe-coerce
-          - unsafe-reference
-          - web-html
-      react-dom:
-        repo: https://github.com/purescript-contrib/purescript-react-dom.git
-        version: v8.0.0
-        dependencies:
-          - effect
-          - react
-          - web-dom
-      read:
-        repo: https://github.com/truqu/purescript-read.git
-        version: v1.0.1
-        dependencies:
-          - maybe
-          - prelude
-          - strings
-      record:
-        repo: https://github.com/purescript/purescript-record.git
-        version: v4.0.0
-        dependencies:
-          - functions
-          - prelude
-          - unsafe-coerce
-      refined:
-        repo: https://github.com/danieljharvey/purescript-refined.git
-        version: v1.0.0
-        dependencies:
-          - argonaut
-          - effect
-          - prelude
-          - quickcheck
-          - typelevel
-      refs:
-        repo: https://github.com/purescript/purescript-refs.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - prelude
-      remotedata:
-        repo: https://github.com/krisajenkins/purescript-remotedata.git
-        version: v5.0.0
-        dependencies:
-          - bifunctors
-          - either
-          - profunctor-lenses
-      resource:
-        repo: https://github.com/joneshf/purescript-resource.git
-        version: v2.0.1
-        dependencies:
-          - aff
-          - console
-          - control
-          - effect
-          - newtype
-          - prelude
-          - psci-support
-          - refs
-      resourcet:
-        repo: https://github.com/robertdp/purescript-resourcet.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - effect
-          - foldable-traversable
-          - maybe
-          - ordered-collections
-          - parallel
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-      result:
-        repo: https://github.com/ad-si/purescript-result.git
-        version: v1.0.3
-        dependencies:
-          - either
-          - foldable-traversable
-          - prelude
-      return:
-        repo: https://github.com/ursi/purescript-return.git
-        version: v0.2.0
-        dependencies:
-          - foldable-traversable
-          - point-free
-          - prelude
-      ring-modules:
-        repo: https://github.com/f-o-a-m/purescript-ring-modules.git
-        version: v5.0.1
-        dependencies:
-          - prelude
-      routing:
-        repo: https://github.com/purescript-contrib/purescript-routing.git
-        version: v11.0.0
-        dependencies:
-          - aff
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - integers
-          - js-uri
-          - lists
-          - maybe
-          - numbers
-          - partial
-          - prelude
-          - semirings
-          - tuples
-          - validation
-          - web-html
-      routing-duplex:
-        repo: https://github.com/natefaubion/purescript-routing-duplex.git
-        version: v0.6.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - js-uri
-          - lazy
-          - numbers
-          - prelude
-          - profunctor
-          - record
-          - strings
-          - typelevel-prelude
-      run:
-        repo: https://github.com/natefaubion/purescript-run.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - free
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - tailrec
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - variant
-      safe-coerce:
-        repo: https://github.com/purescript/purescript-safe-coerce.git
-        version: v2.0.0
-        dependencies:
-          - unsafe-coerce
-      safely:
-        repo: https://github.com/paf31/purescript-safely.git
-        version: v4.0.1
-        dependencies:
-          - freet
-          - lists
-      selection-foldable:
-        repo: https://github.com/jamieyung/purescript-selection-foldable.git
-        version: v0.2.0
-        dependencies:
-          - filterable
-          - foldable-traversable
-          - maybe
-          - prelude
-      semirings:
-        repo: https://github.com/purescript/purescript-semirings.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - lists
-          - newtype
-          - prelude
-      signal:
-        repo: https://github.com/bodil/purescript-signal.git
-        version: v13.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - foldable-traversable
-          - maybe
-          - prelude
-      simple-emitter:
-        repo: https://github.com/oreshinya/purescript-simple-emitter.git
-        version: v2.0.0
-        dependencies:
-          - ordered-collections
-          - refs
-      sized-matrices:
-        repo: https://github.com/csicar/purescript-sized-matrices.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - distributive
-          - foldable-traversable
-          - maybe
-          - prelude
-          - sized-vectors
-          - strings
-          - typelevel
-          - unfoldable
-          - vectorfield
-      sized-vectors:
-        repo: https://github.com/bodil/purescript-sized-vectors.git
-        version: v5.0.2
-        dependencies:
-          - argonaut
-          - arrays
-          - distributive
-          - foldable-traversable
-          - maybe
-          - prelude
-          - quickcheck
-          - typelevel
-          - unfoldable
-      slug:
-        repo: https://github.com/thomashoneyman/purescript-slug.git
-        version: v3.0.1
-        dependencies:
-          - argonaut-codecs
-          - maybe
-          - prelude
-          - strings
-          - unicode
-      soundfonts:
-        repo: https://github.com/newlandsvalley/purescript-soundfonts.git
-        version: v4.1.0
-        dependencies:
-          - aff
-          - affjax
-          - affjax-web
-          - argonaut-core
-          - arraybuffer-types
-          - arrays
-          - b64
-          - bifunctors
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign-object
-          - http-methods
-          - integers
-          - lists
-          - maybe
-          - midi
-          - ordered-collections
-          - parallel
-          - partial
-          - prelude
-          - strings
-          - transformers
-          - tuples
-      sparse-matrices:
-        repo: https://github.com/Ebmtranceboy/purescript-sparse-matrices.git
-        version: v1.2.1
-        dependencies:
-          - console
-          - effect
-          - prelude
-          - sparse-polynomials
-      sparse-polynomials:
-        repo: https://github.com/Ebmtranceboy/purescript-sparse-polynomials.git
-        version: v1.0.5
-        dependencies:
-          - cartesian
-          - console
-          - effect
-          - ordered-collections
-          - prelude
-          - rationals
-          - tuples
-      spec:
-        repo: https://github.com/purescript-spec/purescript-spec.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - ansi
-          - avar
-          - console
-          - exceptions
-          - foldable-traversable
-          - fork
-          - now
-          - pipes
-          - prelude
-          - strings
-          - transformers
-      spec-discovery:
-        repo: https://github.com/purescript-spec/purescript-spec-discovery.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - aff-promise
-          - arrays
-          - console
-          - effect
-          - foldable-traversable
-          - node-fs
-          - prelude
-          - spec
-      spec-quickcheck:
-        repo: https://github.com/purescript-spec/purescript-spec-quickcheck.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - prelude
-          - quickcheck
-          - random
-          - spec
-      ssrs:
-        repo: https://github.com/PureFunctor/purescript-ssrs.git
-        version: v1.0.0
-        dependencies:
-          - dissect
-          - either
-          - fixed-points
-          - free
-          - lists
-          - prelude
-          - safe-coerce
-          - tailrec
-          - tuples
-          - variant
-      st:
-        repo: https://github.com/purescript/purescript-st.git
-        version: v6.0.0
-        dependencies:
-          - partial
-          - prelude
-          - tailrec
-          - unsafe-coerce
-      strictlypositiveint:
-        repo: https://github.com/jamieyung/purescript-strictlypositiveint.git
-        version: v1.0.1
-        dependencies:
-          - prelude
-      string-parsers:
-        repo: https://github.com/purescript-contrib/purescript-string-parsers.git
-        version: v8.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - prelude
-          - strings
-          - tailrec
-      strings:
-        repo: https://github.com/purescript/purescript-strings.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - enums
-          - foldable-traversable
-          - gen
-          - integers
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-          - unsafe-coerce
-      strings-extra:
-        repo: https://github.com/purescript-contrib/purescript-strings-extra.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - maybe
-          - prelude
-          - strings
-          - unicode
-      stringutils:
-        repo: https://github.com/menelaos/purescript-stringutils.git
-        version: v0.0.12
-        dependencies:
-          - arrays
-          - integers
-          - maybe
-          - partial
-          - prelude
-          - strings
-      substitute:
-        repo: https://github.com/ursi/purescript-substitute.git
-        version: v0.2.3
-        dependencies:
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - prelude
-          - return
-          - strings
-      supply:
-        repo: https://github.com/ajnsit/purescript-supply.git
-        version: v0.2.0
-        dependencies:
-          - console
-          - control
-          - effect
-          - lazy
-          - prelude
-          - refs
-          - tuples
-      tailrec:
-        repo: https://github.com/purescript/purescript-tailrec.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - effect
-          - either
-          - identity
-          - maybe
-          - partial
-          - prelude
-          - refs
-      test-unit:
-        repo: https://github.com/bodil/purescript-test-unit.git
-        version: v17.0.0
-        dependencies:
-          - aff
-          - avar
-          - effect
-          - either
-          - free
-          - js-timers
-          - lists
-          - prelude
-          - quickcheck
-          - strings
-      thermite:
-        repo: https://github.com/paf31/purescript-thermite.git
-        version: v6.3.1
-        dependencies:
-          - aff
-          - coroutines
-          - freet
-          - profunctor-lenses
-          - react
-      thermite-dom:
-        repo: https://github.com/athanclark/purescript-thermite-dom.git
-        version: v0.3.1
-        dependencies:
-          - react
-          - react-dom
-          - thermite
-          - web-html
-      these:
-        repo: https://github.com/purescript-contrib/purescript-these.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - gen
-          - lists
-          - quickcheck
-          - quickcheck-laws
-          - tuples
-      transformers:
-        repo: https://github.com/purescript/purescript-transformers.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - distributive
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - identity
-          - lazy
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      tree-rose:
-        repo: https://github.com/jordanmartinez/purescript-tree-rose.git
-        version: v4.0.2
-        dependencies:
-          - control
-          - foldable-traversable
-          - free
-          - lists
-          - maybe
-          - prelude
-          - tailrec
-      tuples:
-        repo: https://github.com/purescript/purescript-tuples.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - invariant
-          - prelude
-      two-or-more:
-        repo: https://github.com/i-am-the-slime/purescript-two-or-more.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - foldable-traversable
-          - maybe
-          - partial
-          - prelude
-          - psci-support
-          - tuples
-      type-equality:
-        repo: https://github.com/purescript/purescript-type-equality.git
-        version: v4.0.1
-        dependencies: []
-      typelevel:
-        repo: https://github.com/bodil/purescript-typelevel.git
-        version: v6.0.0
-        dependencies:
-          - partial
-          - prelude
-          - tuples
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-lists:
-        repo: https://github.com/PureFunctor/purescript-typelevel-lists.git
-        version: v2.1.0
-        dependencies:
-          - prelude
-          - tuples
-          - typelevel-peano
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-peano:
-        repo: https://github.com/csicar/purescript-typelevel-peano.git
-        version: v1.0.1
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - prelude
-          - psci-support
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-prelude:
-        repo: https://github.com/purescript/purescript-typelevel-prelude.git
-        version: v7.0.0
-        dependencies:
-          - prelude
-          - type-equality
-      typelevel-rows:
-        repo: https://github.com/jordanmartinez/purescript-typelevel-rows.git
-        version: v0.1.0
-        dependencies:
-          - prelude
-      uint:
-        repo: https://github.com/purescript-contrib/purescript-uint.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - enums
-          - gen
-          - maybe
-          - numbers
-          - prelude
-      uncurried-transformers:
-        repo: https://github.com/PureFunctor/purescript-uncurried-transformers.git
-        version: v1.1.0
-        dependencies:
-          - control
-          - effect
-          - either
-          - functions
-          - identity
-          - prelude
-          - safe-coerce
-          - tailrec
-          - transformers
-          - tuples
-      undefined-is-not-a-problem:
-        repo: https://github.com/paluh/purescript-undefined-is-not-a-problem.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - assert
-          - effect
-          - either
-          - foreign
-          - maybe
-          - newtype
-          - prelude
-          - random
-          - tuples
-          - type-equality
-          - unsafe-coerce
-      unfoldable:
-        repo: https://github.com/purescript/purescript-unfoldable.git
-        version: v6.0.0
-        dependencies:
-          - foldable-traversable
-          - maybe
-          - partial
-          - prelude
-          - tuples
-      unicode:
-        repo: https://github.com/purescript-contrib/purescript-unicode.git
-        version: v6.0.0
-        dependencies:
-          - foldable-traversable
-          - maybe
-          - strings
-      unlift:
-        repo: https://github.com/tweag/purescript-unlift.git
-        version: v1.0.1
-        dependencies:
-          - aff
-          - effect
-          - either
-          - freet
-          - identity
-          - lists
-          - maybe
-          - monad-control
-          - prelude
-          - st
-          - transformers
-          - tuples
-      unsafe-coerce:
-        repo: https://github.com/purescript/purescript-unsafe-coerce.git
-        version: v6.0.0
-        dependencies: []
-      unsafe-reference:
-        repo: https://github.com/purescript-contrib/purescript-unsafe-reference.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-      uri:
-        repo: https://github.com/purescript-contrib/purescript-uri.git
-        version: v9.0.0
-        dependencies:
-          - arrays
-          - integers
-          - js-uri
-          - numbers
-          - parsing
-          - prelude
-          - profunctor-lenses
-          - these
-          - transformers
-          - unfoldable
-      validation:
-        repo: https://github.com/purescript/purescript-validation.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - newtype
-          - prelude
-      variant:
-        repo: https://github.com/natefaubion/purescript-variant.git
-        version: v8.0.0
-        dependencies:
-          - enums
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - record
-          - tuples
-          - unsafe-coerce
-      vectorfield:
-        repo: https://github.com/csicar/purescript-vectorfield.git
-        version: v1.0.1
-        dependencies:
-          - console
-          - effect
-          - group
-          - prelude
-          - psci-support
-      versions:
-        repo: https://github.com/hdgarrood/purescript-versions.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - either
-          - foldable-traversable
-          - functions
-          - integers
-          - lists
-          - maybe
-          - orders
-          - parsing
-          - partial
-          - strings
-      web-clipboard:
-        repo: https://github.com/purescript-web/purescript-web-clipboard.git
-        version: v4.0.0
-        dependencies:
-          - web-html
-      web-cssom:
-        repo: https://github.com/purescript-web/purescript-web-cssom.git
-        version: v2.0.0
-        dependencies:
-          - web-dom
-          - web-html
-          - web-uievents
-      web-dom:
-        repo: https://github.com/purescript-web/purescript-web-dom.git
-        version: v6.0.0
-        dependencies:
-          - web-events
-      web-dom-parser:
-        repo: https://github.com/purescript-web/purescript-web-dom-parser.git
-        version: v8.0.0
-        dependencies:
-          - effect
-          - partial
-          - prelude
-          - web-dom
-      web-dom-xpath:
-        repo: https://github.com/purescript-web/purescript-web-dom-xpath.git
-        version: v3.0.0
-        dependencies:
-          - web-dom
-      web-encoding:
-        repo: https://github.com/purescript-web/purescript-web-encoding.git
-        version: v3.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - newtype
-          - prelude
-      web-events:
-        repo: https://github.com/purescript-web/purescript-web-events.git
-        version: v4.0.0
-        dependencies:
-          - datetime
-          - enums
-          - foreign
-          - nullable
-      web-fetch:
-        repo: https://github.com/purescript-web/purescript-web-fetch.git
-        version: v3.0.0
-        dependencies:
-          - effect
-          - foreign-object
-          - http-methods
-          - prelude
-          - record
-          - typelevel-prelude
-          - web-file
-          - web-promise
-          - web-streams
-      web-file:
-        repo: https://github.com/purescript-web/purescript-web-file.git
-        version: v4.0.0
-        dependencies:
-          - foreign
-          - media-types
-          - web-dom
-      web-html:
-        repo: https://github.com/purescript-web/purescript-web-html.git
-        version: v4.0.0
-        dependencies:
-          - js-date
-          - web-dom
-          - web-file
-          - web-storage
-      web-page-visibility:
-        repo: https://git.sr.ht/~toastal/purescript-web-page-visibility
-        version: v2.0.0
-        dependencies:
-          - effect
-          - enums
-          - exceptions
-          - maybe
-          - prelude
-          - strings
-          - web-events
-          - web-html
-      web-pointerevents:
-        repo: https://github.com/purescript-web/purescript-web-pointerevents.git
-        version: v1.0.0
-        dependencies:
-          - effect
-          - maybe
-          - prelude
-          - web-dom
-          - web-uievents
-      web-promise:
-        repo: https://github.com/purescript-web/purescript-web-promise.git
-        version: v3.0.0
-        dependencies:
-          - effect
-          - exceptions
-          - foldable-traversable
-          - functions
-          - maybe
-          - prelude
-      web-socket:
-        repo: https://github.com/purescript-web/purescript-web-socket.git
-        version: v4.0.0
-        dependencies:
-          - arraybuffer-types
-          - web-file
-      web-storage:
-        repo: https://github.com/purescript-web/purescript-web-storage.git
-        version: v5.0.0
-        dependencies:
-          - nullable
-          - web-events
-      web-streams:
-        repo: https://github.com/purescript-web/purescript-web-streams.git
-        version: v3.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - exceptions
-          - nullable
-          - prelude
-          - tuples
-          - web-promise
-      web-touchevents:
-        repo: https://github.com/purescript-web/purescript-web-touchevents.git
-        version: v4.0.0
-        dependencies:
-          - web-uievents
-      web-uievents:
-        repo: https://github.com/purescript-web/purescript-web-uievents.git
-        version: v4.0.0
-        dependencies:
-          - web-html
-      web-workers:
-        repo: https://github.com/gbagan/purescript-web-workers.git
-        version: v1.1.0
-        dependencies:
-          - effect
-          - foreign
-          - maybe
-          - prelude
-          - unsafe-coerce
-          - web-events
-      web-xhr:
-        repo: https://github.com/purescript-web/purescript-web-xhr.git
-        version: v5.0.0
-        dependencies:
-          - arraybuffer-types
-          - datetime
-          - http-methods
-          - web-dom
-          - web-file
-          - web-html
-      yoga-fetch:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-fetch.git
-        version: v1.0.1
-        dependencies:
-          - aff
-          - aff-promise
-          - arraybuffer-types
-          - effect
-          - foreign
-          - foreign-object
-          - newtype
-          - prelude
-          - typelevel-prelude
-          - unsafe-coerce
-      yoga-json:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-json.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - identity
-          - lists
-          - maybe
-          - nullable
-          - partial
-          - prelude
-          - record
-          - transformers
-          - typelevel-prelude
-          - variant
-      yoga-postgres:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-postgres.git
-        version: v6.0.0
-        dependencies:
-          - aff
-          - arrays
-          - datetime
-          - effect
-          - either
-          - enums
-          - foldable-traversable
-          - foreign
-          - integers
-          - maybe
-          - nullable
-          - prelude
-          - transformers
-          - unsafe-coerce
+      abc-parser: 2.0.0
+      ace: 9.0.0
+      aff: 7.1.0
+      aff-bus: 6.0.0
+      aff-coroutines: 9.0.0
+      aff-promise: 4.0.0
+      aff-retry: 2.0.0
+      affjax: 13.0.0
+      affjax-node: 1.0.0
+      affjax-web: 1.0.0
+      ansi: 7.0.0
+      argonaut: 9.0.0
+      argonaut-aeson-generic: 0.4.1
+      argonaut-codecs: 9.1.0
+      argonaut-core: 7.0.0
+      argonaut-generic: 8.0.0
+      argonaut-traversals: 10.0.0
+      argparse-basic: 2.0.0
+      array-builder: 0.1.2
+      arraybuffer: 13.1.1
+      arraybuffer-builder: 3.1.0
+      arraybuffer-types: 3.0.2
+      arrays: 7.1.0
+      arrays-zipper: 2.0.1
+      ask: 1.0.0
+      assert: 6.0.0
+      avar: 5.0.0
+      b64: 0.0.8
+      barbies: 1.0.1
+      barlow-lens: 0.9.0
+      basic-auth: 3.0.1
+      bifunctors: 6.0.0
+      bigints: 7.0.1
+      bolson: 0.3.1
+      bower-json: 3.0.0
+      bucketchain: 1.0.1
+      bucketchain-basic-auth: 1.0.1
+      bucketchain-conditional: 1.0.1
+      bucketchain-cors: 1.0.1
+      bucketchain-csrf: 1.0.1
+      bucketchain-header-utils: 1.0.1
+      bucketchain-health: 1.0.1
+      bucketchain-history-api-fallback: 1.0.1
+      bucketchain-logger: 1.0.1
+      bucketchain-secure: 1.0.1
+      bucketchain-simple-api: 5.0.1
+      bucketchain-sslify: 1.0.1
+      bucketchain-static: 1.0.1
+      call-by-name: 4.0.1
+      canvas: 6.0.0
+      canvas-action: 9.0.0
+      cartesian: 1.0.6
+      catenable-lists: 7.0.0
+      channel: 1.0.0
+      checked-exceptions: 3.1.1
+      classless: 0.1.1
+      classless-arbitrary: 0.1.1
+      classless-decode-json: 0.1.1
+      classless-encode-json: 0.1.3
+      classnames: 2.0.0
+      codec: 6.0.0
+      codec-argonaut: 10.0.0
+      colors: 7.0.1
+      concur-core: 0.5.0
+      concur-react: 0.5.0
+      concurrent-queues: 3.0.0
+      console: 6.0.0
+      const: 6.0.0
+      contravariant: 6.0.0
+      control: 6.0.0
+      convertable-options: 1.0.0
+      coroutines: 7.0.0
+      crypto: 5.0.1
+      css: 6.0.0
+      datetime: 6.1.0
+      datetime-parsing: 0.2.0
+      debug: 6.0.2
+      decimals: 7.1.0
+      default-values: 1.0.1
+      deku: 0.9.9
+      deno: 0.0.5
+      dissect: 1.0.0
+      distributive: 6.0.0
+      dodo-printer: 2.2.1
+      dom-filereader: 7.0.0
+      dom-indexed: 11.0.0
+      dotenv: 3.0.0
+      droplet: 0.5.0
+      dynamic-buffer: 3.0.1
+      echarts-simple: 0.0.1
+      effect: 4.0.0
+      either: 6.1.0
+      elmish: 0.8.3
+      elmish-enzyme: 0.1.1
+      elmish-hooks: 0.9.1
+      elmish-html: 0.7.2
+      elmish-testing-library: 0.3.1
+      email-validate: 7.0.0
+      encoding: 0.0.8
+      enums: 6.0.1
+      error: 2.0.0
+      exceptions: 6.0.0
+      exists: 6.0.0
+      exitcodes: 4.0.0
+      expect-inferred: 3.0.0
+      fahrtwind: 2.0.0
+      fallback: 0.1.0
+      fast-vect: 1.1.0
+      fetch: 1.1.4
+      fetch-argonaut: 1.0.0
+      fetch-core: 4.0.4
+      fetch-yoga-json: 1.1.0
+      filterable: 5.0.0
+      fixed-points: 7.0.0
+      fixed-precision: 5.0.0
+      flame: 1.2.0
+      float32: 2.0.0
+      foldable-traversable: 6.0.0
+      foreign: 7.0.0
+      foreign-object: 4.1.0
+      foreign-readwrite: 3.4.0
+      fork: 6.0.0
+      form-urlencoded: 7.0.0
+      formatters: 7.0.0
+      framer-motion: 1.0.1
+      free: 7.0.0
+      freeap: 7.0.0
+      freer-free: 0.0.1
+      freet: 7.0.0
+      functions: 6.0.0
+      functor1: 3.0.0
+      functors: 5.0.0
+      fuzzy: 0.4.0
+      gen: 4.0.0
+      generate-values: 1.0.1
+      generic-router: 0.0.1
+      geometry-plane: 1.0.3
+      github-actions-toolkit: 0.5.0
+      grain: 3.0.0
+      grain-router: 3.0.0
+      grain-virtualized: 3.0.0
+      graphql-client: 9.3.2
+      graphs: 8.1.0
+      group: 4.1.1
+      halogen: 7.0.0
+      halogen-bootstrap5: 2.1.0
+      halogen-css: 10.0.0
+      halogen-echarts-simple: 0.0.4
+      halogen-formless: 4.0.2
+      halogen-hooks: 0.6.3
+      halogen-hooks-extra: 0.9.0
+      halogen-store: 0.5.4
+      halogen-storybook: 2.0.0
+      halogen-subscriptions: 2.0.0
+      halogen-svg-elems: 7.0.0
+      halogen-vdom: 8.0.0
+      halogen-vdom-string-renderer: 0.5.0
+      heckin: 2.0.1
+      heterogeneous: 0.6.0
+      homogeneous: 0.4.0
+      http-methods: 6.0.0
+      httpure: 0.16.0
+      httpurple: 3.0.1
+      httpurple-argonaut: 1.0.1
+      httpurple-yoga-json: 1.0.0
+      humdrum: 0.0.1
+      hyrule: 2.3.5
+      identity: 6.0.0
+      identy: 4.0.1
+      indexed-monad: 2.1.0
+      int64: 3.0.0
+      integers: 6.0.0
+      interpolate: 5.0.2
+      invariant: 6.0.0
+      jarilo: 1.0.1
+      jelly: 0.9.1
+      jelly-hooks: 0.3.1
+      jelly-router: 0.2.2
+      jelly-signal: 0.3.0
+      jest: 1.0.0
+      js-bigints: 1.2.0
+      js-date: 8.0.0
+      js-fileio: 3.0.0
+      js-promise: 1.0.0
+      js-promise-aff: 1.0.0
+      js-timers: 6.1.0
+      js-uri: 3.1.0
+      justifill: 0.5.0
+      jwt: 0.0.9
+      language-cst-parser: 0.12.1
+      lazy: 6.0.0
+      lazy-joe: 1.0.0
+      lcg: 4.0.0
+      leibniz: 5.0.0
+      linalg: 5.1.0
+      lists: 7.0.0
+      literals: 1.0.2
+      logging: 3.0.0
+      logging-journald: 0.4.0
+      machines: 7.0.0
+      marionette: 1.0.0
+      marionette-commander: 0.1.1
+      marionette-react-basic-hooks: 0.1.1
+      matrices: 5.0.1
+      matryoshka: 1.0.0
+      maybe: 6.0.0
+      mdast-util-from-markdown: 0.2.1
+      media-types: 6.0.0
+      midi: 4.0.0
+      milkis: 9.0.0
+      minibench: 4.0.1
+      mmorph: 7.0.0
+      monad-control: 5.0.0
+      monad-logger: 1.3.1
+      monad-loops: 0.5.0
+      monad-unlift: 1.0.1
+      monoid-extras: 0.0.1
+      monoidal: 0.16.0
+      morello: 0.4.0
+      mote: 3.0.0
+      motsunabe: 2.0.0
+      mysql: 6.0.1
+      n3: 0.1.0
+      nano-id: 1.1.0
+      naturals: 3.0.0
+      nested-functor: 0.2.1
+      newtype: 5.0.0
+      nextui: 0.1.0
+      node-buffer: 8.0.0
+      node-buffer-blob: 1.0.0
+      node-child-process: 9.0.0
+      node-fs: 8.1.1
+      node-fs-aff: 9.1.0
+      node-http: 8.0.0
+      node-net: 4.0.0
+      node-path: 5.0.0
+      node-process: 10.0.0
+      node-readline: 7.0.0
+      node-sqlite3: 8.0.0
+      node-streams: 7.0.0
+      node-streams-aff: 4.0.1
+      node-url: 6.0.0
+      nodemailer: 4.0.1
+      nonempty: 7.0.0
+      now: 6.0.0
+      npm-package-json: 2.0.0
+      nullable: 6.0.0
+      numbers: 9.0.0
+      object-maps: 0.1.1
+      ocarina: 1.5.2
+      open-folds: 6.3.0
+      open-memoize: 6.1.0
+      open-pairing: 6.1.0
+      options: 7.0.0
+      optparse: 5.0.0
+      ordered-collections: 3.0.0
+      ordered-set: 0.4.0
+      orders: 6.0.0
+      pairs: 9.0.0
+      parallel: 6.0.0
+      parsing: 10.2.0
+      parsing-dataview: 3.2.4
+      partial: 4.0.0
+      pathy: 9.0.0
+      pha: 0.9.0
+      phaser: 0.6.0
+      pipes: 8.0.0
+      pirates-charm: 0.0.1
+      point-free: 1.0.0
+      pointed-list: 0.5.1
+      polymorphic-vectors: 4.0.0
+      posix-types: 6.0.0
+      precise: 6.0.0
+      precise-datetime: 7.0.0
+      prelude: 6.0.1
+      prettier-printer: 3.0.0
+      profunctor: 6.0.0
+      profunctor-lenses: 8.0.0
+      protobuf: 4.2.0
+      ps-cst: 1.2.0
+      psa-utils: 8.0.0
+      psc-ide: 19.0.0
+      psci-support: 6.0.0
+      qualified-do: 2.2.0
+      quantities: 12.1.0
+      quickcheck: 8.0.1
+      quickcheck-combinators: 0.1.3
+      quickcheck-laws: 7.0.0
+      quickcheck-utf8: 0.0.0
+      random: 6.0.0
+      rationals: 5.0.1
+      rdf: 0.1.0
+      react: 10.0.1
+      react-aria: 0.2.0
+      react-basic: 17.0.0
+      react-basic-classic: 3.0.0
+      react-basic-dnd: 10.1.0
+      react-basic-dom: 6.0.0
+      react-basic-emotion: 7.1.0
+      react-basic-hooks: 8.1.2
+      react-basic-storybook: 2.0.0
+      react-dom: 8.0.0
+      react-halo: 3.0.0
+      react-icons: 1.0.8
+      react-testing-library: 4.0.1
+      react-virtuoso: 1.0.0
+      read: 1.0.1
+      record: 4.0.0
+      record-extra: 5.0.1
+      record-studio: 1.0.4
+      refs: 6.0.0
+      remotedata: 5.0.0
+      resource: 2.0.1
+      resourcet: 1.0.0
+      result: 1.0.3
+      return: 0.2.0
+      ring-modules: 5.0.1
+      rito: 0.3.2
+      routing: 11.0.0
+      routing-duplex: 0.7.0
+      run: 5.0.0
+      safe-coerce: 2.0.0
+      safely: 4.0.1
+      school-of-music: 1.3.0
+      selection-foldable: 0.2.0
+      semirings: 7.0.0
+      signal: 13.0.0
+      simple-emitter: 3.0.1
+      simple-i18n: 2.0.1
+      simple-json: 9.0.0
+      simple-jwt: 4.0.1
+      simple-ulid: 3.0.0
+      sized-matrices: 1.0.0
+      sized-vectors: 5.0.2
+      slug: 3.0.8
+      small-ffi: 4.0.1
+      soundfonts: 4.1.0
+      sparse-matrices: 1.2.1
+      sparse-polynomials: 1.0.5
+      spec: 7.2.0
+      spec-discovery: 8.0.1
+      spec-quickcheck: 5.0.0
+      splitmix: 2.1.0
+      ssrs: 1.0.0
+      st: 6.2.0
+      strictlypositiveint: 1.0.1
+      string-parsers: 8.0.0
+      strings: 6.0.1
+      strings-extra: 4.0.0
+      stringutils: 0.0.12
+      substitute: 0.2.3
+      sunde: 3.0.0
+      supply: 0.2.0
+      svg-parser: 3.0.0
+      systemd-journald: 0.3.0
+      tagged: 4.0.2
+      tailrec: 6.1.0
+      tecton: 0.1.6
+      tecton-halogen: 0.1.3
+      test-unit: 17.0.0
+      thermite: 6.3.1
+      thermite-dom: 0.3.1
+      these: 6.0.0
+      toppokki: 4.0.0
+      transformers: 6.0.0
+      tree-rose: 4.0.2
+      tuples: 7.0.0
+      two-or-more: 1.0.0
+      type-equality: 4.0.1
+      typelevel: 6.0.0
+      typelevel-lists: 2.1.0
+      typelevel-peano: 1.0.1
+      typelevel-prelude: 7.0.0
+      typelevel-rows: 0.1.0
+      uint: 7.0.0
+      ulid: 3.0.1
+      uncurried-transformers: 1.1.0
+      undefined: 2.0.0
+      undefined-is-not-a-problem: 1.1.0
+      unfoldable: 6.0.0
+      unicode: 6.0.0
+      unlift: 1.0.1
+      unordered-collections: 3.0.1
+      unsafe-coerce: 6.0.0
+      unsafe-reference: 5.0.0
+      untagged-to-tagged: 0.1.4
+      untagged-union: 1.0.0
+      uri: 9.0.0
+      uuid: 9.0.0
+      uuidv4: 1.0.0
+      validation: 6.0.0
+      variant: 8.0.0
+      vectorfield: 1.0.1
+      vectors: 2.1.0
+      versions: 7.0.0
+      visx: 0.0.2
+      web-clipboard: 5.0.0
+      web-cssom: 2.0.0
+      web-dom: 6.0.0
+      web-dom-parser: 8.0.0
+      web-dom-xpath: 3.0.0
+      web-encoding: 3.0.0
+      web-events: 4.0.0
+      web-fetch: 3.0.0
+      web-file: 4.0.0
+      web-html: 4.1.0
+      web-pointerevents: 1.0.0
+      web-proletarian: 1.0.0
+      web-promise: 3.1.0
+      web-resize-observer: 2.0.0
+      web-router: 1.0.0
+      web-socket: 4.0.0
+      web-storage: 5.0.0
+      web-streams: 3.0.0
+      web-touchevents: 4.0.0
+      web-uievents: 4.0.0
+      web-url: 2.0.0
+      web-workers: 1.1.0
+      web-xhr: 5.0.0
+      which: 2.0.0
+      yoga-fetch: 1.0.1
+      yoga-json: 4.0.1
+      yoga-om: 0.1.0
+      yoga-postgres: 6.0.0
+      yoga-tree: 1.0.0
   extra_packages: {}
 packages:
   aff:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-aff.git
-    rev: 2d44d9f9d0d6a416a4103fba2fb39e5160f80e36
+    type: registry
+    version: 7.1.0
+    integrity: sha256-7hOC6uQO9XBAI5FD8F33ChLjFAiZVfd4BJMqlMh7TNU=
     dependencies:
+      - arrays
+      - bifunctors
+      - control
       - datetime
       - effect
+      - either
       - exceptions
+      - foldable-traversable
       - functions
+      - maybe
+      - newtype
       - parallel
+      - prelude
+      - refs
+      - tailrec
       - transformers
       - unsafe-coerce
   arrays:
-    type: git
-    url: https://github.com/purescript/purescript-arrays.git
-    rev: d20bae2f76db6cf29b7b75e26e82b8a54c32295e
+    type: registry
+    version: 7.1.0
+    integrity: sha256-Rvb3AVLal0ZLpmpABgOPIUeYHa4M+c5GwcUP5rQ2trA=
     dependencies:
       - bifunctors
       - control
@@ -3521,15 +531,16 @@ packages:
       - nonempty
       - partial
       - prelude
+      - safe-coerce
       - st
       - tailrec
       - tuples
       - unfoldable
       - unsafe-coerce
   avar:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-avar.git
-    rev: d00f5784d9cc8f079babd62740f5c52b87e5caa5
+    type: registry
+    version: 5.0.0
+    integrity: sha256-e7hf0x4hEpcygXP0LtvfvAQ49Bbj2aWtZT3gqM///0A=
     dependencies:
       - aff
       - effect
@@ -3538,9 +549,9 @@ packages:
       - functions
       - maybe
   bifunctors:
-    type: git
-    url: https://github.com/purescript/purescript-bifunctors.git
-    rev: 16ba2fb6dd7f05528ebd9e2f9ca3a068b325e5b3
+    type: registry
+    version: 6.0.0
+    integrity: sha256-/gZwC9YhNxZNQpnHa5BIYerCGM2jeX9ukZiEvYxm5Nw=
     dependencies:
       - const
       - either
@@ -3548,9 +559,9 @@ packages:
       - prelude
       - tuples
   catenable-lists:
-    type: git
-    url: https://github.com/purescript/purescript-catenable-lists.git
-    rev: 09abe1f4888bc00841ad2b59e56a9e7ce7ebd4ab
+    type: registry
+    version: 7.0.0
+    integrity: sha256-76vYENhwF4BWTBsjeLuErCH2jqVT4M3R1HX+4RwSftA=
     dependencies:
       - control
       - foldable-traversable
@@ -3560,24 +571,24 @@ packages:
       - tuples
       - unfoldable
   console:
-    type: git
-    url: https://github.com/purescript/purescript-console.git
-    rev: 3b83d7b792d03872afeea5e62b4f686ab0f09842
+    type: registry
+    version: 6.0.0
+    integrity: sha256-gJpJ53fCDAL8BiCiJXH0HNAJ9K3gJtLo8GDaCK6hA5U=
     dependencies:
       - effect
       - prelude
   const:
-    type: git
-    url: https://github.com/purescript/purescript-const.git
-    rev: ab9570cf2b6e67f7e441178211db1231cfd75c37
+    type: registry
+    version: 6.0.0
+    integrity: sha256-tNrxDW8D8H4jdHE2HiPzpLy08zkzJMmGHdRqt5BQuTc=
     dependencies:
       - invariant
       - newtype
       - prelude
   contravariant:
-    type: git
-    url: https://github.com/purescript/purescript-contravariant.git
-    rev: 9ad3e105b8855bcc25f4e0893c784789d05a58de
+    type: registry
+    version: 6.0.0
+    integrity: sha256-TP+ooAp3vvmdjfQsQJSichF5B4BPDHp3wAJoWchip6c=
     dependencies:
       - const
       - either
@@ -3585,16 +596,16 @@ packages:
       - prelude
       - tuples
   control:
-    type: git
-    url: https://github.com/purescript/purescript-control.git
-    rev: a6033808790879a17b2729e73747a9ed3fb2264e
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sH7Pg9E96JCPF9PIA6oQ8+BjTyO/BH1ZuE/bOcyj4Jk=
     dependencies:
       - newtype
       - prelude
   datetime:
-    type: git
-    url: https://github.com/purescript/purescript-datetime.git
-    rev: a6a0cf1b0324964ad1854bc3377ed8766ba90e6f
+    type: registry
+    version: 6.1.0
+    integrity: sha256-g/5X5BBegQWLpI9IWD+sY6mcaYpzzlW5lz5NBzaMtyI=
     dependencies:
       - bifunctors
       - control
@@ -3613,9 +624,9 @@ packages:
       - prelude
       - tuples
   distributive:
-    type: git
-    url: https://github.com/purescript/purescript-distributive.git
-    rev: 6005e513642e855ebf6f884d24a35c2803ca252a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-HTDdmEnzigMl+02SJB88j+gAXDx9VKsbvR4MJGDPbOQ=
     dependencies:
       - identity
       - newtype
@@ -3623,24 +634,24 @@ packages:
       - tuples
       - type-equality
   effect:
-    type: git
-    url: https://github.com/purescript/purescript-effect.git
-    rev: a192ddb923027d426d6ea3d8deb030c9aa7c7dda
+    type: registry
+    version: 4.0.0
+    integrity: sha256-eBtZu+HZcMa5HilvI6kaDyVX3ji8p0W9MGKy2K4T6+M=
     dependencies:
       - prelude
   either:
-    type: git
-    url: https://github.com/purescript/purescript-either.git
-    rev: af655a04ed2fd694b6688af39ee20d7907ad0763
+    type: registry
+    version: 6.1.0
+    integrity: sha256-6hgTPisnMWVwQivOu2PKYcH8uqjEOOqDyaDQVUchTpY=
     dependencies:
       - control
       - invariant
       - maybe
       - prelude
   enums:
-    type: git
-    url: https://github.com/purescript/purescript-enums.git
-    rev: bae47961d401f9acf88da38f32e87403e5f0cf2f
+    type: registry
+    version: 6.0.1
+    integrity: sha256-HWaD73JFLorc4A6trKIRUeDMdzE+GpkJaEOM1nTNkC8=
     dependencies:
       - control
       - either
@@ -3653,24 +664,24 @@ packages:
       - tuples
       - unfoldable
   exceptions:
-    type: git
-    url: https://github.com/purescript/purescript-exceptions.git
-    rev: afab3c07c820bb49b6c5be50049db46a964a6161
+    type: registry
+    version: 6.0.0
+    integrity: sha256-y/xTAEIZIARCE+50/u1di0ncebJ+CIwNOLswyOWzMTw=
     dependencies:
       - effect
       - either
       - maybe
       - prelude
   exists:
-    type: git
-    url: https://github.com/purescript/purescript-exists.git
-    rev: f765b4ace7869c27b9c05949e18c843881f9173b
+    type: registry
+    version: 6.0.0
+    integrity: sha256-A0JQHpTfo1dNOj9U5/Fd3xndlRSE0g2IQWOGor2yXn8=
     dependencies:
       - unsafe-coerce
   foldable-traversable:
-    type: git
-    url: https://github.com/purescript/purescript-foldable-traversable.git
-    rev: b3926f870532d287ea59e2d5cd3873b81ef2a93a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-fLeqRYM4jUrZD5H4WqcwUgzU7XfYkzO4zhgtNc3jcWM=
     dependencies:
       - bifunctors
       - const
@@ -3684,9 +695,9 @@ packages:
       - prelude
       - tuples
   free:
-    type: git
-    url: https://github.com/purescript/purescript-free.git
-    rev: e2d8fa8023a864363857834e11393483bced5e38
+    type: registry
+    version: 7.0.0
+    integrity: sha256-72auTIZAG6fhz4F94rxyDwgfnHwp+/89rujZpZWrV0w=
     dependencies:
       - catenable-lists
       - control
@@ -3703,15 +714,15 @@ packages:
       - tuples
       - unsafe-coerce
   functions:
-    type: git
-    url: https://github.com/purescript/purescript-functions.git
-    rev: f626f20580483977c5b27a01aac6471e28aff367
+    type: registry
+    version: 6.0.0
+    integrity: sha256-adMyJNEnhGde2unHHAP79gPtlNjNqzgLB8arEOn9hLI=
     dependencies:
       - prelude
   functors:
-    type: git
-    url: https://github.com/purescript/purescript-functors.git
-    rev: 022ffd7a2a7ec12080314f3d217b400674a247b4
+    type: registry
+    version: 5.0.0
+    integrity: sha256-zfPWWYisbD84MqwpJSZFlvM6v86McM68ob8p9s27ywU=
     dependencies:
       - bifunctors
       - const
@@ -3727,9 +738,9 @@ packages:
       - tuples
       - unsafe-coerce
   gen:
-    type: git
-    url: https://github.com/purescript/purescript-gen.git
-    rev: 9fbcc2a1261c32e30d79c5418edef4d96fe76931
+    type: registry
+    version: 4.0.0
+    integrity: sha256-f7yzAXWwr+xnaqEOcvyO3ezKdoes8+WXWdXIHDBCAPI=
     dependencies:
       - either
       - foldable-traversable
@@ -3742,48 +753,48 @@ packages:
       - tuples
       - unfoldable
   identity:
-    type: git
-    url: https://github.com/purescript/purescript-identity.git
-    rev: ef6768f8a52ab0bc943a85f5761ba07c257f639f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-4wY0XZbAksjY6UAg99WkuKyJlQlWAfTi2ssadH0wVMY=
     dependencies:
       - control
       - invariant
       - newtype
       - prelude
   integers:
-    type: git
-    url: https://github.com/purescript/purescript-integers.git
-    rev: 54d712b25c594833083d15dc9ff2418eb9c52822
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sf+sK26R1hzwl3NhXR7WAu9zCDjQnfoXwcyGoseX158=
     dependencies:
       - maybe
       - numbers
       - prelude
   invariant:
-    type: git
-    url: https://github.com/purescript/purescript-invariant.git
-    rev: 1d2a196d51e90623adb88496c2cfd759c6736894
+    type: registry
+    version: 6.0.0
+    integrity: sha256-RGWWyYrz0Hs1KjPDA+87Kia67ZFBhfJ5lMGOMCEFoLo=
     dependencies:
       - control
       - prelude
   js-timers:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-js-timers.git
-    rev: 7cb728b3e6dc29f355143617e6e9ac770ecd9273
+    type: registry
+    version: 6.1.0
+    integrity: sha256-znHWLSSOYw15P5DTcsAdal2lf7nGA2yayLdOZ2t5r7o=
     dependencies:
       - effect
   lazy:
-    type: git
-    url: https://github.com/purescript/purescript-lazy.git
-    rev: 48347841226b27af5205a1a8ec71e27a93ce86fd
+    type: registry
+    version: 6.0.0
+    integrity: sha256-lMsfFOnlqfe4KzRRiW8ot5ge6HtcU3Eyh2XkXcP5IgU=
     dependencies:
       - control
       - foldable-traversable
       - invariant
       - prelude
   lcg:
-    type: git
-    url: https://github.com/purescript/purescript-lcg.git
-    rev: 67c6c6483a563a59ae036d9dca0f1be2835326a5
+    type: registry
+    version: 4.0.0
+    integrity: sha256-h7ME5cthLfbgJOJdsZcSfFpwXsx4rf8YmhebU+3iSYg=
     dependencies:
       - effect
       - integers
@@ -3792,9 +803,9 @@ packages:
       - prelude
       - random
   lists:
-    type: git
-    url: https://github.com/purescript/purescript-lists.git
-    rev: b113451e5b41cad87d669a3165f955c71cd863e2
+    type: registry
+    version: 7.0.0
+    integrity: sha256-EKF15qYqucuXP2lT/xPxhqy58f0FFT6KHdIB/yBOayI=
     dependencies:
       - bifunctors
       - control
@@ -3809,25 +820,25 @@ packages:
       - tuples
       - unfoldable
   maybe:
-    type: git
-    url: https://github.com/purescript/purescript-maybe.git
-    rev: c6f98ac1088766287106c5d9c8e30e7648d36786
+    type: registry
+    version: 6.0.0
+    integrity: sha256-5cCIb0wPwbat2PRkQhUeZO0jcAmf8jCt2qE0wbC3v2Q=
     dependencies:
       - control
       - invariant
       - newtype
       - prelude
   newtype:
-    type: git
-    url: https://github.com/purescript/purescript-newtype.git
-    rev: 29d8e6dd77aec2c975c948364ec3faf26e14ee7b
+    type: registry
+    version: 5.0.0
+    integrity: sha256-gdrQu8oGe9eZE6L3wOI8ql/igOg+zEGB5ITh2g+uttw=
     dependencies:
       - prelude
       - safe-coerce
   nonempty:
-    type: git
-    url: https://github.com/purescript/purescript-nonempty.git
-    rev: 28150ecc7419238b187abd609a92a645273348bb
+    type: registry
+    version: 7.0.0
+    integrity: sha256-54ablJZUHGvvlTJzi3oXyPCuvY6zsrWJuH/dMJ/MFLs=
     dependencies:
       - control
       - foldable-traversable
@@ -3836,16 +847,16 @@ packages:
       - tuples
       - unfoldable
   numbers:
-    type: git
-    url: https://github.com/purescript/purescript-numbers.git
-    rev: 2a53528f18f9415334bae28e7bb3cf3be86342c2
+    type: registry
+    version: 9.0.0
+    integrity: sha256-fDKXExFxMRFgy+v+kbjVbGBIOOQkWGnmm0vtnE3zWRE=
     dependencies:
       - functions
       - maybe
   ordered-collections:
-    type: git
-    url: https://github.com/purescript/purescript-ordered-collections.git
-    rev: 9826b7632d0d0a691173bde308a634195f42a419
+    type: registry
+    version: 3.0.0
+    integrity: sha256-R9WddNBRPkY37gw8XkDCLX2vJ5eI9qdaWDdCp61r2+M=
     dependencies:
       - arrays
       - foldable-traversable
@@ -3859,16 +870,16 @@ packages:
       - tuples
       - unfoldable
   orders:
-    type: git
-    url: https://github.com/purescript/purescript-orders.git
-    rev: f86db621ec5eef1274145f8b1fd8ebbfe0ed4a2c
+    type: registry
+    version: 6.0.0
+    integrity: sha256-nBA0g3/ai0euH8q9pSbGqk53W2q6agm/dECZTHcoink=
     dependencies:
       - newtype
       - prelude
   parallel:
-    type: git
-    url: https://github.com/purescript/purescript-parallel.git
-    rev: 85290dca837771ac4870071008c933d315ef678f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-VJbkGD0rAKX+NUEeBJbYJ78bEKaZbgow+QwQEfPB6ko=
     dependencies:
       - control
       - effect
@@ -3882,19 +893,19 @@ packages:
       - refs
       - transformers
   partial:
-    type: git
-    url: https://github.com/purescript/purescript-partial.git
-    rev: 0fa0646f5ea1ec5f0c46dcbd770c705a6c9ad3ec
+    type: registry
+    version: 4.0.0
+    integrity: sha256-fwXerld6Xw1VkReh8yeQsdtLVrjfGiVuC5bA1Wyo/J4=
     dependencies: []
   prelude:
-    type: git
-    url: https://github.com/purescript/purescript-prelude.git
-    rev: 32787f4399c92459c41602131a5858559eb868c5
+    type: registry
+    version: 6.0.1
+    integrity: sha256-o8p6SLYmVPqzXZhQFd2hGAWEwBoXl1swxLG/scpJ0V0=
     dependencies: []
   profunctor:
-    type: git
-    url: https://github.com/purescript/purescript-profunctor.git
-    rev: 0a966a14e7b0c827d44657dc1710cdc712d2e034
+    type: registry
+    version: 6.0.0
+    integrity: sha256-99NzxFgTr4CGlCSRYG1kShL+JhYbihhHtbOk1/0R5zI=
     dependencies:
       - control
       - distributive
@@ -3905,9 +916,9 @@ packages:
       - prelude
       - tuples
   quickcheck:
-    type: git
-    url: https://github.com/purescript/purescript-quickcheck.git
-    rev: bf5029f97e6c0d7552d3a08d2ab793a19e2c5e3d
+    type: registry
+    version: 8.0.1
+    integrity: sha256-ZvpccKQCvgslTXZCNmpYW4bUsFzhZd/kQUr2WmxFTGY=
     dependencies:
       - arrays
       - console
@@ -3937,46 +948,46 @@ packages:
       - tuples
       - unfoldable
   random:
-    type: git
-    url: https://github.com/purescript/purescript-random.git
-    rev: 9540bc965a9596da02fefd9949418bb19c92533a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-CJ611a35MPCE7XQMp0rdC6MCn76znlhisiCRgboAG+Q=
     dependencies:
       - effect
       - integers
   record:
-    type: git
-    url: https://github.com/purescript/purescript-record.git
-    rev: c89cd1ada6b636692571fc374196b1c39c4c9f70
+    type: registry
+    version: 4.0.0
+    integrity: sha256-Za5U85bTRJEfGK5Sk4hM41oXy84YQI0I8TL3WUn1Qzg=
     dependencies:
       - functions
       - prelude
       - unsafe-coerce
   refs:
-    type: git
-    url: https://github.com/purescript/purescript-refs.git
-    rev: f8e6216da4cb9309fde1f20cd6f69ac3a3b7f9e8
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Vgwne7jIbD3ZMoLNNETLT8Litw6lIYo3MfYNdtYWj9s=
     dependencies:
       - effect
       - prelude
   safe-coerce:
-    type: git
-    url: https://github.com/purescript/purescript-safe-coerce.git
-    rev: 7fa799ae80a38b8d948efcb52608e58e198b3da7
+    type: registry
+    version: 2.0.0
+    integrity: sha256-a1ibQkiUcbODbLE/WAq7Ttbbh9ex+x33VCQ7GngKudU=
     dependencies:
       - unsafe-coerce
   st:
-    type: git
-    url: https://github.com/purescript/purescript-st.git
-    rev: 2cc7ae1c3318a303378c4a9f3fa0f10ee7cc3589
+    type: registry
+    version: 6.2.0
+    integrity: sha256-z9X0WsOUlPwNx9GlCC+YccCyz8MejC8Wb0C4+9fiBRY=
     dependencies:
       - partial
       - prelude
       - tailrec
       - unsafe-coerce
   strings:
-    type: git
-    url: https://github.com/purescript/purescript-strings.git
-    rev: 4bc6954448d056f8aa7a659695a6ad60ad4fdf19
+    type: registry
+    version: 6.0.1
+    integrity: sha256-WssD3DbX4OPzxSdjvRMX0yvc9+pS7n5gyPv5I2Trb7k=
     dependencies:
       - arrays
       - control
@@ -3995,9 +1006,9 @@ packages:
       - unfoldable
       - unsafe-coerce
   tailrec:
-    type: git
-    url: https://github.com/purescript/purescript-tailrec.git
-    rev: 5e2104aa734b31a17074cc805bf087d72b65afd1
+    type: registry
+    version: 6.1.0
+    integrity: sha256-Xx19ECVDRrDWpz9D2GxQHHV89vd61dnXxQm0IcYQHGk=
     dependencies:
       - bifunctors
       - effect
@@ -4008,9 +1019,9 @@ packages:
       - prelude
       - refs
   test-unit:
-    type: git
-    url: https://github.com/bodil/purescript-test-unit.git
-    rev: 3112d7ebe06d467238058a6384dc75ffd960d335
+    type: registry
+    version: 17.0.0
+    integrity: sha256-aITJ2KngFFjASmG0JjnjybaKWl9dn7Hf2B3Wk4engNs=
     dependencies:
       - aff
       - avar
@@ -4023,9 +1034,9 @@ packages:
       - quickcheck
       - strings
   transformers:
-    type: git
-    url: https://github.com/purescript/purescript-transformers.git
-    rev: be72ab52357d9a665cbf93d73ba1c07c4b0957ee
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Pzw40HjthX77tdPAYzjx43LK3X5Bb7ZspYAp27wksFA=
     dependencies:
       - control
       - distributive
@@ -4042,22 +1053,22 @@ packages:
       - tuples
       - unfoldable
   tuples:
-    type: git
-    url: https://github.com/purescript/purescript-tuples.git
-    rev: 4f52da2729b448c8564369378f1232d8d2dc1d8b
+    type: registry
+    version: 7.0.0
+    integrity: sha256-1rXgTomes9105BjgXqIw0FL6Fz1lqqUTLWOumhWec1M=
     dependencies:
       - control
       - invariant
       - prelude
   type-equality:
-    type: git
-    url: https://github.com/purescript/purescript-type-equality.git
-    rev: 0525b7d39e0fbd81b4209518139fb8ab02695774
+    type: registry
+    version: 4.0.1
+    integrity: sha256-Hs9D6Y71zFi/b+qu5NSbuadUQXe5iv5iWx0226vOHUw=
     dependencies: []
   unfoldable:
-    type: git
-    url: https://github.com/purescript/purescript-unfoldable.git
-    rev: 493dfe04ed590e20d8f69079df2f58486882748d
+    type: registry
+    version: 6.0.0
+    integrity: sha256-JtikvJdktRap7vr/K4ITlxUX1QexpnqBq0G/InLr6eg=
     dependencies:
       - foldable-traversable
       - maybe
@@ -4065,7 +1076,7 @@ packages:
       - prelude
       - tuples
   unsafe-coerce:
-    type: git
-    url: https://github.com/purescript/purescript-unsafe-coerce.git
-    rev: ab956f82e66e633f647fb3098e8ddd3ec58d689f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-IqIYW4Vkevn8sI+6aUwRGvd87tVL36BBeOr0cGAE7t0=
     dependencies: []

--- a/exercises/chapter2/spago.lock
+++ b/exercises/chapter2/spago.lock
@@ -1,0 +1,4071 @@
+workspace:
+  packages:
+    my-project:
+      path: ./
+      dependencies:
+        - console
+        - effect
+        - foldable-traversable
+        - integers
+        - lists
+        - numbers
+        - prelude
+        - test-unit
+      test_dependencies: []
+      build_plan:
+        - aff
+        - arrays
+        - avar
+        - bifunctors
+        - catenable-lists
+        - console
+        - const
+        - contravariant
+        - control
+        - datetime
+        - distributive
+        - effect
+        - either
+        - enums
+        - exceptions
+        - exists
+        - foldable-traversable
+        - free
+        - functions
+        - functors
+        - gen
+        - identity
+        - integers
+        - invariant
+        - js-timers
+        - lazy
+        - lcg
+        - lists
+        - maybe
+        - newtype
+        - nonempty
+        - numbers
+        - ordered-collections
+        - orders
+        - parallel
+        - partial
+        - prelude
+        - profunctor
+        - quickcheck
+        - random
+        - record
+        - refs
+        - safe-coerce
+        - st
+        - strings
+        - tailrec
+        - test-unit
+        - transformers
+        - tuples
+        - type-equality
+        - unfoldable
+        - unsafe-coerce
+  package_set:
+    address:
+      url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
+    compiler: ">=0.15.0 <0.16.0"
+    content:
+      ace:
+        repo: https://github.com/purescript-contrib/purescript-ace.git
+        version: v9.0.0
+        dependencies:
+          - arrays
+          - effect
+          - foreign
+          - nullable
+          - prelude
+          - web-html
+          - web-uievents
+      aff:
+        repo: https://github.com/purescript-contrib/purescript-aff.git
+        version: v7.0.0
+        dependencies:
+          - datetime
+          - effect
+          - exceptions
+          - functions
+          - parallel
+          - transformers
+          - unsafe-coerce
+      aff-bus:
+        repo: https://github.com/purescript-contrib/purescript-aff-bus.git
+        version: v6.0.0
+        dependencies:
+          - aff
+          - avar
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - lists
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+      aff-coroutines:
+        repo: https://github.com/purescript-contrib/purescript-aff-coroutines.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - avar
+          - coroutines
+          - effect
+      aff-promise:
+        repo: https://github.com/nwolverson/purescript-aff-promise.git
+        version: v4.0.0
+        dependencies:
+          - aff
+          - foreign
+      aff-retry:
+        repo: https://github.com/Unisay/purescript-aff-retry.git
+        version: v2.0.0
+        dependencies:
+          - aff
+          - arrays
+          - datetime
+          - effect
+          - either
+          - exceptions
+          - integers
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - random
+          - transformers
+      affjax:
+        repo: https://github.com/purescript-contrib/purescript-affjax.git
+        version: v13.0.0
+        dependencies:
+          - aff
+          - argonaut-core
+          - arraybuffer-types
+          - foreign
+          - form-urlencoded
+          - http-methods
+          - integers
+          - media-types
+          - nullable
+          - refs
+          - unsafe-coerce
+          - web-xhr
+      affjax-node:
+        repo: https://github.com/purescript-contrib/purescript-affjax-node.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - affjax
+          - either
+          - maybe
+          - prelude
+      affjax-web:
+        repo: https://github.com/purescript-contrib/purescript-affjax-web.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - affjax
+          - either
+          - maybe
+          - prelude
+      ansi:
+        repo: https://github.com/hdgarrood/purescript-ansi.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - lists
+          - strings
+      argonaut:
+        repo: https://github.com/purescript-contrib/purescript-argonaut.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - argonaut-traversals
+      argonaut-codecs:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-codecs.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-core
+          - arrays
+          - effect
+          - foreign-object
+          - identity
+          - integers
+          - maybe
+          - nonempty
+          - ordered-collections
+          - prelude
+          - record
+      argonaut-core:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-core.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - foreign-object
+          - functions
+          - gen
+          - maybe
+          - nonempty
+          - prelude
+          - strings
+          - tailrec
+      argonaut-generic:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-generic.git
+        version: v8.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - prelude
+          - record
+      argonaut-traversals:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-traversals.git
+        version: v10.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - profunctor-lenses
+      argparse-basic:
+        repo: https://github.com/natefaubion/purescript-argparse-basic.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - record
+          - strings
+          - tuples
+          - unfoldable
+      arraybuffer:
+        repo: https://github.com/purescript-contrib/purescript-arraybuffer.git
+        version: v13.0.0
+        dependencies:
+          - arraybuffer-types
+          - arrays
+          - effect
+          - float32
+          - functions
+          - gen
+          - maybe
+          - nullable
+          - prelude
+          - tailrec
+          - uint
+          - unfoldable
+      arraybuffer-builder:
+        repo: https://github.com/jamesdbrock/purescript-arraybuffer-builder.git
+        version: v3.0.1
+        dependencies:
+          - arraybuffer
+          - arraybuffer-types
+          - effect
+          - float32
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - transformers
+          - uint
+      arraybuffer-types:
+        repo: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
+        version: v3.0.2
+        dependencies: []
+      arrays:
+        repo: https://github.com/purescript/purescript-arrays.git
+        version: v7.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - foldable-traversable
+          - maybe
+          - nonempty
+          - partial
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - unfoldable
+          - unsafe-coerce
+      arrays-zipper:
+        repo: https://github.com/JordanMartinez/purescript-arrays-zipper.git
+        version: v2.0.1
+        dependencies:
+          - arrays
+          - control
+          - quickcheck
+      ask:
+        repo: https://github.com/Mateiadrielrafael/purescript-ask.git
+        version: v1.0.0
+        dependencies:
+          - unsafe-coerce
+      assert:
+        repo: https://github.com/purescript/purescript-assert.git
+        version: v6.0.0
+        dependencies:
+          - console
+          - effect
+          - prelude
+      avar:
+        repo: https://github.com/purescript-contrib/purescript-avar.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - exceptions
+          - functions
+          - maybe
+      b64:
+        repo: https://github.com/menelaos/purescript-b64.git
+        version: v0.0.8
+        dependencies:
+          - arraybuffer-types
+          - either
+          - encoding
+          - enums
+          - exceptions
+          - functions
+          - partial
+          - prelude
+          - strings
+      barlow-lens:
+        repo: https://github.com/sigma-andex/purescript-barlow-lens.git
+        version: v0.9.0
+        dependencies:
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - profunctor-lenses
+          - tuples
+          - typelevel-prelude
+      bifunctors:
+        repo: https://github.com/purescript/purescript-bifunctors.git
+        version: v6.0.0
+        dependencies:
+          - const
+          - either
+          - newtype
+          - prelude
+          - tuples
+      bigints:
+        repo: https://github.com/sharkdp/purescript-bigints.git
+        version: v7.0.1
+        dependencies:
+          - integers
+          - maybe
+          - strings
+      bower-json:
+        repo: https://github.com/klntsky/purescript-bower-json.git
+        version: v3.0.0
+        dependencies:
+          - argonaut-codecs
+          - arrays
+          - either
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - newtype
+          - prelude
+          - tuples
+      call-by-name:
+        repo: https://github.com/natefaubion/purescript-call-by-name.git
+        version: v4.0.1
+        dependencies:
+          - control
+          - either
+          - lazy
+          - maybe
+          - unsafe-coerce
+      canvas:
+        repo: https://github.com/purescript-web/purescript-canvas.git
+        version: v6.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - exceptions
+          - functions
+          - maybe
+      canvas-action:
+        repo: https://github.com/artemisSystem/purescript-canvas-action.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - arrays
+          - canvas
+          - colors
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - maybe
+          - numbers
+          - polymorphic-vectors
+          - prelude
+          - refs
+          - run
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-html
+      cartesian:
+        repo: https://github.com/Ebmtranceboy/purescript-cartesian.git
+        version: v1.0.6
+        dependencies:
+          - console
+          - effect
+          - integers
+          - psci-support
+      catenable-lists:
+        repo: https://github.com/purescript/purescript-catenable-lists.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - lists
+          - maybe
+          - prelude
+          - tuples
+          - unfoldable
+      channel:
+        repo: https://github.com/ConnorDillon/purescript-channel.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - assert
+          - avar
+          - console
+          - contravariant
+          - control
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - lazy
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      checked-exceptions:
+        repo: https://github.com/natefaubion/purescript-checked-exceptions.git
+        version: v3.1.1
+        dependencies:
+          - prelude
+          - transformers
+          - variant
+      codec:
+        repo: https://github.com/garyb/purescript-codec.git
+        version: v5.0.0
+        dependencies:
+          - profunctor
+          - transformers
+      codec-argonaut:
+        repo: https://github.com/garyb/purescript-codec-argonaut.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-core
+          - codec
+          - ordered-collections
+          - type-equality
+          - variant
+      colors:
+        repo: https://github.com/purescript-contrib/purescript-colors.git
+        version: v7.0.1
+        dependencies:
+          - arrays
+          - integers
+          - lists
+          - numbers
+          - partial
+          - strings
+      concurrent-queues:
+        repo: https://github.com/purescript-contrib/purescript-concurrent-queues.git
+        version: v3.0.0
+        dependencies:
+          - aff
+          - avar
+          - effect
+      console:
+        repo: https://github.com/purescript/purescript-console.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - prelude
+      const:
+        repo: https://github.com/purescript/purescript-const.git
+        version: v6.0.0
+        dependencies:
+          - invariant
+          - newtype
+          - prelude
+      contravariant:
+        repo: https://github.com/purescript/purescript-contravariant.git
+        version: v6.0.0
+        dependencies:
+          - const
+          - either
+          - newtype
+          - prelude
+          - tuples
+      control:
+        repo: https://github.com/purescript/purescript-control.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      convertable-options:
+        repo: https://github.com/natefaubion/purescript-convertable-options.git
+        version: v1.0.0
+        dependencies:
+          - console
+          - effect
+          - maybe
+          - record
+      coroutines:
+        repo: https://github.com/purescript-contrib/purescript-coroutines.git
+        version: v7.0.0
+        dependencies:
+          - freet
+          - parallel
+          - profunctor
+      css:
+        repo: https://github.com/purescript-contrib/purescript-css.git
+        version: v6.0.0
+        dependencies:
+          - colors
+          - console
+          - effect
+          - nonempty
+          - profunctor
+          - strings
+          - these
+          - transformers
+      datetime:
+        repo: https://github.com/purescript/purescript-datetime.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - either
+          - enums
+          - foldable-traversable
+          - functions
+          - gen
+          - integers
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - ordered-collections
+          - partial
+          - prelude
+          - tuples
+      datetime-parsing:
+        repo: https://github.com/flounders/purescript-datetime-parsing.git
+        version: v0.2.0
+        dependencies:
+          - arrays
+          - datetime
+          - either
+          - enums
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - numbers
+          - parsing
+          - prelude
+          - strings
+          - unicode
+      debug:
+        repo: https://github.com/garyb/purescript-debug.git
+        version: v6.0.0
+        dependencies:
+          - functions
+          - prelude
+      decimals:
+        repo: https://github.com/sharkdp/purescript-decimals.git
+        version: v7.0.0
+        dependencies:
+          - maybe
+      dissect:
+        repo: https://github.com/PureFunctor/purescript-dissect.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - foreign-object
+          - functors
+          - newtype
+          - partial
+          - prelude
+          - tailrec
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - variant
+      distributive:
+        repo: https://github.com/purescript/purescript-distributive.git
+        version: v6.0.0
+        dependencies:
+          - identity
+          - newtype
+          - prelude
+          - tuples
+          - type-equality
+      dodo-printer:
+        repo: https://github.com/natefaubion/purescript-dodo-printer.git
+        version: v2.2.0
+        dependencies:
+          - aff
+          - ansi
+          - avar
+          - console
+          - effect
+          - foldable-traversable
+          - lists
+          - maybe
+          - minibench
+          - node-child-process
+          - node-fs-aff
+          - node-process
+          - psci-support
+          - strings
+      dom-indexed:
+        repo: https://github.com/purescript-halogen/purescript-dom-indexed.git
+        version: v11.0.0
+        dependencies:
+          - media-types
+          - prelude
+          - web-clipboard
+          - web-pointerevents
+          - web-touchevents
+      droplet:
+        repo: https://github.com/easafe/purescript-droplet.git
+        version: v0.4.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - bigints
+          - datetime
+          - debug
+          - effect
+          - either
+          - enums
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - integers
+          - maybe
+          - newtype
+          - nullable
+          - ordered-collections
+          - partial
+          - prelude
+          - profunctor
+          - record
+          - spec
+          - strings
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+      dynamic-buffer:
+        repo: https://github.com/kritzcreek/purescript-dynamic-buffer.git
+        version: v3.0.1
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - refs
+      effect:
+        repo: https://github.com/purescript/purescript-effect.git
+        version: v4.0.0
+        dependencies:
+          - prelude
+      either:
+        repo: https://github.com/purescript/purescript-either.git
+        version: v6.1.0
+        dependencies:
+          - control
+          - invariant
+          - maybe
+          - prelude
+      elmish:
+        repo: https://github.com/collegevine/purescript-elmish.git
+        version: v0.8.1
+        dependencies:
+          - aff
+          - argonaut-core
+          - arrays
+          - bifunctors
+          - console
+          - debug
+          - effect
+          - either
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - functions
+          - integers
+          - js-date
+          - maybe
+          - nullable
+          - partial
+          - prelude
+          - refs
+          - typelevel-prelude
+          - undefined-is-not-a-problem
+          - unsafe-coerce
+          - web-dom
+          - web-html
+      elmish-enzyme:
+        repo: https://github.com/collegevine/purescript-elmish-enzyme.git
+        version: v0.1.1
+        dependencies:
+          - aff
+          - aff-promise
+          - arrays
+          - console
+          - debug
+          - effect
+          - elmish
+          - foldable-traversable
+          - foreign
+          - functions
+          - prelude
+          - transformers
+          - unsafe-coerce
+      elmish-hooks:
+        repo: https://github.com/collegevine/purescript-elmish-hooks.git
+        version: v0.8.2
+        dependencies:
+          - aff
+          - debug
+          - elmish
+          - maybe
+          - prelude
+          - tuples
+          - undefined-is-not-a-problem
+      elmish-html:
+        repo: https://github.com/collegevine/purescript-elmish-html.git
+        version: v0.7.1
+        dependencies:
+          - effect
+          - elmish
+          - foreign
+          - foreign-object
+          - prelude
+          - record
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-html
+      email-validate:
+        repo: https://github.com/cdepillabout/purescript-email-validate.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - string-parsers
+          - transformers
+      encoding:
+        repo: https://github.com/menelaos/purescript-encoding.git
+        version: v0.0.8
+        dependencies:
+          - arraybuffer-types
+          - either
+          - exceptions
+          - functions
+          - prelude
+      enums:
+        repo: https://github.com/purescript/purescript-enums.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - either
+          - gen
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tuples
+          - unfoldable
+      exceptions:
+        repo: https://github.com/purescript/purescript-exceptions.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - either
+          - maybe
+          - prelude
+      exists:
+        repo: https://github.com/purescript/purescript-exists.git
+        version: v6.0.0
+        dependencies:
+          - unsafe-coerce
+      exitcodes:
+        repo: https://github.com/Risto-Stevcev/purescript-exitcodes.git
+        version: v4.0.0
+        dependencies:
+          - enums
+      expect-inferred:
+        repo: https://github.com/justinwoo/purescript-expect-inferred.git
+        version: v3.0.0
+        dependencies:
+          - prelude
+          - typelevel-prelude
+      fast-vect:
+        repo: https://github.com/sigma-andex/purescript-fast-vect.git
+        version: v0.7.0
+        dependencies:
+          - arrays
+          - filterable
+          - foldable-traversable
+          - lists
+          - maybe
+          - ordered-collections
+          - prelude
+          - profunctor
+          - tuples
+          - unfoldable
+      filterable:
+        repo: https://github.com/purescript/purescript-filterable.git
+        version: v5.0.0
+        dependencies:
+          - arrays
+          - either
+          - foldable-traversable
+          - identity
+          - lists
+          - ordered-collections
+      fixed-points:
+        repo: https://github.com/purescript-contrib/purescript-fixed-points.git
+        version: v7.0.0
+        dependencies:
+          - exists
+          - newtype
+          - prelude
+          - transformers
+      fixed-precision:
+        repo: https://github.com/lumihq/purescript-fixed-precision.git
+        version: v5.0.0
+        dependencies:
+          - arrays
+          - bigints
+          - control
+          - integers
+          - maybe
+          - numbers
+          - partial
+          - prelude
+          - strings
+      flame:
+        repo: https://github.com/easafe/purescript-flame.git
+        version: v1.2.0
+        dependencies:
+          - aff
+          - argonaut-codecs
+          - argonaut-core
+          - argonaut-generic
+          - arrays
+          - bifunctors
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - maybe
+          - newtype
+          - nullable
+          - partial
+          - prelude
+          - random
+          - refs
+          - spec
+          - strings
+          - tuples
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-html
+          - web-uievents
+      float32:
+        repo: https://github.com/purescript-contrib/purescript-float32.git
+        version: v2.0.0
+        dependencies:
+          - gen
+          - maybe
+          - prelude
+      foldable-traversable:
+        repo: https://github.com/purescript/purescript-foldable-traversable.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - const
+          - control
+          - either
+          - functors
+          - identity
+          - maybe
+          - newtype
+          - orders
+          - prelude
+          - tuples
+      foreign:
+        repo: https://github.com/purescript/purescript-foreign.git
+        version: v7.0.0
+        dependencies:
+          - either
+          - functions
+          - identity
+          - integers
+          - lists
+          - maybe
+          - prelude
+          - strings
+          - transformers
+      foreign-object:
+        repo: https://github.com/purescript/purescript-foreign-object.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - functions
+          - gen
+          - lists
+          - maybe
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - typelevel-prelude
+          - unfoldable
+      foreign-readwrite:
+        repo: https://github.com/artemisSystem/purescript-foreign-readwrite.git
+        version: v3.0.0
+        dependencies:
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - record
+          - safe-coerce
+          - transformers
+          - unsafe-coerce
+      fork:
+        repo: https://github.com/purescript-contrib/purescript-fork.git
+        version: v6.0.0
+        dependencies:
+          - aff
+      form-urlencoded:
+        repo: https://github.com/purescript-contrib/purescript-form-urlencoded.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - js-uri
+          - maybe
+          - newtype
+          - prelude
+          - strings
+          - tuples
+      formatters:
+        repo: https://github.com/purescript-contrib/purescript-formatters.git
+        version: v7.0.0
+        dependencies:
+          - datetime
+          - fixed-points
+          - lists
+          - numbers
+          - parsing
+          - prelude
+          - transformers
+      free:
+        repo: https://github.com/purescript/purescript-free.git
+        version: v7.0.0
+        dependencies:
+          - catenable-lists
+          - control
+          - distributive
+          - either
+          - exists
+          - foldable-traversable
+          - invariant
+          - lazy
+          - maybe
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+      freeap:
+        repo: https://github.com/ethul/purescript-freeap.git
+        version: v7.0.0
+        dependencies:
+          - const
+          - exists
+          - gen
+          - lists
+      freet:
+        repo: https://github.com/purescript-contrib/purescript-freet.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - bifunctors
+          - effect
+          - either
+          - exists
+          - free
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      functions:
+        repo: https://github.com/purescript/purescript-functions.git
+        version: v6.0.0
+        dependencies:
+          - prelude
+      functors:
+        repo: https://github.com/purescript/purescript-functors.git
+        version: v5.0.0
+        dependencies:
+          - bifunctors
+          - const
+          - contravariant
+          - control
+          - distributive
+          - either
+          - invariant
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - tuples
+          - unsafe-coerce
+      fuzzy:
+        repo: https://github.com/citizennet/purescript-fuzzy.git
+        version: v0.4.0
+        dependencies:
+          - foldable-traversable
+          - foreign-object
+          - newtype
+          - ordered-collections
+          - prelude
+          - rationals
+          - strings
+          - tuples
+      gen:
+        repo: https://github.com/purescript/purescript-gen.git
+        version: v4.0.0
+        dependencies:
+          - either
+          - foldable-traversable
+          - identity
+          - maybe
+          - newtype
+          - nonempty
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      generate-values:
+        repo: https://github.com/jordanmartinez/purescript-generate-values.git
+        version: v1.0.1
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - enums
+          - foldable-traversable
+          - gen
+          - identity
+          - integers
+          - lcg
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - partial
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      geometry-plane:
+        repo: https://github.com/Ebmtranceboy/purescript-geometry-plane.git
+        version: v1.0.3
+        dependencies:
+          - console
+          - effect
+          - psci-support
+          - sparse-polynomials
+      github-actions-toolkit:
+        repo: https://github.com/purescript-contrib/purescript-github-actions-toolkit.git
+        version: v0.5.0
+        dependencies:
+          - aff
+          - aff-promise
+          - effect
+          - foreign-object
+          - node-buffer
+          - node-path
+          - node-streams
+          - nullable
+          - transformers
+      graphs:
+        repo: https://github.com/purescript/purescript-graphs.git
+        version: v8.0.0
+        dependencies:
+          - catenable-lists
+          - ordered-collections
+      group:
+        repo: https://github.com/morganthomas/purescript-group.git
+        version: v4.1.1
+        dependencies:
+          - lists
+      halogen:
+        repo: https://github.com/purescript-halogen/purescript-halogen.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - avar
+          - console
+          - const
+          - dom-indexed
+          - effect
+          - foreign
+          - fork
+          - free
+          - freeap
+          - halogen-subscriptions
+          - halogen-vdom
+          - media-types
+          - nullable
+          - ordered-collections
+          - parallel
+          - profunctor
+          - transformers
+          - unsafe-coerce
+          - unsafe-reference
+          - web-file
+          - web-uievents
+      halogen-css:
+        repo: https://github.com/purescript-halogen/purescript-halogen-css.git
+        version: v10.0.0
+        dependencies:
+          - css
+          - halogen
+      halogen-formless:
+        repo: https://github.com/thomashoneyman/purescript-halogen-formless.git
+        version: v4.0.0
+        dependencies:
+          - convertable-options
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - halogen
+          - heterogeneous
+          - maybe
+          - prelude
+          - record
+          - safe-coerce
+          - type-equality
+          - unsafe-coerce
+          - unsafe-reference
+          - variant
+          - web-events
+          - web-uievents
+      halogen-hooks:
+        repo: https://github.com/thomashoneyman/purescript-halogen-hooks.git
+        version: v0.6.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - effect
+          - exceptions
+          - foldable-traversable
+          - foreign-object
+          - free
+          - freeap
+          - halogen
+          - halogen-subscriptions
+          - maybe
+          - newtype
+          - ordered-collections
+          - parallel
+          - partial
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+          - unsafe-reference
+          - web-dom
+          - web-html
+      halogen-hooks-extra:
+        repo: https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git
+        version: v0.9.0
+        dependencies:
+          - halogen-hooks
+      halogen-store:
+        repo: https://github.com/thomashoneyman/purescript-halogen-store.git
+        version: v0.5.0
+        dependencies:
+          - aff
+          - distributive
+          - effect
+          - fork
+          - halogen
+          - halogen-hooks
+          - halogen-subscriptions
+          - maybe
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-reference
+      halogen-storybook:
+        repo: https://github.com/rnons/purescript-halogen-storybook.git
+        version: v2.0.0
+        dependencies:
+          - foreign-object
+          - halogen
+          - prelude
+          - routing
+      halogen-subscriptions:
+        repo: https://github.com/purescript-halogen/purescript-halogen-subscriptions.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - effect
+          - foldable-traversable
+          - functors
+          - refs
+          - safe-coerce
+          - unsafe-reference
+      halogen-svg-elems:
+        repo: https://github.com/JordanMartinez/purescript-halogen-svg-elems.git
+        version: v6.0.0
+        dependencies:
+          - halogen
+      halogen-vdom:
+        repo: https://github.com/purescript-halogen/purescript-halogen-vdom.git
+        version: v8.0.0
+        dependencies:
+          - bifunctors
+          - effect
+          - foreign
+          - foreign-object
+          - maybe
+          - prelude
+          - refs
+          - tuples
+          - unsafe-coerce
+          - web-html
+      halogen-vdom-string-renderer:
+        repo: https://github.com/purescript-halogen/purescript-halogen-vdom-string-renderer.git
+        version: v0.5.0
+        dependencies:
+          - foreign
+          - halogen-vdom
+          - ordered-collections
+          - prelude
+      heckin:
+        repo: https://github.com/maxdeviant/purescript-heckin.git
+        version: v2.0.1
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - maybe
+          - prelude
+          - strings
+          - transformers
+          - tuples
+          - unicode
+      heterogeneous:
+        repo: https://github.com/natefaubion/purescript-heterogeneous.git
+        version: v0.6.0
+        dependencies:
+          - either
+          - functors
+          - prelude
+          - record
+          - tuples
+          - variant
+      heterogeneous-extrablatt:
+        repo: https://github.com/sigma-andex/purescript-heterogeneous-extrablatt.git
+        version: v0.2.1
+        dependencies:
+          - heterogeneous
+          - prelude
+          - record
+      http-methods:
+        repo: https://github.com/purescript-contrib/purescript-http-methods.git
+        version: v6.0.0
+        dependencies:
+          - either
+          - prelude
+          - strings
+      httpure:
+        repo: https://github.com/citizennet/purescript-httpure.git
+        version: v0.15.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - js-uri
+          - maybe
+          - newtype
+          - node-buffer
+          - node-fs
+          - node-http
+          - node-streams
+          - options
+          - ordered-collections
+          - prelude
+          - refs
+          - strings
+          - tuples
+          - type-equality
+      httpurple:
+        repo: https://github.com/sigma-andex/purescript-httpurple.git
+        version: v1.3.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - js-uri
+          - justifill
+          - maybe
+          - newtype
+          - node-buffer
+          - node-fs
+          - node-http
+          - node-net
+          - node-process
+          - node-streams
+          - options
+          - ordered-collections
+          - posix-types
+          - prelude
+          - profunctor
+          - record
+          - refs
+          - routing-duplex
+          - strings
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+      httpurple-argonaut:
+        repo: https://github.com/sigma-andex/purescript-httpurple-argonaut.git
+        version: v1.0.1
+        dependencies:
+          - argonaut
+          - console
+          - effect
+          - either
+          - httpurple
+          - prelude
+      httpurple-yoga-json:
+        repo: https://github.com/sigma-andex/purescript-httpurple-yoga-json.git
+        version: v1.0.0
+        dependencies:
+          - console
+          - effect
+          - either
+          - foreign
+          - httpurple
+          - lists
+          - prelude
+          - yoga-json
+      identity:
+        repo: https://github.com/purescript/purescript-identity.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - invariant
+          - newtype
+          - prelude
+      indexed-monad:
+        repo: https://github.com/garyb/purescript-indexed-monad.git
+        version: v2.1.0
+        dependencies:
+          - control
+          - newtype
+      int64:
+        repo: https://github.com/purescript-contrib/purescript-int64.git
+        version: v2.0.0
+        dependencies:
+          - effect
+          - foreign
+          - functions
+          - integers
+          - maybe
+          - nullable
+          - prelude
+          - quickcheck
+      integers:
+        repo: https://github.com/purescript/purescript-integers.git
+        version: v6.0.0
+        dependencies:
+          - maybe
+          - numbers
+          - prelude
+      interpolate:
+        repo: https://github.com/jordanmartinez/purescript-interpolate.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+      invariant:
+        repo: https://github.com/purescript/purescript-invariant.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - prelude
+      js-date:
+        repo: https://github.com/purescript-contrib/purescript-js-date.git
+        version: v8.0.0
+        dependencies:
+          - datetime
+          - effect
+          - exceptions
+          - foreign
+          - integers
+          - now
+      js-fileio:
+        repo: https://github.com/newlandsvalley/purescript-js-fileio.git
+        version: v3.0.0
+        dependencies:
+          - aff
+          - effect
+          - prelude
+      js-timers:
+        repo: https://github.com/purescript-contrib/purescript-js-timers.git
+        version: v6.1.0
+        dependencies:
+          - effect
+      js-uri:
+        repo: https://github.com/purescript-contrib/purescript-js-uri.git
+        version: v3.0.0
+        dependencies:
+          - functions
+          - maybe
+      justifill:
+        repo: https://github.com/i-am-the-slime/purescript-justifill.git
+        version: v0.5.0
+        dependencies:
+          - maybe
+          - prelude
+          - record
+          - typelevel-prelude
+      jwt:
+        repo: https://github.com/menelaos/purescript-jwt.git
+        version: v0.0.9
+        dependencies:
+          - argonaut-core
+          - arrays
+          - b64
+          - either
+          - exceptions
+          - prelude
+          - profunctor-lenses
+          - strings
+      language-cst-parser:
+        repo: https://github.com/natefaubion/purescript-language-cst-parser.git
+        version: v0.12.0
+        dependencies:
+          - arrays
+          - const
+          - control
+          - either
+          - foldable-traversable
+          - free
+          - functions
+          - functors
+          - identity
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - ordered-collections
+          - partial
+          - prelude
+          - st
+          - strings
+          - transformers
+          - tuples
+          - typelevel-prelude
+          - unfoldable
+          - unsafe-coerce
+      lazy:
+        repo: https://github.com/purescript/purescript-lazy.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - invariant
+          - prelude
+      lcg:
+        repo: https://github.com/purescript/purescript-lcg.git
+        version: v4.0.0
+        dependencies:
+          - effect
+          - integers
+          - maybe
+          - partial
+          - prelude
+          - random
+      leibniz:
+        repo: https://github.com/paf31/purescript-leibniz.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+          - unsafe-coerce
+      linalg:
+        repo: https://github.com/gbagan/purescript-linalg.git
+        version: v5.1.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - functions
+          - maybe
+          - prelude
+          - tuples
+      lists:
+        repo: https://github.com/purescript/purescript-lists.git
+        version: v7.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - foldable-traversable
+          - lazy
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      logging:
+        repo: https://github.com/rightfold/purescript-logging.git
+        version: v3.0.0
+        dependencies:
+          - console
+          - contravariant
+          - effect
+          - either
+          - prelude
+          - transformers
+          - tuples
+      machines:
+        repo: https://github.com/purescript-contrib/purescript-machines.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - lists
+          - maybe
+          - prelude
+          - profunctor
+          - tuples
+          - unfoldable
+      matrices:
+        repo: https://github.com/kRITZCREEK/purescript-matrices.git
+        version: v5.0.1
+        dependencies:
+          - arrays
+          - strings
+      matryoshka:
+        repo: https://github.com/purescript-contrib/purescript-matryoshka.git
+        version: v1.0.0
+        dependencies:
+          - fixed-points
+          - free
+          - prelude
+          - profunctor
+          - transformers
+      maybe:
+        repo: https://github.com/purescript/purescript-maybe.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - invariant
+          - newtype
+          - prelude
+      media-types:
+        repo: https://github.com/purescript-contrib/purescript-media-types.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      metadata:
+        repo: https://github.com/purescript/purescript-metadata.git
+        version: v0.15.0
+        dependencies: []
+      midi:
+        repo: https://github.com/newlandsvalley/purescript-midi.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - ordered-collections
+          - prelude
+          - signal
+          - string-parsers
+          - strings
+          - tuples
+          - unfoldable
+      minibench:
+        repo: https://github.com/purescript/purescript-minibench.git
+        version: v4.0.0
+        dependencies:
+          - console
+          - effect
+          - integers
+          - numbers
+          - partial
+          - prelude
+          - refs
+      mmorph:
+        repo: https://github.com/Thimoteus/purescript-mmorph.git
+        version: v7.0.0
+        dependencies:
+          - free
+          - functors
+          - transformers
+      monad-control:
+        repo: https://github.com/athanclark/purescript-monad-control.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - freet
+          - identity
+          - lists
+      monad-logger:
+        repo: https://github.com/cprussin/purescript-monad-logger.git
+        version: v1.3.1
+        dependencies:
+          - aff
+          - ansi
+          - argonaut
+          - arrays
+          - console
+          - control
+          - effect
+          - foldable-traversable
+          - foreign-object
+          - integers
+          - js-date
+          - maybe
+          - newtype
+          - ordered-collections
+          - prelude
+          - strings
+          - transformers
+          - tuples
+      monad-loops:
+        repo: https://github.com/mlang/purescript-monad-loops.git
+        version: v0.5.0
+        dependencies:
+          - lists
+          - maybe
+          - prelude
+          - tailrec
+          - tuples
+      monad-unlift:
+        repo: https://github.com/athanclark/purescript-monad-unlift.git
+        version: v1.0.1
+        dependencies:
+          - monad-control
+      monoidal:
+        repo: https://github.com/mcneissue/purescript-monoidal.git
+        version: v0.16.0
+        dependencies:
+          - either
+          - profunctor
+          - these
+          - tuples
+      morello:
+        repo: https://github.com/sigma-andex/purescript-morello.git
+        version: v0.3.2
+        dependencies:
+          - arrays
+          - barlow-lens
+          - foldable-traversable
+          - heterogeneous
+          - heterogeneous-extrablatt
+          - newtype
+          - prelude
+          - profunctor
+          - profunctor-lenses
+          - record
+          - tuples
+          - typelevel-prelude
+          - validation
+      motsunabe:
+        repo: https://github.com/justinwoo/purescript-motsunabe.git
+        version: v2.0.0
+        dependencies:
+          - lists
+          - strings
+      nano-id:
+        repo: https://github.com/eikooc/nano-id.git
+        version: v1.1.0
+        dependencies:
+          - aff
+          - effect
+          - lists
+          - maybe
+          - prelude
+          - random
+          - spec
+          - strings
+          - stringutils
+      naturals:
+        repo: https://github.com/LiamGoodacre/purescript-naturals.git
+        version: v3.0.0
+        dependencies:
+          - enums
+          - maybe
+          - prelude
+      nested-functor:
+        repo: https://github.com/acple/purescript-nested-functor.git
+        version: v0.2.1
+        dependencies:
+          - prelude
+          - type-equality
+      newtype:
+        repo: https://github.com/purescript/purescript-newtype.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+          - safe-coerce
+      node-buffer:
+        repo: https://github.com/purescript-node/purescript-node-buffer.git
+        version: v8.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - maybe
+          - st
+          - unsafe-coerce
+      node-buffer-blob:
+        repo: https://github.com/purescript-node/purescript-node-buffer-blob.git
+        version: v1.0.0
+        dependencies:
+          - aff-promise
+          - arraybuffer-types
+          - arrays
+          - console
+          - effect
+          - maybe
+          - media-types
+          - newtype
+          - node-buffer
+          - nullable
+          - prelude
+          - web-streams
+      node-child-process:
+        repo: https://github.com/purescript-node/purescript-node-child-process.git
+        version: v9.0.0
+        dependencies:
+          - exceptions
+          - foreign
+          - foreign-object
+          - functions
+          - node-fs
+          - node-streams
+          - nullable
+          - posix-types
+          - unsafe-coerce
+      node-fs:
+        repo: https://github.com/purescript-node/purescript-node-fs.git
+        version: v8.0.0
+        dependencies:
+          - datetime
+          - effect
+          - either
+          - enums
+          - exceptions
+          - functions
+          - integers
+          - js-date
+          - maybe
+          - node-buffer
+          - node-path
+          - node-streams
+          - nullable
+          - partial
+          - prelude
+          - strings
+          - unsafe-coerce
+      node-fs-aff:
+        repo: https://github.com/purescript-node/purescript-node-fs-aff.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - either
+          - node-fs
+          - node-path
+      node-http:
+        repo: https://github.com/purescript-node/purescript-node-http.git
+        version: v8.0.0
+        dependencies:
+          - arraybuffer-types
+          - contravariant
+          - effect
+          - foreign
+          - foreign-object
+          - maybe
+          - node-buffer
+          - node-net
+          - node-streams
+          - node-url
+          - nullable
+          - options
+          - prelude
+          - unsafe-coerce
+      node-net:
+        repo: https://github.com/purescript-node/purescript-node-net.git
+        version: v4.0.0
+        dependencies:
+          - effect
+          - either
+          - exceptions
+          - foreign
+          - maybe
+          - node-buffer
+          - node-fs
+          - nullable
+          - options
+          - prelude
+          - transformers
+      node-path:
+        repo: https://github.com/purescript-node/purescript-node-path.git
+        version: v5.0.0
+        dependencies:
+          - effect
+      node-process:
+        repo: https://github.com/purescript-node/purescript-node-process.git
+        version: v10.0.0
+        dependencies:
+          - effect
+          - foreign-object
+          - maybe
+          - node-streams
+          - posix-types
+          - prelude
+          - unsafe-coerce
+      node-readline:
+        repo: https://github.com/purescript-node/purescript-node-readline.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - foreign
+          - node-process
+          - node-streams
+          - options
+          - prelude
+      node-streams:
+        repo: https://github.com/purescript-node/purescript-node-streams.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - either
+          - exceptions
+          - node-buffer
+          - nullable
+          - prelude
+      node-streams-aff:
+        repo: https://github.com/jamesdbrock/purescript-node-streams-aff.git
+        version: v2.0.0
+        dependencies:
+          - aff
+          - arrays
+          - effect
+          - either
+          - exceptions
+          - maybe
+          - node-buffer
+          - node-streams
+          - prelude
+          - st
+          - tuples
+      node-url:
+        repo: https://github.com/purescript-node/purescript-node-url.git
+        version: v6.0.0
+        dependencies:
+          - nullable
+      nonempty:
+        repo: https://github.com/purescript/purescript-nonempty.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - maybe
+          - prelude
+          - tuples
+          - unfoldable
+      now:
+        repo: https://github.com/purescript-contrib/purescript-now.git
+        version: v6.0.0
+        dependencies:
+          - datetime
+          - effect
+      npm-package-json:
+        repo: https://github.com/maxdeviant/purescript-npm-package-json.git
+        version: v2.0.0
+        dependencies:
+          - argonaut
+          - control
+          - either
+          - foreign-object
+          - maybe
+          - ordered-collections
+          - prelude
+      nullable:
+        repo: https://github.com/purescript-contrib/purescript-nullable.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - functions
+          - maybe
+      numbers:
+        repo: https://github.com/purescript/purescript-numbers.git
+        version: v9.0.0
+        dependencies:
+          - functions
+          - maybe
+      open-folds:
+        repo: https://github.com/purescript-open-community/purescript-open-folds.git
+        version: v6.3.0
+        dependencies:
+          - bifunctors
+          - console
+          - control
+          - distributive
+          - effect
+          - either
+          - foldable-traversable
+          - identity
+          - invariant
+          - maybe
+          - newtype
+          - ordered-collections
+          - prelude
+          - profunctor
+          - psci-support
+          - tuples
+      open-memoize:
+        repo: https://github.com/purescript-open-community/purescript-open-memoize.git
+        version: v6.1.0
+        dependencies:
+          - console
+          - effect
+          - either
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - psci-support
+          - strings
+          - tuples
+      open-pairing:
+        repo: https://github.com/purescript-open-community/purescript-open-pairing.git
+        version: v6.1.0
+        dependencies:
+          - console
+          - control
+          - effect
+          - either
+          - free
+          - functors
+          - identity
+          - newtype
+          - prelude
+          - psci-support
+          - transformers
+          - tuples
+      options:
+        repo: https://github.com/purescript-contrib/purescript-options.git
+        version: v7.0.0
+        dependencies:
+          - contravariant
+          - foreign
+          - foreign-object
+          - maybe
+          - tuples
+      optparse:
+        repo: https://github.com/f-o-a-m/purescript-optparse.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - control
+          - effect
+          - either
+          - enums
+          - exists
+          - exitcodes
+          - foldable-traversable
+          - free
+          - gen
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - newtype
+          - node-buffer
+          - node-process
+          - node-streams
+          - nonempty
+          - numbers
+          - open-memoize
+          - partial
+          - prelude
+          - quickcheck
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+      ordered-collections:
+        repo: https://github.com/purescript/purescript-ordered-collections.git
+        version: v3.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - gen
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - unfoldable
+      ordered-set:
+        repo: https://github.com/flip111/purescript-ordered-set.git
+        version: v0.4.0
+        dependencies:
+          - argonaut-codecs
+          - arrays
+          - partial
+          - prelude
+          - unfoldable
+      orders:
+        repo: https://github.com/purescript/purescript-orders.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      pairs:
+        repo: https://github.com/sharkdp/purescript-pairs.git
+        version: v9.0.0
+        dependencies:
+          - console
+          - distributive
+          - foldable-traversable
+          - quickcheck
+      parallel:
+        repo: https://github.com/purescript/purescript-parallel.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - functors
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - refs
+          - transformers
+      parsing:
+        repo: https://github.com/purescript-contrib/purescript-parsing.git
+        version: v9.1.0
+        dependencies:
+          - arrays
+          - either
+          - foldable-traversable
+          - identity
+          - integers
+          - lists
+          - maybe
+          - nullable
+          - prelude
+          - strings
+          - transformers
+          - unicode
+      parsing-dataview:
+        repo: https://github.com/jamesdbrock/purescript-parsing-dataview.git
+        version: v3.1.0
+        dependencies:
+          - arraybuffer
+          - arraybuffer-types
+          - effect
+          - float32
+          - maybe
+          - parsing
+          - prelude
+          - transformers
+          - tuples
+          - uint
+      partial:
+        repo: https://github.com/purescript/purescript-partial.git
+        version: v4.0.0
+        dependencies: []
+      pathy:
+        repo: https://github.com/purescript-contrib/purescript-pathy.git
+        version: v9.0.0
+        dependencies:
+          - console
+          - exceptions
+          - lists
+          - partial
+          - profunctor
+          - strings
+          - transformers
+          - typelevel-prelude
+          - unsafe-coerce
+      pha:
+        repo: https://github.com/gbagan/purescript-pha.git
+        version: v0.9.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - datetime
+          - effect
+          - foldable-traversable
+          - free
+          - integers
+          - maybe
+          - prelude
+          - profunctor-lenses
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+          - unsafe-reference
+          - web-dom
+          - web-events
+          - web-html
+          - web-pointerevents
+          - web-uievents
+      phaser:
+        repo: https://github.com/lfarroco/purescript-phaser.git
+        version: v0.6.0
+        dependencies:
+          - canvas
+          - console
+          - effect
+          - maybe
+          - nullable
+          - options
+          - prelude
+          - web-html
+      pipes:
+        repo: https://github.com/felixschl/purescript-pipes.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - lists
+          - mmorph
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      point-free:
+        repo: https://github.com/ursi/purescript-point-free.git
+        version: v1.0.0
+        dependencies:
+          - prelude
+      polymorphic-vectors:
+        repo: https://github.com/artemisSystem/purescript-polymorphic-vectors.git
+        version: v4.0.0
+        dependencies:
+          - distributive
+          - foldable-traversable
+          - numbers
+          - prelude
+          - record
+          - safe-coerce
+          - type-equality
+          - typelevel-prelude
+      posix-types:
+        repo: https://github.com/purescript-node/purescript-posix-types.git
+        version: v6.0.0
+        dependencies:
+          - maybe
+          - prelude
+      precise:
+        repo: https://github.com/purescript-contrib/purescript-precise.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - exceptions
+          - gen
+          - integers
+          - lists
+          - numbers
+          - prelude
+          - strings
+      precise-datetime:
+        repo: https://github.com/awakesecurity/purescript-precise-datetime.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - datetime
+          - decimals
+          - either
+          - enums
+          - foldable-traversable
+          - formatters
+          - integers
+          - js-date
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - strings
+          - tuples
+          - unicode
+      prelude:
+        repo: https://github.com/purescript/purescript-prelude.git
+        version: v6.0.0
+        dependencies: []
+      prettier-printer:
+        repo: https://github.com/paulyoung/purescript-prettier-printer.git
+        version: v3.0.0
+        dependencies:
+          - console
+          - lists
+          - prelude
+          - strings
+          - tuples
+      profunctor:
+        repo: https://github.com/purescript/purescript-profunctor.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - distributive
+          - either
+          - exists
+          - invariant
+          - newtype
+          - prelude
+          - tuples
+      profunctor-lenses:
+        repo: https://github.com/purescript-contrib/purescript-profunctor-lenses.git
+        version: v8.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - const
+          - control
+          - distributive
+          - either
+          - foldable-traversable
+          - foreign-object
+          - functors
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - ordered-collections
+          - partial
+          - prelude
+          - profunctor
+          - record
+          - transformers
+          - tuples
+      protobuf:
+        repo: https://github.com/xc-jp/purescript-protobuf.git
+        version: v4.0.0
+        dependencies:
+          - arraybuffer
+          - arraybuffer-builder
+          - arraybuffer-types
+          - arrays
+          - control
+          - effect
+          - either
+          - enums
+          - exceptions
+          - float32
+          - foldable-traversable
+          - functions
+          - int64
+          - maybe
+          - newtype
+          - parsing
+          - parsing-dataview
+          - prelude
+          - record
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+          - uint
+          - web-encoding
+      ps-cst:
+        repo: https://github.com/purescript-codegen/purescript-ps-cst.git
+        version: v1.2.0
+        dependencies:
+          - ansi
+          - console
+          - dodo-printer
+          - effect
+          - node-fs-aff
+          - node-path
+          - psci-support
+          - record
+          - strings
+      psa-utils:
+        repo: https://github.com/natefaubion/purescript-psa-utils.git
+        version: v8.0.0
+        dependencies:
+          - ansi
+          - argonaut-codecs
+          - argonaut-core
+          - arrays
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - maybe
+          - node-path
+          - ordered-collections
+          - prelude
+          - strings
+          - tuples
+          - unsafe-coerce
+      psc-ide:
+        repo: https://github.com/kRITZCREEK/purescript-psc-ide.git
+        version: v19.0.0
+        dependencies:
+          - aff
+          - argonaut
+          - arrays
+          - console
+          - maybe
+          - node-child-process
+          - node-fs
+          - parallel
+          - random
+      psci-support:
+        repo: https://github.com/purescript/purescript-psci-support.git
+        version: v6.0.0
+        dependencies:
+          - console
+          - effect
+          - prelude
+      qualified-do:
+        repo: https://github.com/artemisSystem/purescript-qualified-do.git
+        version: v2.2.0
+        dependencies:
+          - arrays
+          - control
+          - foldable-traversable
+          - parallel
+          - prelude
+          - unfoldable
+      quantities:
+        repo: https://github.com/sharkdp/purescript-quantities.git
+        version: v12.0.1
+        dependencies:
+          - decimals
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - newtype
+          - nonempty
+          - numbers
+          - pairs
+          - prelude
+          - tuples
+      quickcheck:
+        repo: https://github.com/purescript/purescript-quickcheck.git
+        version: v8.0.1
+        dependencies:
+          - arrays
+          - console
+          - control
+          - effect
+          - either
+          - enums
+          - exceptions
+          - foldable-traversable
+          - gen
+          - identity
+          - integers
+          - lazy
+          - lcg
+          - lists
+          - maybe
+          - newtype
+          - nonempty
+          - numbers
+          - partial
+          - prelude
+          - record
+          - st
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+          - unfoldable
+      quickcheck-combinators:
+        repo: https://github.com/athanclark/purescript-quickcheck-combinators.git
+        version: v0.1.3
+        dependencies:
+          - quickcheck
+          - typelevel
+      quickcheck-laws:
+        repo: https://github.com/purescript-contrib/purescript-quickcheck-laws.git
+        version: v7.0.0
+        dependencies:
+          - enums
+          - quickcheck
+      quickcheck-utf8:
+        repo: https://github.com/openchronology/purescript-quickcheck-utf8.git
+        version: v0.0.0
+        dependencies:
+          - quickcheck
+      quotient:
+        repo: https://github.com/rightfold/purescript-quotient.git
+        version: v3.0.0
+        dependencies:
+          - prelude
+          - quickcheck
+      random:
+        repo: https://github.com/purescript/purescript-random.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - integers
+      rationals:
+        repo: https://github.com/anttih/purescript-rationals.git
+        version: v5.0.0
+        dependencies:
+          - integers
+          - prelude
+      react:
+        repo: https://github.com/purescript-contrib/purescript-react.git
+        version: v10.0.1
+        dependencies:
+          - effect
+          - exceptions
+          - maybe
+          - nullable
+          - prelude
+          - typelevel-prelude
+          - unsafe-coerce
+      react-basic:
+        repo: https://github.com/lumihq/purescript-react-basic.git
+        version: v17.0.0
+        dependencies:
+          - effect
+          - prelude
+          - record
+      react-basic-dom:
+        repo: https://github.com/lumihq/purescript-react-basic-dom.git
+        version: v5.0.0
+        dependencies:
+          - effect
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - nullable
+          - prelude
+          - react-basic
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-file
+          - web-html
+      react-basic-hooks:
+        repo: https://github.com/megamaddu/purescript-react-basic-hooks.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - aff-promise
+          - bifunctors
+          - console
+          - control
+          - datetime
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - functions
+          - indexed-monad
+          - integers
+          - maybe
+          - newtype
+          - now
+          - nullable
+          - ordered-collections
+          - prelude
+          - react-basic
+          - refs
+          - tuples
+          - type-equality
+          - unsafe-coerce
+          - unsafe-reference
+          - web-html
+      react-dom:
+        repo: https://github.com/purescript-contrib/purescript-react-dom.git
+        version: v8.0.0
+        dependencies:
+          - effect
+          - react
+          - web-dom
+      read:
+        repo: https://github.com/truqu/purescript-read.git
+        version: v1.0.1
+        dependencies:
+          - maybe
+          - prelude
+          - strings
+      record:
+        repo: https://github.com/purescript/purescript-record.git
+        version: v4.0.0
+        dependencies:
+          - functions
+          - prelude
+          - unsafe-coerce
+      refined:
+        repo: https://github.com/danieljharvey/purescript-refined.git
+        version: v1.0.0
+        dependencies:
+          - argonaut
+          - effect
+          - prelude
+          - quickcheck
+          - typelevel
+      refs:
+        repo: https://github.com/purescript/purescript-refs.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - prelude
+      remotedata:
+        repo: https://github.com/krisajenkins/purescript-remotedata.git
+        version: v5.0.0
+        dependencies:
+          - bifunctors
+          - either
+          - profunctor-lenses
+      resource:
+        repo: https://github.com/joneshf/purescript-resource.git
+        version: v2.0.1
+        dependencies:
+          - aff
+          - console
+          - control
+          - effect
+          - newtype
+          - prelude
+          - psci-support
+          - refs
+      resourcet:
+        repo: https://github.com/robertdp/purescript-resourcet.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - effect
+          - foldable-traversable
+          - maybe
+          - ordered-collections
+          - parallel
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+      result:
+        repo: https://github.com/ad-si/purescript-result.git
+        version: v1.0.3
+        dependencies:
+          - either
+          - foldable-traversable
+          - prelude
+      return:
+        repo: https://github.com/ursi/purescript-return.git
+        version: v0.2.0
+        dependencies:
+          - foldable-traversable
+          - point-free
+          - prelude
+      ring-modules:
+        repo: https://github.com/f-o-a-m/purescript-ring-modules.git
+        version: v5.0.1
+        dependencies:
+          - prelude
+      routing:
+        repo: https://github.com/purescript-contrib/purescript-routing.git
+        version: v11.0.0
+        dependencies:
+          - aff
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - integers
+          - js-uri
+          - lists
+          - maybe
+          - numbers
+          - partial
+          - prelude
+          - semirings
+          - tuples
+          - validation
+          - web-html
+      routing-duplex:
+        repo: https://github.com/natefaubion/purescript-routing-duplex.git
+        version: v0.6.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - js-uri
+          - lazy
+          - numbers
+          - prelude
+          - profunctor
+          - record
+          - strings
+          - typelevel-prelude
+      run:
+        repo: https://github.com/natefaubion/purescript-run.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - free
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - tailrec
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - variant
+      safe-coerce:
+        repo: https://github.com/purescript/purescript-safe-coerce.git
+        version: v2.0.0
+        dependencies:
+          - unsafe-coerce
+      safely:
+        repo: https://github.com/paf31/purescript-safely.git
+        version: v4.0.1
+        dependencies:
+          - freet
+          - lists
+      selection-foldable:
+        repo: https://github.com/jamieyung/purescript-selection-foldable.git
+        version: v0.2.0
+        dependencies:
+          - filterable
+          - foldable-traversable
+          - maybe
+          - prelude
+      semirings:
+        repo: https://github.com/purescript/purescript-semirings.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - lists
+          - newtype
+          - prelude
+      signal:
+        repo: https://github.com/bodil/purescript-signal.git
+        version: v13.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - foldable-traversable
+          - maybe
+          - prelude
+      simple-emitter:
+        repo: https://github.com/oreshinya/purescript-simple-emitter.git
+        version: v2.0.0
+        dependencies:
+          - ordered-collections
+          - refs
+      sized-matrices:
+        repo: https://github.com/csicar/purescript-sized-matrices.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - distributive
+          - foldable-traversable
+          - maybe
+          - prelude
+          - sized-vectors
+          - strings
+          - typelevel
+          - unfoldable
+          - vectorfield
+      sized-vectors:
+        repo: https://github.com/bodil/purescript-sized-vectors.git
+        version: v5.0.2
+        dependencies:
+          - argonaut
+          - arrays
+          - distributive
+          - foldable-traversable
+          - maybe
+          - prelude
+          - quickcheck
+          - typelevel
+          - unfoldable
+      slug:
+        repo: https://github.com/thomashoneyman/purescript-slug.git
+        version: v3.0.1
+        dependencies:
+          - argonaut-codecs
+          - maybe
+          - prelude
+          - strings
+          - unicode
+      soundfonts:
+        repo: https://github.com/newlandsvalley/purescript-soundfonts.git
+        version: v4.1.0
+        dependencies:
+          - aff
+          - affjax
+          - affjax-web
+          - argonaut-core
+          - arraybuffer-types
+          - arrays
+          - b64
+          - bifunctors
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign-object
+          - http-methods
+          - integers
+          - lists
+          - maybe
+          - midi
+          - ordered-collections
+          - parallel
+          - partial
+          - prelude
+          - strings
+          - transformers
+          - tuples
+      sparse-matrices:
+        repo: https://github.com/Ebmtranceboy/purescript-sparse-matrices.git
+        version: v1.2.1
+        dependencies:
+          - console
+          - effect
+          - prelude
+          - sparse-polynomials
+      sparse-polynomials:
+        repo: https://github.com/Ebmtranceboy/purescript-sparse-polynomials.git
+        version: v1.0.5
+        dependencies:
+          - cartesian
+          - console
+          - effect
+          - ordered-collections
+          - prelude
+          - rationals
+          - tuples
+      spec:
+        repo: https://github.com/purescript-spec/purescript-spec.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - ansi
+          - avar
+          - console
+          - exceptions
+          - foldable-traversable
+          - fork
+          - now
+          - pipes
+          - prelude
+          - strings
+          - transformers
+      spec-discovery:
+        repo: https://github.com/purescript-spec/purescript-spec-discovery.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - aff-promise
+          - arrays
+          - console
+          - effect
+          - foldable-traversable
+          - node-fs
+          - prelude
+          - spec
+      spec-quickcheck:
+        repo: https://github.com/purescript-spec/purescript-spec-quickcheck.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - prelude
+          - quickcheck
+          - random
+          - spec
+      ssrs:
+        repo: https://github.com/PureFunctor/purescript-ssrs.git
+        version: v1.0.0
+        dependencies:
+          - dissect
+          - either
+          - fixed-points
+          - free
+          - lists
+          - prelude
+          - safe-coerce
+          - tailrec
+          - tuples
+          - variant
+      st:
+        repo: https://github.com/purescript/purescript-st.git
+        version: v6.0.0
+        dependencies:
+          - partial
+          - prelude
+          - tailrec
+          - unsafe-coerce
+      strictlypositiveint:
+        repo: https://github.com/jamieyung/purescript-strictlypositiveint.git
+        version: v1.0.1
+        dependencies:
+          - prelude
+      string-parsers:
+        repo: https://github.com/purescript-contrib/purescript-string-parsers.git
+        version: v8.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - prelude
+          - strings
+          - tailrec
+      strings:
+        repo: https://github.com/purescript/purescript-strings.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - enums
+          - foldable-traversable
+          - gen
+          - integers
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+          - unsafe-coerce
+      strings-extra:
+        repo: https://github.com/purescript-contrib/purescript-strings-extra.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - maybe
+          - prelude
+          - strings
+          - unicode
+      stringutils:
+        repo: https://github.com/menelaos/purescript-stringutils.git
+        version: v0.0.12
+        dependencies:
+          - arrays
+          - integers
+          - maybe
+          - partial
+          - prelude
+          - strings
+      substitute:
+        repo: https://github.com/ursi/purescript-substitute.git
+        version: v0.2.3
+        dependencies:
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - prelude
+          - return
+          - strings
+      supply:
+        repo: https://github.com/ajnsit/purescript-supply.git
+        version: v0.2.0
+        dependencies:
+          - console
+          - control
+          - effect
+          - lazy
+          - prelude
+          - refs
+          - tuples
+      tailrec:
+        repo: https://github.com/purescript/purescript-tailrec.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - effect
+          - either
+          - identity
+          - maybe
+          - partial
+          - prelude
+          - refs
+      test-unit:
+        repo: https://github.com/bodil/purescript-test-unit.git
+        version: v17.0.0
+        dependencies:
+          - aff
+          - avar
+          - effect
+          - either
+          - free
+          - js-timers
+          - lists
+          - prelude
+          - quickcheck
+          - strings
+      thermite:
+        repo: https://github.com/paf31/purescript-thermite.git
+        version: v6.3.1
+        dependencies:
+          - aff
+          - coroutines
+          - freet
+          - profunctor-lenses
+          - react
+      thermite-dom:
+        repo: https://github.com/athanclark/purescript-thermite-dom.git
+        version: v0.3.1
+        dependencies:
+          - react
+          - react-dom
+          - thermite
+          - web-html
+      these:
+        repo: https://github.com/purescript-contrib/purescript-these.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - gen
+          - lists
+          - quickcheck
+          - quickcheck-laws
+          - tuples
+      transformers:
+        repo: https://github.com/purescript/purescript-transformers.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - distributive
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - identity
+          - lazy
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      tree-rose:
+        repo: https://github.com/jordanmartinez/purescript-tree-rose.git
+        version: v4.0.2
+        dependencies:
+          - control
+          - foldable-traversable
+          - free
+          - lists
+          - maybe
+          - prelude
+          - tailrec
+      tuples:
+        repo: https://github.com/purescript/purescript-tuples.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - invariant
+          - prelude
+      two-or-more:
+        repo: https://github.com/i-am-the-slime/purescript-two-or-more.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - foldable-traversable
+          - maybe
+          - partial
+          - prelude
+          - psci-support
+          - tuples
+      type-equality:
+        repo: https://github.com/purescript/purescript-type-equality.git
+        version: v4.0.1
+        dependencies: []
+      typelevel:
+        repo: https://github.com/bodil/purescript-typelevel.git
+        version: v6.0.0
+        dependencies:
+          - partial
+          - prelude
+          - tuples
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-lists:
+        repo: https://github.com/PureFunctor/purescript-typelevel-lists.git
+        version: v2.1.0
+        dependencies:
+          - prelude
+          - tuples
+          - typelevel-peano
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-peano:
+        repo: https://github.com/csicar/purescript-typelevel-peano.git
+        version: v1.0.1
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - prelude
+          - psci-support
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-prelude:
+        repo: https://github.com/purescript/purescript-typelevel-prelude.git
+        version: v7.0.0
+        dependencies:
+          - prelude
+          - type-equality
+      typelevel-rows:
+        repo: https://github.com/jordanmartinez/purescript-typelevel-rows.git
+        version: v0.1.0
+        dependencies:
+          - prelude
+      uint:
+        repo: https://github.com/purescript-contrib/purescript-uint.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - enums
+          - gen
+          - maybe
+          - numbers
+          - prelude
+      uncurried-transformers:
+        repo: https://github.com/PureFunctor/purescript-uncurried-transformers.git
+        version: v1.1.0
+        dependencies:
+          - control
+          - effect
+          - either
+          - functions
+          - identity
+          - prelude
+          - safe-coerce
+          - tailrec
+          - transformers
+          - tuples
+      undefined-is-not-a-problem:
+        repo: https://github.com/paluh/purescript-undefined-is-not-a-problem.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - assert
+          - effect
+          - either
+          - foreign
+          - maybe
+          - newtype
+          - prelude
+          - random
+          - tuples
+          - type-equality
+          - unsafe-coerce
+      unfoldable:
+        repo: https://github.com/purescript/purescript-unfoldable.git
+        version: v6.0.0
+        dependencies:
+          - foldable-traversable
+          - maybe
+          - partial
+          - prelude
+          - tuples
+      unicode:
+        repo: https://github.com/purescript-contrib/purescript-unicode.git
+        version: v6.0.0
+        dependencies:
+          - foldable-traversable
+          - maybe
+          - strings
+      unlift:
+        repo: https://github.com/tweag/purescript-unlift.git
+        version: v1.0.1
+        dependencies:
+          - aff
+          - effect
+          - either
+          - freet
+          - identity
+          - lists
+          - maybe
+          - monad-control
+          - prelude
+          - st
+          - transformers
+          - tuples
+      unsafe-coerce:
+        repo: https://github.com/purescript/purescript-unsafe-coerce.git
+        version: v6.0.0
+        dependencies: []
+      unsafe-reference:
+        repo: https://github.com/purescript-contrib/purescript-unsafe-reference.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+      uri:
+        repo: https://github.com/purescript-contrib/purescript-uri.git
+        version: v9.0.0
+        dependencies:
+          - arrays
+          - integers
+          - js-uri
+          - numbers
+          - parsing
+          - prelude
+          - profunctor-lenses
+          - these
+          - transformers
+          - unfoldable
+      validation:
+        repo: https://github.com/purescript/purescript-validation.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - newtype
+          - prelude
+      variant:
+        repo: https://github.com/natefaubion/purescript-variant.git
+        version: v8.0.0
+        dependencies:
+          - enums
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - record
+          - tuples
+          - unsafe-coerce
+      vectorfield:
+        repo: https://github.com/csicar/purescript-vectorfield.git
+        version: v1.0.1
+        dependencies:
+          - console
+          - effect
+          - group
+          - prelude
+          - psci-support
+      versions:
+        repo: https://github.com/hdgarrood/purescript-versions.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - either
+          - foldable-traversable
+          - functions
+          - integers
+          - lists
+          - maybe
+          - orders
+          - parsing
+          - partial
+          - strings
+      web-clipboard:
+        repo: https://github.com/purescript-web/purescript-web-clipboard.git
+        version: v4.0.0
+        dependencies:
+          - web-html
+      web-cssom:
+        repo: https://github.com/purescript-web/purescript-web-cssom.git
+        version: v2.0.0
+        dependencies:
+          - web-dom
+          - web-html
+          - web-uievents
+      web-dom:
+        repo: https://github.com/purescript-web/purescript-web-dom.git
+        version: v6.0.0
+        dependencies:
+          - web-events
+      web-dom-parser:
+        repo: https://github.com/purescript-web/purescript-web-dom-parser.git
+        version: v8.0.0
+        dependencies:
+          - effect
+          - partial
+          - prelude
+          - web-dom
+      web-dom-xpath:
+        repo: https://github.com/purescript-web/purescript-web-dom-xpath.git
+        version: v3.0.0
+        dependencies:
+          - web-dom
+      web-encoding:
+        repo: https://github.com/purescript-web/purescript-web-encoding.git
+        version: v3.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - newtype
+          - prelude
+      web-events:
+        repo: https://github.com/purescript-web/purescript-web-events.git
+        version: v4.0.0
+        dependencies:
+          - datetime
+          - enums
+          - foreign
+          - nullable
+      web-fetch:
+        repo: https://github.com/purescript-web/purescript-web-fetch.git
+        version: v3.0.0
+        dependencies:
+          - effect
+          - foreign-object
+          - http-methods
+          - prelude
+          - record
+          - typelevel-prelude
+          - web-file
+          - web-promise
+          - web-streams
+      web-file:
+        repo: https://github.com/purescript-web/purescript-web-file.git
+        version: v4.0.0
+        dependencies:
+          - foreign
+          - media-types
+          - web-dom
+      web-html:
+        repo: https://github.com/purescript-web/purescript-web-html.git
+        version: v4.0.0
+        dependencies:
+          - js-date
+          - web-dom
+          - web-file
+          - web-storage
+      web-page-visibility:
+        repo: https://git.sr.ht/~toastal/purescript-web-page-visibility
+        version: v2.0.0
+        dependencies:
+          - effect
+          - enums
+          - exceptions
+          - maybe
+          - prelude
+          - strings
+          - web-events
+          - web-html
+      web-pointerevents:
+        repo: https://github.com/purescript-web/purescript-web-pointerevents.git
+        version: v1.0.0
+        dependencies:
+          - effect
+          - maybe
+          - prelude
+          - web-dom
+          - web-uievents
+      web-promise:
+        repo: https://github.com/purescript-web/purescript-web-promise.git
+        version: v3.0.0
+        dependencies:
+          - effect
+          - exceptions
+          - foldable-traversable
+          - functions
+          - maybe
+          - prelude
+      web-socket:
+        repo: https://github.com/purescript-web/purescript-web-socket.git
+        version: v4.0.0
+        dependencies:
+          - arraybuffer-types
+          - web-file
+      web-storage:
+        repo: https://github.com/purescript-web/purescript-web-storage.git
+        version: v5.0.0
+        dependencies:
+          - nullable
+          - web-events
+      web-streams:
+        repo: https://github.com/purescript-web/purescript-web-streams.git
+        version: v3.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - exceptions
+          - nullable
+          - prelude
+          - tuples
+          - web-promise
+      web-touchevents:
+        repo: https://github.com/purescript-web/purescript-web-touchevents.git
+        version: v4.0.0
+        dependencies:
+          - web-uievents
+      web-uievents:
+        repo: https://github.com/purescript-web/purescript-web-uievents.git
+        version: v4.0.0
+        dependencies:
+          - web-html
+      web-workers:
+        repo: https://github.com/gbagan/purescript-web-workers.git
+        version: v1.1.0
+        dependencies:
+          - effect
+          - foreign
+          - maybe
+          - prelude
+          - unsafe-coerce
+          - web-events
+      web-xhr:
+        repo: https://github.com/purescript-web/purescript-web-xhr.git
+        version: v5.0.0
+        dependencies:
+          - arraybuffer-types
+          - datetime
+          - http-methods
+          - web-dom
+          - web-file
+          - web-html
+      yoga-fetch:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-fetch.git
+        version: v1.0.1
+        dependencies:
+          - aff
+          - aff-promise
+          - arraybuffer-types
+          - effect
+          - foreign
+          - foreign-object
+          - newtype
+          - prelude
+          - typelevel-prelude
+          - unsafe-coerce
+      yoga-json:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-json.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - identity
+          - lists
+          - maybe
+          - nullable
+          - partial
+          - prelude
+          - record
+          - transformers
+          - typelevel-prelude
+          - variant
+      yoga-postgres:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-postgres.git
+        version: v6.0.0
+        dependencies:
+          - aff
+          - arrays
+          - datetime
+          - effect
+          - either
+          - enums
+          - foldable-traversable
+          - foreign
+          - integers
+          - maybe
+          - nullable
+          - prelude
+          - transformers
+          - unsafe-coerce
+  extra_packages: {}
+packages:
+  aff:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-aff.git
+    rev: 2d44d9f9d0d6a416a4103fba2fb39e5160f80e36
+    dependencies:
+      - datetime
+      - effect
+      - exceptions
+      - functions
+      - parallel
+      - transformers
+      - unsafe-coerce
+  arrays:
+    type: git
+    url: https://github.com/purescript/purescript-arrays.git
+    rev: d20bae2f76db6cf29b7b75e26e82b8a54c32295e
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - maybe
+      - nonempty
+      - partial
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  avar:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-avar.git
+    rev: d00f5784d9cc8f079babd62740f5c52b87e5caa5
+    dependencies:
+      - aff
+      - effect
+      - either
+      - exceptions
+      - functions
+      - maybe
+  bifunctors:
+    type: git
+    url: https://github.com/purescript/purescript-bifunctors.git
+    rev: 16ba2fb6dd7f05528ebd9e2f9ca3a068b325e5b3
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  catenable-lists:
+    type: git
+    url: https://github.com/purescript/purescript-catenable-lists.git
+    rev: 09abe1f4888bc00841ad2b59e56a9e7ce7ebd4ab
+    dependencies:
+      - control
+      - foldable-traversable
+      - lists
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  console:
+    type: git
+    url: https://github.com/purescript/purescript-console.git
+    rev: 3b83d7b792d03872afeea5e62b4f686ab0f09842
+    dependencies:
+      - effect
+      - prelude
+  const:
+    type: git
+    url: https://github.com/purescript/purescript-const.git
+    rev: ab9570cf2b6e67f7e441178211db1231cfd75c37
+    dependencies:
+      - invariant
+      - newtype
+      - prelude
+  contravariant:
+    type: git
+    url: https://github.com/purescript/purescript-contravariant.git
+    rev: 9ad3e105b8855bcc25f4e0893c784789d05a58de
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  control:
+    type: git
+    url: https://github.com/purescript/purescript-control.git
+    rev: a6033808790879a17b2729e73747a9ed3fb2264e
+    dependencies:
+      - newtype
+      - prelude
+  datetime:
+    type: git
+    url: https://github.com/purescript/purescript-datetime.git
+    rev: a6a0cf1b0324964ad1854bc3377ed8766ba90e6f
+    dependencies:
+      - bifunctors
+      - control
+      - either
+      - enums
+      - foldable-traversable
+      - functions
+      - gen
+      - integers
+      - lists
+      - maybe
+      - newtype
+      - numbers
+      - ordered-collections
+      - partial
+      - prelude
+      - tuples
+  distributive:
+    type: git
+    url: https://github.com/purescript/purescript-distributive.git
+    rev: 6005e513642e855ebf6f884d24a35c2803ca252a
+    dependencies:
+      - identity
+      - newtype
+      - prelude
+      - tuples
+      - type-equality
+  effect:
+    type: git
+    url: https://github.com/purescript/purescript-effect.git
+    rev: a192ddb923027d426d6ea3d8deb030c9aa7c7dda
+    dependencies:
+      - prelude
+  either:
+    type: git
+    url: https://github.com/purescript/purescript-either.git
+    rev: af655a04ed2fd694b6688af39ee20d7907ad0763
+    dependencies:
+      - control
+      - invariant
+      - maybe
+      - prelude
+  enums:
+    type: git
+    url: https://github.com/purescript/purescript-enums.git
+    rev: bae47961d401f9acf88da38f32e87403e5f0cf2f
+    dependencies:
+      - control
+      - either
+      - gen
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tuples
+      - unfoldable
+  exceptions:
+    type: git
+    url: https://github.com/purescript/purescript-exceptions.git
+    rev: afab3c07c820bb49b6c5be50049db46a964a6161
+    dependencies:
+      - effect
+      - either
+      - maybe
+      - prelude
+  exists:
+    type: git
+    url: https://github.com/purescript/purescript-exists.git
+    rev: f765b4ace7869c27b9c05949e18c843881f9173b
+    dependencies:
+      - unsafe-coerce
+  foldable-traversable:
+    type: git
+    url: https://github.com/purescript/purescript-foldable-traversable.git
+    rev: b3926f870532d287ea59e2d5cd3873b81ef2a93a
+    dependencies:
+      - bifunctors
+      - const
+      - control
+      - either
+      - functors
+      - identity
+      - maybe
+      - newtype
+      - orders
+      - prelude
+      - tuples
+  free:
+    type: git
+    url: https://github.com/purescript/purescript-free.git
+    rev: e2d8fa8023a864363857834e11393483bced5e38
+    dependencies:
+      - catenable-lists
+      - control
+      - distributive
+      - either
+      - exists
+      - foldable-traversable
+      - invariant
+      - lazy
+      - maybe
+      - prelude
+      - tailrec
+      - transformers
+      - tuples
+      - unsafe-coerce
+  functions:
+    type: git
+    url: https://github.com/purescript/purescript-functions.git
+    rev: f626f20580483977c5b27a01aac6471e28aff367
+    dependencies:
+      - prelude
+  functors:
+    type: git
+    url: https://github.com/purescript/purescript-functors.git
+    rev: 022ffd7a2a7ec12080314f3d217b400674a247b4
+    dependencies:
+      - bifunctors
+      - const
+      - contravariant
+      - control
+      - distributive
+      - either
+      - invariant
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - tuples
+      - unsafe-coerce
+  gen:
+    type: git
+    url: https://github.com/purescript/purescript-gen.git
+    rev: 9fbcc2a1261c32e30d79c5418edef4d96fe76931
+    dependencies:
+      - either
+      - foldable-traversable
+      - identity
+      - maybe
+      - newtype
+      - nonempty
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  identity:
+    type: git
+    url: https://github.com/purescript/purescript-identity.git
+    rev: ef6768f8a52ab0bc943a85f5761ba07c257f639f
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  integers:
+    type: git
+    url: https://github.com/purescript/purescript-integers.git
+    rev: 54d712b25c594833083d15dc9ff2418eb9c52822
+    dependencies:
+      - maybe
+      - numbers
+      - prelude
+  invariant:
+    type: git
+    url: https://github.com/purescript/purescript-invariant.git
+    rev: 1d2a196d51e90623adb88496c2cfd759c6736894
+    dependencies:
+      - control
+      - prelude
+  js-timers:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-js-timers.git
+    rev: 7cb728b3e6dc29f355143617e6e9ac770ecd9273
+    dependencies:
+      - effect
+  lazy:
+    type: git
+    url: https://github.com/purescript/purescript-lazy.git
+    rev: 48347841226b27af5205a1a8ec71e27a93ce86fd
+    dependencies:
+      - control
+      - foldable-traversable
+      - invariant
+      - prelude
+  lcg:
+    type: git
+    url: https://github.com/purescript/purescript-lcg.git
+    rev: 67c6c6483a563a59ae036d9dca0f1be2835326a5
+    dependencies:
+      - effect
+      - integers
+      - maybe
+      - partial
+      - prelude
+      - random
+  lists:
+    type: git
+    url: https://github.com/purescript/purescript-lists.git
+    rev: b113451e5b41cad87d669a3165f955c71cd863e2
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - lazy
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  maybe:
+    type: git
+    url: https://github.com/purescript/purescript-maybe.git
+    rev: c6f98ac1088766287106c5d9c8e30e7648d36786
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  newtype:
+    type: git
+    url: https://github.com/purescript/purescript-newtype.git
+    rev: 29d8e6dd77aec2c975c948364ec3faf26e14ee7b
+    dependencies:
+      - prelude
+      - safe-coerce
+  nonempty:
+    type: git
+    url: https://github.com/purescript/purescript-nonempty.git
+    rev: 28150ecc7419238b187abd609a92a645273348bb
+    dependencies:
+      - control
+      - foldable-traversable
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  numbers:
+    type: git
+    url: https://github.com/purescript/purescript-numbers.git
+    rev: 2a53528f18f9415334bae28e7bb3cf3be86342c2
+    dependencies:
+      - functions
+      - maybe
+  ordered-collections:
+    type: git
+    url: https://github.com/purescript/purescript-ordered-collections.git
+    rev: 9826b7632d0d0a691173bde308a634195f42a419
+    dependencies:
+      - arrays
+      - foldable-traversable
+      - gen
+      - lists
+      - maybe
+      - partial
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+  orders:
+    type: git
+    url: https://github.com/purescript/purescript-orders.git
+    rev: f86db621ec5eef1274145f8b1fd8ebbfe0ed4a2c
+    dependencies:
+      - newtype
+      - prelude
+  parallel:
+    type: git
+    url: https://github.com/purescript/purescript-parallel.git
+    rev: 85290dca837771ac4870071008c933d315ef678f
+    dependencies:
+      - control
+      - effect
+      - either
+      - foldable-traversable
+      - functors
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - refs
+      - transformers
+  partial:
+    type: git
+    url: https://github.com/purescript/purescript-partial.git
+    rev: 0fa0646f5ea1ec5f0c46dcbd770c705a6c9ad3ec
+    dependencies: []
+  prelude:
+    type: git
+    url: https://github.com/purescript/purescript-prelude.git
+    rev: 32787f4399c92459c41602131a5858559eb868c5
+    dependencies: []
+  profunctor:
+    type: git
+    url: https://github.com/purescript/purescript-profunctor.git
+    rev: 0a966a14e7b0c827d44657dc1710cdc712d2e034
+    dependencies:
+      - control
+      - distributive
+      - either
+      - exists
+      - invariant
+      - newtype
+      - prelude
+      - tuples
+  quickcheck:
+    type: git
+    url: https://github.com/purescript/purescript-quickcheck.git
+    rev: bf5029f97e6c0d7552d3a08d2ab793a19e2c5e3d
+    dependencies:
+      - arrays
+      - console
+      - control
+      - effect
+      - either
+      - enums
+      - exceptions
+      - foldable-traversable
+      - gen
+      - identity
+      - integers
+      - lazy
+      - lcg
+      - lists
+      - maybe
+      - newtype
+      - nonempty
+      - numbers
+      - partial
+      - prelude
+      - record
+      - st
+      - strings
+      - tailrec
+      - transformers
+      - tuples
+      - unfoldable
+  random:
+    type: git
+    url: https://github.com/purescript/purescript-random.git
+    rev: 9540bc965a9596da02fefd9949418bb19c92533a
+    dependencies:
+      - effect
+      - integers
+  record:
+    type: git
+    url: https://github.com/purescript/purescript-record.git
+    rev: c89cd1ada6b636692571fc374196b1c39c4c9f70
+    dependencies:
+      - functions
+      - prelude
+      - unsafe-coerce
+  refs:
+    type: git
+    url: https://github.com/purescript/purescript-refs.git
+    rev: f8e6216da4cb9309fde1f20cd6f69ac3a3b7f9e8
+    dependencies:
+      - effect
+      - prelude
+  safe-coerce:
+    type: git
+    url: https://github.com/purescript/purescript-safe-coerce.git
+    rev: 7fa799ae80a38b8d948efcb52608e58e198b3da7
+    dependencies:
+      - unsafe-coerce
+  st:
+    type: git
+    url: https://github.com/purescript/purescript-st.git
+    rev: 2cc7ae1c3318a303378c4a9f3fa0f10ee7cc3589
+    dependencies:
+      - partial
+      - prelude
+      - tailrec
+      - unsafe-coerce
+  strings:
+    type: git
+    url: https://github.com/purescript/purescript-strings.git
+    rev: 4bc6954448d056f8aa7a659695a6ad60ad4fdf19
+    dependencies:
+      - arrays
+      - control
+      - either
+      - enums
+      - foldable-traversable
+      - gen
+      - integers
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  tailrec:
+    type: git
+    url: https://github.com/purescript/purescript-tailrec.git
+    rev: 5e2104aa734b31a17074cc805bf087d72b65afd1
+    dependencies:
+      - bifunctors
+      - effect
+      - either
+      - identity
+      - maybe
+      - partial
+      - prelude
+      - refs
+  test-unit:
+    type: git
+    url: https://github.com/bodil/purescript-test-unit.git
+    rev: 3112d7ebe06d467238058a6384dc75ffd960d335
+    dependencies:
+      - aff
+      - avar
+      - effect
+      - either
+      - free
+      - js-timers
+      - lists
+      - prelude
+      - quickcheck
+      - strings
+  transformers:
+    type: git
+    url: https://github.com/purescript/purescript-transformers.git
+    rev: be72ab52357d9a665cbf93d73ba1c07c4b0957ee
+    dependencies:
+      - control
+      - distributive
+      - effect
+      - either
+      - exceptions
+      - foldable-traversable
+      - identity
+      - lazy
+      - maybe
+      - newtype
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  tuples:
+    type: git
+    url: https://github.com/purescript/purescript-tuples.git
+    rev: 4f52da2729b448c8564369378f1232d8d2dc1d8b
+    dependencies:
+      - control
+      - invariant
+      - prelude
+  type-equality:
+    type: git
+    url: https://github.com/purescript/purescript-type-equality.git
+    rev: 0525b7d39e0fbd81b4209518139fb8ab02695774
+    dependencies: []
+  unfoldable:
+    type: git
+    url: https://github.com/purescript/purescript-unfoldable.git
+    rev: 493dfe04ed590e20d8f69079df2f58486882748d
+    dependencies:
+      - foldable-traversable
+      - maybe
+      - partial
+      - prelude
+      - tuples
+  unsafe-coerce:
+    type: git
+    url: https://github.com/purescript/purescript-unsafe-coerce.git
+    rev: ab956f82e66e633f647fb3098e8ddd3ec58d689f
+    dependencies: []

--- a/exercises/chapter2/spago.yaml
+++ b/exercises/chapter2/spago.yaml
@@ -12,4 +12,4 @@ package:
 workspace:
   extraPackages: {}
   packageSet:
-    url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
+    registry: 10.0.0

--- a/exercises/chapter2/spago.yaml
+++ b/exercises/chapter2/spago.yaml
@@ -1,0 +1,15 @@
+package:
+  dependencies:
+    - console
+    - effect
+    - foldable-traversable
+    - integers
+    - lists
+    - numbers
+    - prelude
+    - test-unit
+  name: my-project
+workspace:
+  extraPackages: {}
+  packageSet:
+    url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json

--- a/exercises/chapter3/spago.lock
+++ b/exercises/chapter3/spago.lock
@@ -1,0 +1,4070 @@
+workspace:
+  packages:
+    my-project:
+      path: ./
+      dependencies:
+        - console
+        - control
+        - effect
+        - lists
+        - maybe
+        - prelude
+        - test-unit
+      test_dependencies: []
+      build_plan:
+        - aff
+        - arrays
+        - avar
+        - bifunctors
+        - catenable-lists
+        - console
+        - const
+        - contravariant
+        - control
+        - datetime
+        - distributive
+        - effect
+        - either
+        - enums
+        - exceptions
+        - exists
+        - foldable-traversable
+        - free
+        - functions
+        - functors
+        - gen
+        - identity
+        - integers
+        - invariant
+        - js-timers
+        - lazy
+        - lcg
+        - lists
+        - maybe
+        - newtype
+        - nonempty
+        - numbers
+        - ordered-collections
+        - orders
+        - parallel
+        - partial
+        - prelude
+        - profunctor
+        - quickcheck
+        - random
+        - record
+        - refs
+        - safe-coerce
+        - st
+        - strings
+        - tailrec
+        - test-unit
+        - transformers
+        - tuples
+        - type-equality
+        - unfoldable
+        - unsafe-coerce
+  package_set:
+    address:
+      url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
+    compiler: ">=0.15.0 <0.16.0"
+    content:
+      ace:
+        repo: https://github.com/purescript-contrib/purescript-ace.git
+        version: v9.0.0
+        dependencies:
+          - arrays
+          - effect
+          - foreign
+          - nullable
+          - prelude
+          - web-html
+          - web-uievents
+      aff:
+        repo: https://github.com/purescript-contrib/purescript-aff.git
+        version: v7.0.0
+        dependencies:
+          - datetime
+          - effect
+          - exceptions
+          - functions
+          - parallel
+          - transformers
+          - unsafe-coerce
+      aff-bus:
+        repo: https://github.com/purescript-contrib/purescript-aff-bus.git
+        version: v6.0.0
+        dependencies:
+          - aff
+          - avar
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - lists
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+      aff-coroutines:
+        repo: https://github.com/purescript-contrib/purescript-aff-coroutines.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - avar
+          - coroutines
+          - effect
+      aff-promise:
+        repo: https://github.com/nwolverson/purescript-aff-promise.git
+        version: v4.0.0
+        dependencies:
+          - aff
+          - foreign
+      aff-retry:
+        repo: https://github.com/Unisay/purescript-aff-retry.git
+        version: v2.0.0
+        dependencies:
+          - aff
+          - arrays
+          - datetime
+          - effect
+          - either
+          - exceptions
+          - integers
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - random
+          - transformers
+      affjax:
+        repo: https://github.com/purescript-contrib/purescript-affjax.git
+        version: v13.0.0
+        dependencies:
+          - aff
+          - argonaut-core
+          - arraybuffer-types
+          - foreign
+          - form-urlencoded
+          - http-methods
+          - integers
+          - media-types
+          - nullable
+          - refs
+          - unsafe-coerce
+          - web-xhr
+      affjax-node:
+        repo: https://github.com/purescript-contrib/purescript-affjax-node.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - affjax
+          - either
+          - maybe
+          - prelude
+      affjax-web:
+        repo: https://github.com/purescript-contrib/purescript-affjax-web.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - affjax
+          - either
+          - maybe
+          - prelude
+      ansi:
+        repo: https://github.com/hdgarrood/purescript-ansi.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - lists
+          - strings
+      argonaut:
+        repo: https://github.com/purescript-contrib/purescript-argonaut.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - argonaut-traversals
+      argonaut-codecs:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-codecs.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-core
+          - arrays
+          - effect
+          - foreign-object
+          - identity
+          - integers
+          - maybe
+          - nonempty
+          - ordered-collections
+          - prelude
+          - record
+      argonaut-core:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-core.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - foreign-object
+          - functions
+          - gen
+          - maybe
+          - nonempty
+          - prelude
+          - strings
+          - tailrec
+      argonaut-generic:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-generic.git
+        version: v8.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - prelude
+          - record
+      argonaut-traversals:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-traversals.git
+        version: v10.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - profunctor-lenses
+      argparse-basic:
+        repo: https://github.com/natefaubion/purescript-argparse-basic.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - record
+          - strings
+          - tuples
+          - unfoldable
+      arraybuffer:
+        repo: https://github.com/purescript-contrib/purescript-arraybuffer.git
+        version: v13.0.0
+        dependencies:
+          - arraybuffer-types
+          - arrays
+          - effect
+          - float32
+          - functions
+          - gen
+          - maybe
+          - nullable
+          - prelude
+          - tailrec
+          - uint
+          - unfoldable
+      arraybuffer-builder:
+        repo: https://github.com/jamesdbrock/purescript-arraybuffer-builder.git
+        version: v3.0.1
+        dependencies:
+          - arraybuffer
+          - arraybuffer-types
+          - effect
+          - float32
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - transformers
+          - uint
+      arraybuffer-types:
+        repo: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
+        version: v3.0.2
+        dependencies: []
+      arrays:
+        repo: https://github.com/purescript/purescript-arrays.git
+        version: v7.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - foldable-traversable
+          - maybe
+          - nonempty
+          - partial
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - unfoldable
+          - unsafe-coerce
+      arrays-zipper:
+        repo: https://github.com/JordanMartinez/purescript-arrays-zipper.git
+        version: v2.0.1
+        dependencies:
+          - arrays
+          - control
+          - quickcheck
+      ask:
+        repo: https://github.com/Mateiadrielrafael/purescript-ask.git
+        version: v1.0.0
+        dependencies:
+          - unsafe-coerce
+      assert:
+        repo: https://github.com/purescript/purescript-assert.git
+        version: v6.0.0
+        dependencies:
+          - console
+          - effect
+          - prelude
+      avar:
+        repo: https://github.com/purescript-contrib/purescript-avar.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - exceptions
+          - functions
+          - maybe
+      b64:
+        repo: https://github.com/menelaos/purescript-b64.git
+        version: v0.0.8
+        dependencies:
+          - arraybuffer-types
+          - either
+          - encoding
+          - enums
+          - exceptions
+          - functions
+          - partial
+          - prelude
+          - strings
+      barlow-lens:
+        repo: https://github.com/sigma-andex/purescript-barlow-lens.git
+        version: v0.9.0
+        dependencies:
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - profunctor-lenses
+          - tuples
+          - typelevel-prelude
+      bifunctors:
+        repo: https://github.com/purescript/purescript-bifunctors.git
+        version: v6.0.0
+        dependencies:
+          - const
+          - either
+          - newtype
+          - prelude
+          - tuples
+      bigints:
+        repo: https://github.com/sharkdp/purescript-bigints.git
+        version: v7.0.1
+        dependencies:
+          - integers
+          - maybe
+          - strings
+      bower-json:
+        repo: https://github.com/klntsky/purescript-bower-json.git
+        version: v3.0.0
+        dependencies:
+          - argonaut-codecs
+          - arrays
+          - either
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - newtype
+          - prelude
+          - tuples
+      call-by-name:
+        repo: https://github.com/natefaubion/purescript-call-by-name.git
+        version: v4.0.1
+        dependencies:
+          - control
+          - either
+          - lazy
+          - maybe
+          - unsafe-coerce
+      canvas:
+        repo: https://github.com/purescript-web/purescript-canvas.git
+        version: v6.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - exceptions
+          - functions
+          - maybe
+      canvas-action:
+        repo: https://github.com/artemisSystem/purescript-canvas-action.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - arrays
+          - canvas
+          - colors
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - maybe
+          - numbers
+          - polymorphic-vectors
+          - prelude
+          - refs
+          - run
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-html
+      cartesian:
+        repo: https://github.com/Ebmtranceboy/purescript-cartesian.git
+        version: v1.0.6
+        dependencies:
+          - console
+          - effect
+          - integers
+          - psci-support
+      catenable-lists:
+        repo: https://github.com/purescript/purescript-catenable-lists.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - lists
+          - maybe
+          - prelude
+          - tuples
+          - unfoldable
+      channel:
+        repo: https://github.com/ConnorDillon/purescript-channel.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - assert
+          - avar
+          - console
+          - contravariant
+          - control
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - lazy
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      checked-exceptions:
+        repo: https://github.com/natefaubion/purescript-checked-exceptions.git
+        version: v3.1.1
+        dependencies:
+          - prelude
+          - transformers
+          - variant
+      codec:
+        repo: https://github.com/garyb/purescript-codec.git
+        version: v5.0.0
+        dependencies:
+          - profunctor
+          - transformers
+      codec-argonaut:
+        repo: https://github.com/garyb/purescript-codec-argonaut.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-core
+          - codec
+          - ordered-collections
+          - type-equality
+          - variant
+      colors:
+        repo: https://github.com/purescript-contrib/purescript-colors.git
+        version: v7.0.1
+        dependencies:
+          - arrays
+          - integers
+          - lists
+          - numbers
+          - partial
+          - strings
+      concurrent-queues:
+        repo: https://github.com/purescript-contrib/purescript-concurrent-queues.git
+        version: v3.0.0
+        dependencies:
+          - aff
+          - avar
+          - effect
+      console:
+        repo: https://github.com/purescript/purescript-console.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - prelude
+      const:
+        repo: https://github.com/purescript/purescript-const.git
+        version: v6.0.0
+        dependencies:
+          - invariant
+          - newtype
+          - prelude
+      contravariant:
+        repo: https://github.com/purescript/purescript-contravariant.git
+        version: v6.0.0
+        dependencies:
+          - const
+          - either
+          - newtype
+          - prelude
+          - tuples
+      control:
+        repo: https://github.com/purescript/purescript-control.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      convertable-options:
+        repo: https://github.com/natefaubion/purescript-convertable-options.git
+        version: v1.0.0
+        dependencies:
+          - console
+          - effect
+          - maybe
+          - record
+      coroutines:
+        repo: https://github.com/purescript-contrib/purescript-coroutines.git
+        version: v7.0.0
+        dependencies:
+          - freet
+          - parallel
+          - profunctor
+      css:
+        repo: https://github.com/purescript-contrib/purescript-css.git
+        version: v6.0.0
+        dependencies:
+          - colors
+          - console
+          - effect
+          - nonempty
+          - profunctor
+          - strings
+          - these
+          - transformers
+      datetime:
+        repo: https://github.com/purescript/purescript-datetime.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - either
+          - enums
+          - foldable-traversable
+          - functions
+          - gen
+          - integers
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - ordered-collections
+          - partial
+          - prelude
+          - tuples
+      datetime-parsing:
+        repo: https://github.com/flounders/purescript-datetime-parsing.git
+        version: v0.2.0
+        dependencies:
+          - arrays
+          - datetime
+          - either
+          - enums
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - numbers
+          - parsing
+          - prelude
+          - strings
+          - unicode
+      debug:
+        repo: https://github.com/garyb/purescript-debug.git
+        version: v6.0.0
+        dependencies:
+          - functions
+          - prelude
+      decimals:
+        repo: https://github.com/sharkdp/purescript-decimals.git
+        version: v7.0.0
+        dependencies:
+          - maybe
+      dissect:
+        repo: https://github.com/PureFunctor/purescript-dissect.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - foreign-object
+          - functors
+          - newtype
+          - partial
+          - prelude
+          - tailrec
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - variant
+      distributive:
+        repo: https://github.com/purescript/purescript-distributive.git
+        version: v6.0.0
+        dependencies:
+          - identity
+          - newtype
+          - prelude
+          - tuples
+          - type-equality
+      dodo-printer:
+        repo: https://github.com/natefaubion/purescript-dodo-printer.git
+        version: v2.2.0
+        dependencies:
+          - aff
+          - ansi
+          - avar
+          - console
+          - effect
+          - foldable-traversable
+          - lists
+          - maybe
+          - minibench
+          - node-child-process
+          - node-fs-aff
+          - node-process
+          - psci-support
+          - strings
+      dom-indexed:
+        repo: https://github.com/purescript-halogen/purescript-dom-indexed.git
+        version: v11.0.0
+        dependencies:
+          - media-types
+          - prelude
+          - web-clipboard
+          - web-pointerevents
+          - web-touchevents
+      droplet:
+        repo: https://github.com/easafe/purescript-droplet.git
+        version: v0.4.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - bigints
+          - datetime
+          - debug
+          - effect
+          - either
+          - enums
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - integers
+          - maybe
+          - newtype
+          - nullable
+          - ordered-collections
+          - partial
+          - prelude
+          - profunctor
+          - record
+          - spec
+          - strings
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+      dynamic-buffer:
+        repo: https://github.com/kritzcreek/purescript-dynamic-buffer.git
+        version: v3.0.1
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - refs
+      effect:
+        repo: https://github.com/purescript/purescript-effect.git
+        version: v4.0.0
+        dependencies:
+          - prelude
+      either:
+        repo: https://github.com/purescript/purescript-either.git
+        version: v6.1.0
+        dependencies:
+          - control
+          - invariant
+          - maybe
+          - prelude
+      elmish:
+        repo: https://github.com/collegevine/purescript-elmish.git
+        version: v0.8.1
+        dependencies:
+          - aff
+          - argonaut-core
+          - arrays
+          - bifunctors
+          - console
+          - debug
+          - effect
+          - either
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - functions
+          - integers
+          - js-date
+          - maybe
+          - nullable
+          - partial
+          - prelude
+          - refs
+          - typelevel-prelude
+          - undefined-is-not-a-problem
+          - unsafe-coerce
+          - web-dom
+          - web-html
+      elmish-enzyme:
+        repo: https://github.com/collegevine/purescript-elmish-enzyme.git
+        version: v0.1.1
+        dependencies:
+          - aff
+          - aff-promise
+          - arrays
+          - console
+          - debug
+          - effect
+          - elmish
+          - foldable-traversable
+          - foreign
+          - functions
+          - prelude
+          - transformers
+          - unsafe-coerce
+      elmish-hooks:
+        repo: https://github.com/collegevine/purescript-elmish-hooks.git
+        version: v0.8.2
+        dependencies:
+          - aff
+          - debug
+          - elmish
+          - maybe
+          - prelude
+          - tuples
+          - undefined-is-not-a-problem
+      elmish-html:
+        repo: https://github.com/collegevine/purescript-elmish-html.git
+        version: v0.7.1
+        dependencies:
+          - effect
+          - elmish
+          - foreign
+          - foreign-object
+          - prelude
+          - record
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-html
+      email-validate:
+        repo: https://github.com/cdepillabout/purescript-email-validate.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - string-parsers
+          - transformers
+      encoding:
+        repo: https://github.com/menelaos/purescript-encoding.git
+        version: v0.0.8
+        dependencies:
+          - arraybuffer-types
+          - either
+          - exceptions
+          - functions
+          - prelude
+      enums:
+        repo: https://github.com/purescript/purescript-enums.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - either
+          - gen
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tuples
+          - unfoldable
+      exceptions:
+        repo: https://github.com/purescript/purescript-exceptions.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - either
+          - maybe
+          - prelude
+      exists:
+        repo: https://github.com/purescript/purescript-exists.git
+        version: v6.0.0
+        dependencies:
+          - unsafe-coerce
+      exitcodes:
+        repo: https://github.com/Risto-Stevcev/purescript-exitcodes.git
+        version: v4.0.0
+        dependencies:
+          - enums
+      expect-inferred:
+        repo: https://github.com/justinwoo/purescript-expect-inferred.git
+        version: v3.0.0
+        dependencies:
+          - prelude
+          - typelevel-prelude
+      fast-vect:
+        repo: https://github.com/sigma-andex/purescript-fast-vect.git
+        version: v0.7.0
+        dependencies:
+          - arrays
+          - filterable
+          - foldable-traversable
+          - lists
+          - maybe
+          - ordered-collections
+          - prelude
+          - profunctor
+          - tuples
+          - unfoldable
+      filterable:
+        repo: https://github.com/purescript/purescript-filterable.git
+        version: v5.0.0
+        dependencies:
+          - arrays
+          - either
+          - foldable-traversable
+          - identity
+          - lists
+          - ordered-collections
+      fixed-points:
+        repo: https://github.com/purescript-contrib/purescript-fixed-points.git
+        version: v7.0.0
+        dependencies:
+          - exists
+          - newtype
+          - prelude
+          - transformers
+      fixed-precision:
+        repo: https://github.com/lumihq/purescript-fixed-precision.git
+        version: v5.0.0
+        dependencies:
+          - arrays
+          - bigints
+          - control
+          - integers
+          - maybe
+          - numbers
+          - partial
+          - prelude
+          - strings
+      flame:
+        repo: https://github.com/easafe/purescript-flame.git
+        version: v1.2.0
+        dependencies:
+          - aff
+          - argonaut-codecs
+          - argonaut-core
+          - argonaut-generic
+          - arrays
+          - bifunctors
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - maybe
+          - newtype
+          - nullable
+          - partial
+          - prelude
+          - random
+          - refs
+          - spec
+          - strings
+          - tuples
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-html
+          - web-uievents
+      float32:
+        repo: https://github.com/purescript-contrib/purescript-float32.git
+        version: v2.0.0
+        dependencies:
+          - gen
+          - maybe
+          - prelude
+      foldable-traversable:
+        repo: https://github.com/purescript/purescript-foldable-traversable.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - const
+          - control
+          - either
+          - functors
+          - identity
+          - maybe
+          - newtype
+          - orders
+          - prelude
+          - tuples
+      foreign:
+        repo: https://github.com/purescript/purescript-foreign.git
+        version: v7.0.0
+        dependencies:
+          - either
+          - functions
+          - identity
+          - integers
+          - lists
+          - maybe
+          - prelude
+          - strings
+          - transformers
+      foreign-object:
+        repo: https://github.com/purescript/purescript-foreign-object.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - functions
+          - gen
+          - lists
+          - maybe
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - typelevel-prelude
+          - unfoldable
+      foreign-readwrite:
+        repo: https://github.com/artemisSystem/purescript-foreign-readwrite.git
+        version: v3.0.0
+        dependencies:
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - record
+          - safe-coerce
+          - transformers
+          - unsafe-coerce
+      fork:
+        repo: https://github.com/purescript-contrib/purescript-fork.git
+        version: v6.0.0
+        dependencies:
+          - aff
+      form-urlencoded:
+        repo: https://github.com/purescript-contrib/purescript-form-urlencoded.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - js-uri
+          - maybe
+          - newtype
+          - prelude
+          - strings
+          - tuples
+      formatters:
+        repo: https://github.com/purescript-contrib/purescript-formatters.git
+        version: v7.0.0
+        dependencies:
+          - datetime
+          - fixed-points
+          - lists
+          - numbers
+          - parsing
+          - prelude
+          - transformers
+      free:
+        repo: https://github.com/purescript/purescript-free.git
+        version: v7.0.0
+        dependencies:
+          - catenable-lists
+          - control
+          - distributive
+          - either
+          - exists
+          - foldable-traversable
+          - invariant
+          - lazy
+          - maybe
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+      freeap:
+        repo: https://github.com/ethul/purescript-freeap.git
+        version: v7.0.0
+        dependencies:
+          - const
+          - exists
+          - gen
+          - lists
+      freet:
+        repo: https://github.com/purescript-contrib/purescript-freet.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - bifunctors
+          - effect
+          - either
+          - exists
+          - free
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      functions:
+        repo: https://github.com/purescript/purescript-functions.git
+        version: v6.0.0
+        dependencies:
+          - prelude
+      functors:
+        repo: https://github.com/purescript/purescript-functors.git
+        version: v5.0.0
+        dependencies:
+          - bifunctors
+          - const
+          - contravariant
+          - control
+          - distributive
+          - either
+          - invariant
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - tuples
+          - unsafe-coerce
+      fuzzy:
+        repo: https://github.com/citizennet/purescript-fuzzy.git
+        version: v0.4.0
+        dependencies:
+          - foldable-traversable
+          - foreign-object
+          - newtype
+          - ordered-collections
+          - prelude
+          - rationals
+          - strings
+          - tuples
+      gen:
+        repo: https://github.com/purescript/purescript-gen.git
+        version: v4.0.0
+        dependencies:
+          - either
+          - foldable-traversable
+          - identity
+          - maybe
+          - newtype
+          - nonempty
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      generate-values:
+        repo: https://github.com/jordanmartinez/purescript-generate-values.git
+        version: v1.0.1
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - enums
+          - foldable-traversable
+          - gen
+          - identity
+          - integers
+          - lcg
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - partial
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      geometry-plane:
+        repo: https://github.com/Ebmtranceboy/purescript-geometry-plane.git
+        version: v1.0.3
+        dependencies:
+          - console
+          - effect
+          - psci-support
+          - sparse-polynomials
+      github-actions-toolkit:
+        repo: https://github.com/purescript-contrib/purescript-github-actions-toolkit.git
+        version: v0.5.0
+        dependencies:
+          - aff
+          - aff-promise
+          - effect
+          - foreign-object
+          - node-buffer
+          - node-path
+          - node-streams
+          - nullable
+          - transformers
+      graphs:
+        repo: https://github.com/purescript/purescript-graphs.git
+        version: v8.0.0
+        dependencies:
+          - catenable-lists
+          - ordered-collections
+      group:
+        repo: https://github.com/morganthomas/purescript-group.git
+        version: v4.1.1
+        dependencies:
+          - lists
+      halogen:
+        repo: https://github.com/purescript-halogen/purescript-halogen.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - avar
+          - console
+          - const
+          - dom-indexed
+          - effect
+          - foreign
+          - fork
+          - free
+          - freeap
+          - halogen-subscriptions
+          - halogen-vdom
+          - media-types
+          - nullable
+          - ordered-collections
+          - parallel
+          - profunctor
+          - transformers
+          - unsafe-coerce
+          - unsafe-reference
+          - web-file
+          - web-uievents
+      halogen-css:
+        repo: https://github.com/purescript-halogen/purescript-halogen-css.git
+        version: v10.0.0
+        dependencies:
+          - css
+          - halogen
+      halogen-formless:
+        repo: https://github.com/thomashoneyman/purescript-halogen-formless.git
+        version: v4.0.0
+        dependencies:
+          - convertable-options
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - halogen
+          - heterogeneous
+          - maybe
+          - prelude
+          - record
+          - safe-coerce
+          - type-equality
+          - unsafe-coerce
+          - unsafe-reference
+          - variant
+          - web-events
+          - web-uievents
+      halogen-hooks:
+        repo: https://github.com/thomashoneyman/purescript-halogen-hooks.git
+        version: v0.6.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - effect
+          - exceptions
+          - foldable-traversable
+          - foreign-object
+          - free
+          - freeap
+          - halogen
+          - halogen-subscriptions
+          - maybe
+          - newtype
+          - ordered-collections
+          - parallel
+          - partial
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+          - unsafe-reference
+          - web-dom
+          - web-html
+      halogen-hooks-extra:
+        repo: https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git
+        version: v0.9.0
+        dependencies:
+          - halogen-hooks
+      halogen-store:
+        repo: https://github.com/thomashoneyman/purescript-halogen-store.git
+        version: v0.5.0
+        dependencies:
+          - aff
+          - distributive
+          - effect
+          - fork
+          - halogen
+          - halogen-hooks
+          - halogen-subscriptions
+          - maybe
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-reference
+      halogen-storybook:
+        repo: https://github.com/rnons/purescript-halogen-storybook.git
+        version: v2.0.0
+        dependencies:
+          - foreign-object
+          - halogen
+          - prelude
+          - routing
+      halogen-subscriptions:
+        repo: https://github.com/purescript-halogen/purescript-halogen-subscriptions.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - effect
+          - foldable-traversable
+          - functors
+          - refs
+          - safe-coerce
+          - unsafe-reference
+      halogen-svg-elems:
+        repo: https://github.com/JordanMartinez/purescript-halogen-svg-elems.git
+        version: v6.0.0
+        dependencies:
+          - halogen
+      halogen-vdom:
+        repo: https://github.com/purescript-halogen/purescript-halogen-vdom.git
+        version: v8.0.0
+        dependencies:
+          - bifunctors
+          - effect
+          - foreign
+          - foreign-object
+          - maybe
+          - prelude
+          - refs
+          - tuples
+          - unsafe-coerce
+          - web-html
+      halogen-vdom-string-renderer:
+        repo: https://github.com/purescript-halogen/purescript-halogen-vdom-string-renderer.git
+        version: v0.5.0
+        dependencies:
+          - foreign
+          - halogen-vdom
+          - ordered-collections
+          - prelude
+      heckin:
+        repo: https://github.com/maxdeviant/purescript-heckin.git
+        version: v2.0.1
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - maybe
+          - prelude
+          - strings
+          - transformers
+          - tuples
+          - unicode
+      heterogeneous:
+        repo: https://github.com/natefaubion/purescript-heterogeneous.git
+        version: v0.6.0
+        dependencies:
+          - either
+          - functors
+          - prelude
+          - record
+          - tuples
+          - variant
+      heterogeneous-extrablatt:
+        repo: https://github.com/sigma-andex/purescript-heterogeneous-extrablatt.git
+        version: v0.2.1
+        dependencies:
+          - heterogeneous
+          - prelude
+          - record
+      http-methods:
+        repo: https://github.com/purescript-contrib/purescript-http-methods.git
+        version: v6.0.0
+        dependencies:
+          - either
+          - prelude
+          - strings
+      httpure:
+        repo: https://github.com/citizennet/purescript-httpure.git
+        version: v0.15.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - js-uri
+          - maybe
+          - newtype
+          - node-buffer
+          - node-fs
+          - node-http
+          - node-streams
+          - options
+          - ordered-collections
+          - prelude
+          - refs
+          - strings
+          - tuples
+          - type-equality
+      httpurple:
+        repo: https://github.com/sigma-andex/purescript-httpurple.git
+        version: v1.3.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - js-uri
+          - justifill
+          - maybe
+          - newtype
+          - node-buffer
+          - node-fs
+          - node-http
+          - node-net
+          - node-process
+          - node-streams
+          - options
+          - ordered-collections
+          - posix-types
+          - prelude
+          - profunctor
+          - record
+          - refs
+          - routing-duplex
+          - strings
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+      httpurple-argonaut:
+        repo: https://github.com/sigma-andex/purescript-httpurple-argonaut.git
+        version: v1.0.1
+        dependencies:
+          - argonaut
+          - console
+          - effect
+          - either
+          - httpurple
+          - prelude
+      httpurple-yoga-json:
+        repo: https://github.com/sigma-andex/purescript-httpurple-yoga-json.git
+        version: v1.0.0
+        dependencies:
+          - console
+          - effect
+          - either
+          - foreign
+          - httpurple
+          - lists
+          - prelude
+          - yoga-json
+      identity:
+        repo: https://github.com/purescript/purescript-identity.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - invariant
+          - newtype
+          - prelude
+      indexed-monad:
+        repo: https://github.com/garyb/purescript-indexed-monad.git
+        version: v2.1.0
+        dependencies:
+          - control
+          - newtype
+      int64:
+        repo: https://github.com/purescript-contrib/purescript-int64.git
+        version: v2.0.0
+        dependencies:
+          - effect
+          - foreign
+          - functions
+          - integers
+          - maybe
+          - nullable
+          - prelude
+          - quickcheck
+      integers:
+        repo: https://github.com/purescript/purescript-integers.git
+        version: v6.0.0
+        dependencies:
+          - maybe
+          - numbers
+          - prelude
+      interpolate:
+        repo: https://github.com/jordanmartinez/purescript-interpolate.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+      invariant:
+        repo: https://github.com/purescript/purescript-invariant.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - prelude
+      js-date:
+        repo: https://github.com/purescript-contrib/purescript-js-date.git
+        version: v8.0.0
+        dependencies:
+          - datetime
+          - effect
+          - exceptions
+          - foreign
+          - integers
+          - now
+      js-fileio:
+        repo: https://github.com/newlandsvalley/purescript-js-fileio.git
+        version: v3.0.0
+        dependencies:
+          - aff
+          - effect
+          - prelude
+      js-timers:
+        repo: https://github.com/purescript-contrib/purescript-js-timers.git
+        version: v6.1.0
+        dependencies:
+          - effect
+      js-uri:
+        repo: https://github.com/purescript-contrib/purescript-js-uri.git
+        version: v3.0.0
+        dependencies:
+          - functions
+          - maybe
+      justifill:
+        repo: https://github.com/i-am-the-slime/purescript-justifill.git
+        version: v0.5.0
+        dependencies:
+          - maybe
+          - prelude
+          - record
+          - typelevel-prelude
+      jwt:
+        repo: https://github.com/menelaos/purescript-jwt.git
+        version: v0.0.9
+        dependencies:
+          - argonaut-core
+          - arrays
+          - b64
+          - either
+          - exceptions
+          - prelude
+          - profunctor-lenses
+          - strings
+      language-cst-parser:
+        repo: https://github.com/natefaubion/purescript-language-cst-parser.git
+        version: v0.12.0
+        dependencies:
+          - arrays
+          - const
+          - control
+          - either
+          - foldable-traversable
+          - free
+          - functions
+          - functors
+          - identity
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - ordered-collections
+          - partial
+          - prelude
+          - st
+          - strings
+          - transformers
+          - tuples
+          - typelevel-prelude
+          - unfoldable
+          - unsafe-coerce
+      lazy:
+        repo: https://github.com/purescript/purescript-lazy.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - invariant
+          - prelude
+      lcg:
+        repo: https://github.com/purescript/purescript-lcg.git
+        version: v4.0.0
+        dependencies:
+          - effect
+          - integers
+          - maybe
+          - partial
+          - prelude
+          - random
+      leibniz:
+        repo: https://github.com/paf31/purescript-leibniz.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+          - unsafe-coerce
+      linalg:
+        repo: https://github.com/gbagan/purescript-linalg.git
+        version: v5.1.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - functions
+          - maybe
+          - prelude
+          - tuples
+      lists:
+        repo: https://github.com/purescript/purescript-lists.git
+        version: v7.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - foldable-traversable
+          - lazy
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      logging:
+        repo: https://github.com/rightfold/purescript-logging.git
+        version: v3.0.0
+        dependencies:
+          - console
+          - contravariant
+          - effect
+          - either
+          - prelude
+          - transformers
+          - tuples
+      machines:
+        repo: https://github.com/purescript-contrib/purescript-machines.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - lists
+          - maybe
+          - prelude
+          - profunctor
+          - tuples
+          - unfoldable
+      matrices:
+        repo: https://github.com/kRITZCREEK/purescript-matrices.git
+        version: v5.0.1
+        dependencies:
+          - arrays
+          - strings
+      matryoshka:
+        repo: https://github.com/purescript-contrib/purescript-matryoshka.git
+        version: v1.0.0
+        dependencies:
+          - fixed-points
+          - free
+          - prelude
+          - profunctor
+          - transformers
+      maybe:
+        repo: https://github.com/purescript/purescript-maybe.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - invariant
+          - newtype
+          - prelude
+      media-types:
+        repo: https://github.com/purescript-contrib/purescript-media-types.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      metadata:
+        repo: https://github.com/purescript/purescript-metadata.git
+        version: v0.15.0
+        dependencies: []
+      midi:
+        repo: https://github.com/newlandsvalley/purescript-midi.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - ordered-collections
+          - prelude
+          - signal
+          - string-parsers
+          - strings
+          - tuples
+          - unfoldable
+      minibench:
+        repo: https://github.com/purescript/purescript-minibench.git
+        version: v4.0.0
+        dependencies:
+          - console
+          - effect
+          - integers
+          - numbers
+          - partial
+          - prelude
+          - refs
+      mmorph:
+        repo: https://github.com/Thimoteus/purescript-mmorph.git
+        version: v7.0.0
+        dependencies:
+          - free
+          - functors
+          - transformers
+      monad-control:
+        repo: https://github.com/athanclark/purescript-monad-control.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - freet
+          - identity
+          - lists
+      monad-logger:
+        repo: https://github.com/cprussin/purescript-monad-logger.git
+        version: v1.3.1
+        dependencies:
+          - aff
+          - ansi
+          - argonaut
+          - arrays
+          - console
+          - control
+          - effect
+          - foldable-traversable
+          - foreign-object
+          - integers
+          - js-date
+          - maybe
+          - newtype
+          - ordered-collections
+          - prelude
+          - strings
+          - transformers
+          - tuples
+      monad-loops:
+        repo: https://github.com/mlang/purescript-monad-loops.git
+        version: v0.5.0
+        dependencies:
+          - lists
+          - maybe
+          - prelude
+          - tailrec
+          - tuples
+      monad-unlift:
+        repo: https://github.com/athanclark/purescript-monad-unlift.git
+        version: v1.0.1
+        dependencies:
+          - monad-control
+      monoidal:
+        repo: https://github.com/mcneissue/purescript-monoidal.git
+        version: v0.16.0
+        dependencies:
+          - either
+          - profunctor
+          - these
+          - tuples
+      morello:
+        repo: https://github.com/sigma-andex/purescript-morello.git
+        version: v0.3.2
+        dependencies:
+          - arrays
+          - barlow-lens
+          - foldable-traversable
+          - heterogeneous
+          - heterogeneous-extrablatt
+          - newtype
+          - prelude
+          - profunctor
+          - profunctor-lenses
+          - record
+          - tuples
+          - typelevel-prelude
+          - validation
+      motsunabe:
+        repo: https://github.com/justinwoo/purescript-motsunabe.git
+        version: v2.0.0
+        dependencies:
+          - lists
+          - strings
+      nano-id:
+        repo: https://github.com/eikooc/nano-id.git
+        version: v1.1.0
+        dependencies:
+          - aff
+          - effect
+          - lists
+          - maybe
+          - prelude
+          - random
+          - spec
+          - strings
+          - stringutils
+      naturals:
+        repo: https://github.com/LiamGoodacre/purescript-naturals.git
+        version: v3.0.0
+        dependencies:
+          - enums
+          - maybe
+          - prelude
+      nested-functor:
+        repo: https://github.com/acple/purescript-nested-functor.git
+        version: v0.2.1
+        dependencies:
+          - prelude
+          - type-equality
+      newtype:
+        repo: https://github.com/purescript/purescript-newtype.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+          - safe-coerce
+      node-buffer:
+        repo: https://github.com/purescript-node/purescript-node-buffer.git
+        version: v8.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - maybe
+          - st
+          - unsafe-coerce
+      node-buffer-blob:
+        repo: https://github.com/purescript-node/purescript-node-buffer-blob.git
+        version: v1.0.0
+        dependencies:
+          - aff-promise
+          - arraybuffer-types
+          - arrays
+          - console
+          - effect
+          - maybe
+          - media-types
+          - newtype
+          - node-buffer
+          - nullable
+          - prelude
+          - web-streams
+      node-child-process:
+        repo: https://github.com/purescript-node/purescript-node-child-process.git
+        version: v9.0.0
+        dependencies:
+          - exceptions
+          - foreign
+          - foreign-object
+          - functions
+          - node-fs
+          - node-streams
+          - nullable
+          - posix-types
+          - unsafe-coerce
+      node-fs:
+        repo: https://github.com/purescript-node/purescript-node-fs.git
+        version: v8.0.0
+        dependencies:
+          - datetime
+          - effect
+          - either
+          - enums
+          - exceptions
+          - functions
+          - integers
+          - js-date
+          - maybe
+          - node-buffer
+          - node-path
+          - node-streams
+          - nullable
+          - partial
+          - prelude
+          - strings
+          - unsafe-coerce
+      node-fs-aff:
+        repo: https://github.com/purescript-node/purescript-node-fs-aff.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - either
+          - node-fs
+          - node-path
+      node-http:
+        repo: https://github.com/purescript-node/purescript-node-http.git
+        version: v8.0.0
+        dependencies:
+          - arraybuffer-types
+          - contravariant
+          - effect
+          - foreign
+          - foreign-object
+          - maybe
+          - node-buffer
+          - node-net
+          - node-streams
+          - node-url
+          - nullable
+          - options
+          - prelude
+          - unsafe-coerce
+      node-net:
+        repo: https://github.com/purescript-node/purescript-node-net.git
+        version: v4.0.0
+        dependencies:
+          - effect
+          - either
+          - exceptions
+          - foreign
+          - maybe
+          - node-buffer
+          - node-fs
+          - nullable
+          - options
+          - prelude
+          - transformers
+      node-path:
+        repo: https://github.com/purescript-node/purescript-node-path.git
+        version: v5.0.0
+        dependencies:
+          - effect
+      node-process:
+        repo: https://github.com/purescript-node/purescript-node-process.git
+        version: v10.0.0
+        dependencies:
+          - effect
+          - foreign-object
+          - maybe
+          - node-streams
+          - posix-types
+          - prelude
+          - unsafe-coerce
+      node-readline:
+        repo: https://github.com/purescript-node/purescript-node-readline.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - foreign
+          - node-process
+          - node-streams
+          - options
+          - prelude
+      node-streams:
+        repo: https://github.com/purescript-node/purescript-node-streams.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - either
+          - exceptions
+          - node-buffer
+          - nullable
+          - prelude
+      node-streams-aff:
+        repo: https://github.com/jamesdbrock/purescript-node-streams-aff.git
+        version: v2.0.0
+        dependencies:
+          - aff
+          - arrays
+          - effect
+          - either
+          - exceptions
+          - maybe
+          - node-buffer
+          - node-streams
+          - prelude
+          - st
+          - tuples
+      node-url:
+        repo: https://github.com/purescript-node/purescript-node-url.git
+        version: v6.0.0
+        dependencies:
+          - nullable
+      nonempty:
+        repo: https://github.com/purescript/purescript-nonempty.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - maybe
+          - prelude
+          - tuples
+          - unfoldable
+      now:
+        repo: https://github.com/purescript-contrib/purescript-now.git
+        version: v6.0.0
+        dependencies:
+          - datetime
+          - effect
+      npm-package-json:
+        repo: https://github.com/maxdeviant/purescript-npm-package-json.git
+        version: v2.0.0
+        dependencies:
+          - argonaut
+          - control
+          - either
+          - foreign-object
+          - maybe
+          - ordered-collections
+          - prelude
+      nullable:
+        repo: https://github.com/purescript-contrib/purescript-nullable.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - functions
+          - maybe
+      numbers:
+        repo: https://github.com/purescript/purescript-numbers.git
+        version: v9.0.0
+        dependencies:
+          - functions
+          - maybe
+      open-folds:
+        repo: https://github.com/purescript-open-community/purescript-open-folds.git
+        version: v6.3.0
+        dependencies:
+          - bifunctors
+          - console
+          - control
+          - distributive
+          - effect
+          - either
+          - foldable-traversable
+          - identity
+          - invariant
+          - maybe
+          - newtype
+          - ordered-collections
+          - prelude
+          - profunctor
+          - psci-support
+          - tuples
+      open-memoize:
+        repo: https://github.com/purescript-open-community/purescript-open-memoize.git
+        version: v6.1.0
+        dependencies:
+          - console
+          - effect
+          - either
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - psci-support
+          - strings
+          - tuples
+      open-pairing:
+        repo: https://github.com/purescript-open-community/purescript-open-pairing.git
+        version: v6.1.0
+        dependencies:
+          - console
+          - control
+          - effect
+          - either
+          - free
+          - functors
+          - identity
+          - newtype
+          - prelude
+          - psci-support
+          - transformers
+          - tuples
+      options:
+        repo: https://github.com/purescript-contrib/purescript-options.git
+        version: v7.0.0
+        dependencies:
+          - contravariant
+          - foreign
+          - foreign-object
+          - maybe
+          - tuples
+      optparse:
+        repo: https://github.com/f-o-a-m/purescript-optparse.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - control
+          - effect
+          - either
+          - enums
+          - exists
+          - exitcodes
+          - foldable-traversable
+          - free
+          - gen
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - newtype
+          - node-buffer
+          - node-process
+          - node-streams
+          - nonempty
+          - numbers
+          - open-memoize
+          - partial
+          - prelude
+          - quickcheck
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+      ordered-collections:
+        repo: https://github.com/purescript/purescript-ordered-collections.git
+        version: v3.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - gen
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - unfoldable
+      ordered-set:
+        repo: https://github.com/flip111/purescript-ordered-set.git
+        version: v0.4.0
+        dependencies:
+          - argonaut-codecs
+          - arrays
+          - partial
+          - prelude
+          - unfoldable
+      orders:
+        repo: https://github.com/purescript/purescript-orders.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      pairs:
+        repo: https://github.com/sharkdp/purescript-pairs.git
+        version: v9.0.0
+        dependencies:
+          - console
+          - distributive
+          - foldable-traversable
+          - quickcheck
+      parallel:
+        repo: https://github.com/purescript/purescript-parallel.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - functors
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - refs
+          - transformers
+      parsing:
+        repo: https://github.com/purescript-contrib/purescript-parsing.git
+        version: v9.1.0
+        dependencies:
+          - arrays
+          - either
+          - foldable-traversable
+          - identity
+          - integers
+          - lists
+          - maybe
+          - nullable
+          - prelude
+          - strings
+          - transformers
+          - unicode
+      parsing-dataview:
+        repo: https://github.com/jamesdbrock/purescript-parsing-dataview.git
+        version: v3.1.0
+        dependencies:
+          - arraybuffer
+          - arraybuffer-types
+          - effect
+          - float32
+          - maybe
+          - parsing
+          - prelude
+          - transformers
+          - tuples
+          - uint
+      partial:
+        repo: https://github.com/purescript/purescript-partial.git
+        version: v4.0.0
+        dependencies: []
+      pathy:
+        repo: https://github.com/purescript-contrib/purescript-pathy.git
+        version: v9.0.0
+        dependencies:
+          - console
+          - exceptions
+          - lists
+          - partial
+          - profunctor
+          - strings
+          - transformers
+          - typelevel-prelude
+          - unsafe-coerce
+      pha:
+        repo: https://github.com/gbagan/purescript-pha.git
+        version: v0.9.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - datetime
+          - effect
+          - foldable-traversable
+          - free
+          - integers
+          - maybe
+          - prelude
+          - profunctor-lenses
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+          - unsafe-reference
+          - web-dom
+          - web-events
+          - web-html
+          - web-pointerevents
+          - web-uievents
+      phaser:
+        repo: https://github.com/lfarroco/purescript-phaser.git
+        version: v0.6.0
+        dependencies:
+          - canvas
+          - console
+          - effect
+          - maybe
+          - nullable
+          - options
+          - prelude
+          - web-html
+      pipes:
+        repo: https://github.com/felixschl/purescript-pipes.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - lists
+          - mmorph
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      point-free:
+        repo: https://github.com/ursi/purescript-point-free.git
+        version: v1.0.0
+        dependencies:
+          - prelude
+      polymorphic-vectors:
+        repo: https://github.com/artemisSystem/purescript-polymorphic-vectors.git
+        version: v4.0.0
+        dependencies:
+          - distributive
+          - foldable-traversable
+          - numbers
+          - prelude
+          - record
+          - safe-coerce
+          - type-equality
+          - typelevel-prelude
+      posix-types:
+        repo: https://github.com/purescript-node/purescript-posix-types.git
+        version: v6.0.0
+        dependencies:
+          - maybe
+          - prelude
+      precise:
+        repo: https://github.com/purescript-contrib/purescript-precise.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - exceptions
+          - gen
+          - integers
+          - lists
+          - numbers
+          - prelude
+          - strings
+      precise-datetime:
+        repo: https://github.com/awakesecurity/purescript-precise-datetime.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - datetime
+          - decimals
+          - either
+          - enums
+          - foldable-traversable
+          - formatters
+          - integers
+          - js-date
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - strings
+          - tuples
+          - unicode
+      prelude:
+        repo: https://github.com/purescript/purescript-prelude.git
+        version: v6.0.0
+        dependencies: []
+      prettier-printer:
+        repo: https://github.com/paulyoung/purescript-prettier-printer.git
+        version: v3.0.0
+        dependencies:
+          - console
+          - lists
+          - prelude
+          - strings
+          - tuples
+      profunctor:
+        repo: https://github.com/purescript/purescript-profunctor.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - distributive
+          - either
+          - exists
+          - invariant
+          - newtype
+          - prelude
+          - tuples
+      profunctor-lenses:
+        repo: https://github.com/purescript-contrib/purescript-profunctor-lenses.git
+        version: v8.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - const
+          - control
+          - distributive
+          - either
+          - foldable-traversable
+          - foreign-object
+          - functors
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - ordered-collections
+          - partial
+          - prelude
+          - profunctor
+          - record
+          - transformers
+          - tuples
+      protobuf:
+        repo: https://github.com/xc-jp/purescript-protobuf.git
+        version: v4.0.0
+        dependencies:
+          - arraybuffer
+          - arraybuffer-builder
+          - arraybuffer-types
+          - arrays
+          - control
+          - effect
+          - either
+          - enums
+          - exceptions
+          - float32
+          - foldable-traversable
+          - functions
+          - int64
+          - maybe
+          - newtype
+          - parsing
+          - parsing-dataview
+          - prelude
+          - record
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+          - uint
+          - web-encoding
+      ps-cst:
+        repo: https://github.com/purescript-codegen/purescript-ps-cst.git
+        version: v1.2.0
+        dependencies:
+          - ansi
+          - console
+          - dodo-printer
+          - effect
+          - node-fs-aff
+          - node-path
+          - psci-support
+          - record
+          - strings
+      psa-utils:
+        repo: https://github.com/natefaubion/purescript-psa-utils.git
+        version: v8.0.0
+        dependencies:
+          - ansi
+          - argonaut-codecs
+          - argonaut-core
+          - arrays
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - maybe
+          - node-path
+          - ordered-collections
+          - prelude
+          - strings
+          - tuples
+          - unsafe-coerce
+      psc-ide:
+        repo: https://github.com/kRITZCREEK/purescript-psc-ide.git
+        version: v19.0.0
+        dependencies:
+          - aff
+          - argonaut
+          - arrays
+          - console
+          - maybe
+          - node-child-process
+          - node-fs
+          - parallel
+          - random
+      psci-support:
+        repo: https://github.com/purescript/purescript-psci-support.git
+        version: v6.0.0
+        dependencies:
+          - console
+          - effect
+          - prelude
+      qualified-do:
+        repo: https://github.com/artemisSystem/purescript-qualified-do.git
+        version: v2.2.0
+        dependencies:
+          - arrays
+          - control
+          - foldable-traversable
+          - parallel
+          - prelude
+          - unfoldable
+      quantities:
+        repo: https://github.com/sharkdp/purescript-quantities.git
+        version: v12.0.1
+        dependencies:
+          - decimals
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - newtype
+          - nonempty
+          - numbers
+          - pairs
+          - prelude
+          - tuples
+      quickcheck:
+        repo: https://github.com/purescript/purescript-quickcheck.git
+        version: v8.0.1
+        dependencies:
+          - arrays
+          - console
+          - control
+          - effect
+          - either
+          - enums
+          - exceptions
+          - foldable-traversable
+          - gen
+          - identity
+          - integers
+          - lazy
+          - lcg
+          - lists
+          - maybe
+          - newtype
+          - nonempty
+          - numbers
+          - partial
+          - prelude
+          - record
+          - st
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+          - unfoldable
+      quickcheck-combinators:
+        repo: https://github.com/athanclark/purescript-quickcheck-combinators.git
+        version: v0.1.3
+        dependencies:
+          - quickcheck
+          - typelevel
+      quickcheck-laws:
+        repo: https://github.com/purescript-contrib/purescript-quickcheck-laws.git
+        version: v7.0.0
+        dependencies:
+          - enums
+          - quickcheck
+      quickcheck-utf8:
+        repo: https://github.com/openchronology/purescript-quickcheck-utf8.git
+        version: v0.0.0
+        dependencies:
+          - quickcheck
+      quotient:
+        repo: https://github.com/rightfold/purescript-quotient.git
+        version: v3.0.0
+        dependencies:
+          - prelude
+          - quickcheck
+      random:
+        repo: https://github.com/purescript/purescript-random.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - integers
+      rationals:
+        repo: https://github.com/anttih/purescript-rationals.git
+        version: v5.0.0
+        dependencies:
+          - integers
+          - prelude
+      react:
+        repo: https://github.com/purescript-contrib/purescript-react.git
+        version: v10.0.1
+        dependencies:
+          - effect
+          - exceptions
+          - maybe
+          - nullable
+          - prelude
+          - typelevel-prelude
+          - unsafe-coerce
+      react-basic:
+        repo: https://github.com/lumihq/purescript-react-basic.git
+        version: v17.0.0
+        dependencies:
+          - effect
+          - prelude
+          - record
+      react-basic-dom:
+        repo: https://github.com/lumihq/purescript-react-basic-dom.git
+        version: v5.0.0
+        dependencies:
+          - effect
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - nullable
+          - prelude
+          - react-basic
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-file
+          - web-html
+      react-basic-hooks:
+        repo: https://github.com/megamaddu/purescript-react-basic-hooks.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - aff-promise
+          - bifunctors
+          - console
+          - control
+          - datetime
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - functions
+          - indexed-monad
+          - integers
+          - maybe
+          - newtype
+          - now
+          - nullable
+          - ordered-collections
+          - prelude
+          - react-basic
+          - refs
+          - tuples
+          - type-equality
+          - unsafe-coerce
+          - unsafe-reference
+          - web-html
+      react-dom:
+        repo: https://github.com/purescript-contrib/purescript-react-dom.git
+        version: v8.0.0
+        dependencies:
+          - effect
+          - react
+          - web-dom
+      read:
+        repo: https://github.com/truqu/purescript-read.git
+        version: v1.0.1
+        dependencies:
+          - maybe
+          - prelude
+          - strings
+      record:
+        repo: https://github.com/purescript/purescript-record.git
+        version: v4.0.0
+        dependencies:
+          - functions
+          - prelude
+          - unsafe-coerce
+      refined:
+        repo: https://github.com/danieljharvey/purescript-refined.git
+        version: v1.0.0
+        dependencies:
+          - argonaut
+          - effect
+          - prelude
+          - quickcheck
+          - typelevel
+      refs:
+        repo: https://github.com/purescript/purescript-refs.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - prelude
+      remotedata:
+        repo: https://github.com/krisajenkins/purescript-remotedata.git
+        version: v5.0.0
+        dependencies:
+          - bifunctors
+          - either
+          - profunctor-lenses
+      resource:
+        repo: https://github.com/joneshf/purescript-resource.git
+        version: v2.0.1
+        dependencies:
+          - aff
+          - console
+          - control
+          - effect
+          - newtype
+          - prelude
+          - psci-support
+          - refs
+      resourcet:
+        repo: https://github.com/robertdp/purescript-resourcet.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - effect
+          - foldable-traversable
+          - maybe
+          - ordered-collections
+          - parallel
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+      result:
+        repo: https://github.com/ad-si/purescript-result.git
+        version: v1.0.3
+        dependencies:
+          - either
+          - foldable-traversable
+          - prelude
+      return:
+        repo: https://github.com/ursi/purescript-return.git
+        version: v0.2.0
+        dependencies:
+          - foldable-traversable
+          - point-free
+          - prelude
+      ring-modules:
+        repo: https://github.com/f-o-a-m/purescript-ring-modules.git
+        version: v5.0.1
+        dependencies:
+          - prelude
+      routing:
+        repo: https://github.com/purescript-contrib/purescript-routing.git
+        version: v11.0.0
+        dependencies:
+          - aff
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - integers
+          - js-uri
+          - lists
+          - maybe
+          - numbers
+          - partial
+          - prelude
+          - semirings
+          - tuples
+          - validation
+          - web-html
+      routing-duplex:
+        repo: https://github.com/natefaubion/purescript-routing-duplex.git
+        version: v0.6.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - js-uri
+          - lazy
+          - numbers
+          - prelude
+          - profunctor
+          - record
+          - strings
+          - typelevel-prelude
+      run:
+        repo: https://github.com/natefaubion/purescript-run.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - free
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - tailrec
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - variant
+      safe-coerce:
+        repo: https://github.com/purescript/purescript-safe-coerce.git
+        version: v2.0.0
+        dependencies:
+          - unsafe-coerce
+      safely:
+        repo: https://github.com/paf31/purescript-safely.git
+        version: v4.0.1
+        dependencies:
+          - freet
+          - lists
+      selection-foldable:
+        repo: https://github.com/jamieyung/purescript-selection-foldable.git
+        version: v0.2.0
+        dependencies:
+          - filterable
+          - foldable-traversable
+          - maybe
+          - prelude
+      semirings:
+        repo: https://github.com/purescript/purescript-semirings.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - lists
+          - newtype
+          - prelude
+      signal:
+        repo: https://github.com/bodil/purescript-signal.git
+        version: v13.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - foldable-traversable
+          - maybe
+          - prelude
+      simple-emitter:
+        repo: https://github.com/oreshinya/purescript-simple-emitter.git
+        version: v2.0.0
+        dependencies:
+          - ordered-collections
+          - refs
+      sized-matrices:
+        repo: https://github.com/csicar/purescript-sized-matrices.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - distributive
+          - foldable-traversable
+          - maybe
+          - prelude
+          - sized-vectors
+          - strings
+          - typelevel
+          - unfoldable
+          - vectorfield
+      sized-vectors:
+        repo: https://github.com/bodil/purescript-sized-vectors.git
+        version: v5.0.2
+        dependencies:
+          - argonaut
+          - arrays
+          - distributive
+          - foldable-traversable
+          - maybe
+          - prelude
+          - quickcheck
+          - typelevel
+          - unfoldable
+      slug:
+        repo: https://github.com/thomashoneyman/purescript-slug.git
+        version: v3.0.1
+        dependencies:
+          - argonaut-codecs
+          - maybe
+          - prelude
+          - strings
+          - unicode
+      soundfonts:
+        repo: https://github.com/newlandsvalley/purescript-soundfonts.git
+        version: v4.1.0
+        dependencies:
+          - aff
+          - affjax
+          - affjax-web
+          - argonaut-core
+          - arraybuffer-types
+          - arrays
+          - b64
+          - bifunctors
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign-object
+          - http-methods
+          - integers
+          - lists
+          - maybe
+          - midi
+          - ordered-collections
+          - parallel
+          - partial
+          - prelude
+          - strings
+          - transformers
+          - tuples
+      sparse-matrices:
+        repo: https://github.com/Ebmtranceboy/purescript-sparse-matrices.git
+        version: v1.2.1
+        dependencies:
+          - console
+          - effect
+          - prelude
+          - sparse-polynomials
+      sparse-polynomials:
+        repo: https://github.com/Ebmtranceboy/purescript-sparse-polynomials.git
+        version: v1.0.5
+        dependencies:
+          - cartesian
+          - console
+          - effect
+          - ordered-collections
+          - prelude
+          - rationals
+          - tuples
+      spec:
+        repo: https://github.com/purescript-spec/purescript-spec.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - ansi
+          - avar
+          - console
+          - exceptions
+          - foldable-traversable
+          - fork
+          - now
+          - pipes
+          - prelude
+          - strings
+          - transformers
+      spec-discovery:
+        repo: https://github.com/purescript-spec/purescript-spec-discovery.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - aff-promise
+          - arrays
+          - console
+          - effect
+          - foldable-traversable
+          - node-fs
+          - prelude
+          - spec
+      spec-quickcheck:
+        repo: https://github.com/purescript-spec/purescript-spec-quickcheck.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - prelude
+          - quickcheck
+          - random
+          - spec
+      ssrs:
+        repo: https://github.com/PureFunctor/purescript-ssrs.git
+        version: v1.0.0
+        dependencies:
+          - dissect
+          - either
+          - fixed-points
+          - free
+          - lists
+          - prelude
+          - safe-coerce
+          - tailrec
+          - tuples
+          - variant
+      st:
+        repo: https://github.com/purescript/purescript-st.git
+        version: v6.0.0
+        dependencies:
+          - partial
+          - prelude
+          - tailrec
+          - unsafe-coerce
+      strictlypositiveint:
+        repo: https://github.com/jamieyung/purescript-strictlypositiveint.git
+        version: v1.0.1
+        dependencies:
+          - prelude
+      string-parsers:
+        repo: https://github.com/purescript-contrib/purescript-string-parsers.git
+        version: v8.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - prelude
+          - strings
+          - tailrec
+      strings:
+        repo: https://github.com/purescript/purescript-strings.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - enums
+          - foldable-traversable
+          - gen
+          - integers
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+          - unsafe-coerce
+      strings-extra:
+        repo: https://github.com/purescript-contrib/purescript-strings-extra.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - maybe
+          - prelude
+          - strings
+          - unicode
+      stringutils:
+        repo: https://github.com/menelaos/purescript-stringutils.git
+        version: v0.0.12
+        dependencies:
+          - arrays
+          - integers
+          - maybe
+          - partial
+          - prelude
+          - strings
+      substitute:
+        repo: https://github.com/ursi/purescript-substitute.git
+        version: v0.2.3
+        dependencies:
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - prelude
+          - return
+          - strings
+      supply:
+        repo: https://github.com/ajnsit/purescript-supply.git
+        version: v0.2.0
+        dependencies:
+          - console
+          - control
+          - effect
+          - lazy
+          - prelude
+          - refs
+          - tuples
+      tailrec:
+        repo: https://github.com/purescript/purescript-tailrec.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - effect
+          - either
+          - identity
+          - maybe
+          - partial
+          - prelude
+          - refs
+      test-unit:
+        repo: https://github.com/bodil/purescript-test-unit.git
+        version: v17.0.0
+        dependencies:
+          - aff
+          - avar
+          - effect
+          - either
+          - free
+          - js-timers
+          - lists
+          - prelude
+          - quickcheck
+          - strings
+      thermite:
+        repo: https://github.com/paf31/purescript-thermite.git
+        version: v6.3.1
+        dependencies:
+          - aff
+          - coroutines
+          - freet
+          - profunctor-lenses
+          - react
+      thermite-dom:
+        repo: https://github.com/athanclark/purescript-thermite-dom.git
+        version: v0.3.1
+        dependencies:
+          - react
+          - react-dom
+          - thermite
+          - web-html
+      these:
+        repo: https://github.com/purescript-contrib/purescript-these.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - gen
+          - lists
+          - quickcheck
+          - quickcheck-laws
+          - tuples
+      transformers:
+        repo: https://github.com/purescript/purescript-transformers.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - distributive
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - identity
+          - lazy
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      tree-rose:
+        repo: https://github.com/jordanmartinez/purescript-tree-rose.git
+        version: v4.0.2
+        dependencies:
+          - control
+          - foldable-traversable
+          - free
+          - lists
+          - maybe
+          - prelude
+          - tailrec
+      tuples:
+        repo: https://github.com/purescript/purescript-tuples.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - invariant
+          - prelude
+      two-or-more:
+        repo: https://github.com/i-am-the-slime/purescript-two-or-more.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - foldable-traversable
+          - maybe
+          - partial
+          - prelude
+          - psci-support
+          - tuples
+      type-equality:
+        repo: https://github.com/purescript/purescript-type-equality.git
+        version: v4.0.1
+        dependencies: []
+      typelevel:
+        repo: https://github.com/bodil/purescript-typelevel.git
+        version: v6.0.0
+        dependencies:
+          - partial
+          - prelude
+          - tuples
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-lists:
+        repo: https://github.com/PureFunctor/purescript-typelevel-lists.git
+        version: v2.1.0
+        dependencies:
+          - prelude
+          - tuples
+          - typelevel-peano
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-peano:
+        repo: https://github.com/csicar/purescript-typelevel-peano.git
+        version: v1.0.1
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - prelude
+          - psci-support
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-prelude:
+        repo: https://github.com/purescript/purescript-typelevel-prelude.git
+        version: v7.0.0
+        dependencies:
+          - prelude
+          - type-equality
+      typelevel-rows:
+        repo: https://github.com/jordanmartinez/purescript-typelevel-rows.git
+        version: v0.1.0
+        dependencies:
+          - prelude
+      uint:
+        repo: https://github.com/purescript-contrib/purescript-uint.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - enums
+          - gen
+          - maybe
+          - numbers
+          - prelude
+      uncurried-transformers:
+        repo: https://github.com/PureFunctor/purescript-uncurried-transformers.git
+        version: v1.1.0
+        dependencies:
+          - control
+          - effect
+          - either
+          - functions
+          - identity
+          - prelude
+          - safe-coerce
+          - tailrec
+          - transformers
+          - tuples
+      undefined-is-not-a-problem:
+        repo: https://github.com/paluh/purescript-undefined-is-not-a-problem.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - assert
+          - effect
+          - either
+          - foreign
+          - maybe
+          - newtype
+          - prelude
+          - random
+          - tuples
+          - type-equality
+          - unsafe-coerce
+      unfoldable:
+        repo: https://github.com/purescript/purescript-unfoldable.git
+        version: v6.0.0
+        dependencies:
+          - foldable-traversable
+          - maybe
+          - partial
+          - prelude
+          - tuples
+      unicode:
+        repo: https://github.com/purescript-contrib/purescript-unicode.git
+        version: v6.0.0
+        dependencies:
+          - foldable-traversable
+          - maybe
+          - strings
+      unlift:
+        repo: https://github.com/tweag/purescript-unlift.git
+        version: v1.0.1
+        dependencies:
+          - aff
+          - effect
+          - either
+          - freet
+          - identity
+          - lists
+          - maybe
+          - monad-control
+          - prelude
+          - st
+          - transformers
+          - tuples
+      unsafe-coerce:
+        repo: https://github.com/purescript/purescript-unsafe-coerce.git
+        version: v6.0.0
+        dependencies: []
+      unsafe-reference:
+        repo: https://github.com/purescript-contrib/purescript-unsafe-reference.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+      uri:
+        repo: https://github.com/purescript-contrib/purescript-uri.git
+        version: v9.0.0
+        dependencies:
+          - arrays
+          - integers
+          - js-uri
+          - numbers
+          - parsing
+          - prelude
+          - profunctor-lenses
+          - these
+          - transformers
+          - unfoldable
+      validation:
+        repo: https://github.com/purescript/purescript-validation.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - newtype
+          - prelude
+      variant:
+        repo: https://github.com/natefaubion/purescript-variant.git
+        version: v8.0.0
+        dependencies:
+          - enums
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - record
+          - tuples
+          - unsafe-coerce
+      vectorfield:
+        repo: https://github.com/csicar/purescript-vectorfield.git
+        version: v1.0.1
+        dependencies:
+          - console
+          - effect
+          - group
+          - prelude
+          - psci-support
+      versions:
+        repo: https://github.com/hdgarrood/purescript-versions.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - either
+          - foldable-traversable
+          - functions
+          - integers
+          - lists
+          - maybe
+          - orders
+          - parsing
+          - partial
+          - strings
+      web-clipboard:
+        repo: https://github.com/purescript-web/purescript-web-clipboard.git
+        version: v4.0.0
+        dependencies:
+          - web-html
+      web-cssom:
+        repo: https://github.com/purescript-web/purescript-web-cssom.git
+        version: v2.0.0
+        dependencies:
+          - web-dom
+          - web-html
+          - web-uievents
+      web-dom:
+        repo: https://github.com/purescript-web/purescript-web-dom.git
+        version: v6.0.0
+        dependencies:
+          - web-events
+      web-dom-parser:
+        repo: https://github.com/purescript-web/purescript-web-dom-parser.git
+        version: v8.0.0
+        dependencies:
+          - effect
+          - partial
+          - prelude
+          - web-dom
+      web-dom-xpath:
+        repo: https://github.com/purescript-web/purescript-web-dom-xpath.git
+        version: v3.0.0
+        dependencies:
+          - web-dom
+      web-encoding:
+        repo: https://github.com/purescript-web/purescript-web-encoding.git
+        version: v3.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - newtype
+          - prelude
+      web-events:
+        repo: https://github.com/purescript-web/purescript-web-events.git
+        version: v4.0.0
+        dependencies:
+          - datetime
+          - enums
+          - foreign
+          - nullable
+      web-fetch:
+        repo: https://github.com/purescript-web/purescript-web-fetch.git
+        version: v3.0.0
+        dependencies:
+          - effect
+          - foreign-object
+          - http-methods
+          - prelude
+          - record
+          - typelevel-prelude
+          - web-file
+          - web-promise
+          - web-streams
+      web-file:
+        repo: https://github.com/purescript-web/purescript-web-file.git
+        version: v4.0.0
+        dependencies:
+          - foreign
+          - media-types
+          - web-dom
+      web-html:
+        repo: https://github.com/purescript-web/purescript-web-html.git
+        version: v4.0.0
+        dependencies:
+          - js-date
+          - web-dom
+          - web-file
+          - web-storage
+      web-page-visibility:
+        repo: https://git.sr.ht/~toastal/purescript-web-page-visibility
+        version: v2.0.0
+        dependencies:
+          - effect
+          - enums
+          - exceptions
+          - maybe
+          - prelude
+          - strings
+          - web-events
+          - web-html
+      web-pointerevents:
+        repo: https://github.com/purescript-web/purescript-web-pointerevents.git
+        version: v1.0.0
+        dependencies:
+          - effect
+          - maybe
+          - prelude
+          - web-dom
+          - web-uievents
+      web-promise:
+        repo: https://github.com/purescript-web/purescript-web-promise.git
+        version: v3.0.0
+        dependencies:
+          - effect
+          - exceptions
+          - foldable-traversable
+          - functions
+          - maybe
+          - prelude
+      web-socket:
+        repo: https://github.com/purescript-web/purescript-web-socket.git
+        version: v4.0.0
+        dependencies:
+          - arraybuffer-types
+          - web-file
+      web-storage:
+        repo: https://github.com/purescript-web/purescript-web-storage.git
+        version: v5.0.0
+        dependencies:
+          - nullable
+          - web-events
+      web-streams:
+        repo: https://github.com/purescript-web/purescript-web-streams.git
+        version: v3.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - exceptions
+          - nullable
+          - prelude
+          - tuples
+          - web-promise
+      web-touchevents:
+        repo: https://github.com/purescript-web/purescript-web-touchevents.git
+        version: v4.0.0
+        dependencies:
+          - web-uievents
+      web-uievents:
+        repo: https://github.com/purescript-web/purescript-web-uievents.git
+        version: v4.0.0
+        dependencies:
+          - web-html
+      web-workers:
+        repo: https://github.com/gbagan/purescript-web-workers.git
+        version: v1.1.0
+        dependencies:
+          - effect
+          - foreign
+          - maybe
+          - prelude
+          - unsafe-coerce
+          - web-events
+      web-xhr:
+        repo: https://github.com/purescript-web/purescript-web-xhr.git
+        version: v5.0.0
+        dependencies:
+          - arraybuffer-types
+          - datetime
+          - http-methods
+          - web-dom
+          - web-file
+          - web-html
+      yoga-fetch:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-fetch.git
+        version: v1.0.1
+        dependencies:
+          - aff
+          - aff-promise
+          - arraybuffer-types
+          - effect
+          - foreign
+          - foreign-object
+          - newtype
+          - prelude
+          - typelevel-prelude
+          - unsafe-coerce
+      yoga-json:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-json.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - identity
+          - lists
+          - maybe
+          - nullable
+          - partial
+          - prelude
+          - record
+          - transformers
+          - typelevel-prelude
+          - variant
+      yoga-postgres:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-postgres.git
+        version: v6.0.0
+        dependencies:
+          - aff
+          - arrays
+          - datetime
+          - effect
+          - either
+          - enums
+          - foldable-traversable
+          - foreign
+          - integers
+          - maybe
+          - nullable
+          - prelude
+          - transformers
+          - unsafe-coerce
+  extra_packages: {}
+packages:
+  aff:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-aff.git
+    rev: 2d44d9f9d0d6a416a4103fba2fb39e5160f80e36
+    dependencies:
+      - datetime
+      - effect
+      - exceptions
+      - functions
+      - parallel
+      - transformers
+      - unsafe-coerce
+  arrays:
+    type: git
+    url: https://github.com/purescript/purescript-arrays.git
+    rev: d20bae2f76db6cf29b7b75e26e82b8a54c32295e
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - maybe
+      - nonempty
+      - partial
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  avar:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-avar.git
+    rev: d00f5784d9cc8f079babd62740f5c52b87e5caa5
+    dependencies:
+      - aff
+      - effect
+      - either
+      - exceptions
+      - functions
+      - maybe
+  bifunctors:
+    type: git
+    url: https://github.com/purescript/purescript-bifunctors.git
+    rev: 16ba2fb6dd7f05528ebd9e2f9ca3a068b325e5b3
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  catenable-lists:
+    type: git
+    url: https://github.com/purescript/purescript-catenable-lists.git
+    rev: 09abe1f4888bc00841ad2b59e56a9e7ce7ebd4ab
+    dependencies:
+      - control
+      - foldable-traversable
+      - lists
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  console:
+    type: git
+    url: https://github.com/purescript/purescript-console.git
+    rev: 3b83d7b792d03872afeea5e62b4f686ab0f09842
+    dependencies:
+      - effect
+      - prelude
+  const:
+    type: git
+    url: https://github.com/purescript/purescript-const.git
+    rev: ab9570cf2b6e67f7e441178211db1231cfd75c37
+    dependencies:
+      - invariant
+      - newtype
+      - prelude
+  contravariant:
+    type: git
+    url: https://github.com/purescript/purescript-contravariant.git
+    rev: 9ad3e105b8855bcc25f4e0893c784789d05a58de
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  control:
+    type: git
+    url: https://github.com/purescript/purescript-control.git
+    rev: a6033808790879a17b2729e73747a9ed3fb2264e
+    dependencies:
+      - newtype
+      - prelude
+  datetime:
+    type: git
+    url: https://github.com/purescript/purescript-datetime.git
+    rev: a6a0cf1b0324964ad1854bc3377ed8766ba90e6f
+    dependencies:
+      - bifunctors
+      - control
+      - either
+      - enums
+      - foldable-traversable
+      - functions
+      - gen
+      - integers
+      - lists
+      - maybe
+      - newtype
+      - numbers
+      - ordered-collections
+      - partial
+      - prelude
+      - tuples
+  distributive:
+    type: git
+    url: https://github.com/purescript/purescript-distributive.git
+    rev: 6005e513642e855ebf6f884d24a35c2803ca252a
+    dependencies:
+      - identity
+      - newtype
+      - prelude
+      - tuples
+      - type-equality
+  effect:
+    type: git
+    url: https://github.com/purescript/purescript-effect.git
+    rev: a192ddb923027d426d6ea3d8deb030c9aa7c7dda
+    dependencies:
+      - prelude
+  either:
+    type: git
+    url: https://github.com/purescript/purescript-either.git
+    rev: af655a04ed2fd694b6688af39ee20d7907ad0763
+    dependencies:
+      - control
+      - invariant
+      - maybe
+      - prelude
+  enums:
+    type: git
+    url: https://github.com/purescript/purescript-enums.git
+    rev: bae47961d401f9acf88da38f32e87403e5f0cf2f
+    dependencies:
+      - control
+      - either
+      - gen
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tuples
+      - unfoldable
+  exceptions:
+    type: git
+    url: https://github.com/purescript/purescript-exceptions.git
+    rev: afab3c07c820bb49b6c5be50049db46a964a6161
+    dependencies:
+      - effect
+      - either
+      - maybe
+      - prelude
+  exists:
+    type: git
+    url: https://github.com/purescript/purescript-exists.git
+    rev: f765b4ace7869c27b9c05949e18c843881f9173b
+    dependencies:
+      - unsafe-coerce
+  foldable-traversable:
+    type: git
+    url: https://github.com/purescript/purescript-foldable-traversable.git
+    rev: b3926f870532d287ea59e2d5cd3873b81ef2a93a
+    dependencies:
+      - bifunctors
+      - const
+      - control
+      - either
+      - functors
+      - identity
+      - maybe
+      - newtype
+      - orders
+      - prelude
+      - tuples
+  free:
+    type: git
+    url: https://github.com/purescript/purescript-free.git
+    rev: e2d8fa8023a864363857834e11393483bced5e38
+    dependencies:
+      - catenable-lists
+      - control
+      - distributive
+      - either
+      - exists
+      - foldable-traversable
+      - invariant
+      - lazy
+      - maybe
+      - prelude
+      - tailrec
+      - transformers
+      - tuples
+      - unsafe-coerce
+  functions:
+    type: git
+    url: https://github.com/purescript/purescript-functions.git
+    rev: f626f20580483977c5b27a01aac6471e28aff367
+    dependencies:
+      - prelude
+  functors:
+    type: git
+    url: https://github.com/purescript/purescript-functors.git
+    rev: 022ffd7a2a7ec12080314f3d217b400674a247b4
+    dependencies:
+      - bifunctors
+      - const
+      - contravariant
+      - control
+      - distributive
+      - either
+      - invariant
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - tuples
+      - unsafe-coerce
+  gen:
+    type: git
+    url: https://github.com/purescript/purescript-gen.git
+    rev: 9fbcc2a1261c32e30d79c5418edef4d96fe76931
+    dependencies:
+      - either
+      - foldable-traversable
+      - identity
+      - maybe
+      - newtype
+      - nonempty
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  identity:
+    type: git
+    url: https://github.com/purescript/purescript-identity.git
+    rev: ef6768f8a52ab0bc943a85f5761ba07c257f639f
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  integers:
+    type: git
+    url: https://github.com/purescript/purescript-integers.git
+    rev: 54d712b25c594833083d15dc9ff2418eb9c52822
+    dependencies:
+      - maybe
+      - numbers
+      - prelude
+  invariant:
+    type: git
+    url: https://github.com/purescript/purescript-invariant.git
+    rev: 1d2a196d51e90623adb88496c2cfd759c6736894
+    dependencies:
+      - control
+      - prelude
+  js-timers:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-js-timers.git
+    rev: 7cb728b3e6dc29f355143617e6e9ac770ecd9273
+    dependencies:
+      - effect
+  lazy:
+    type: git
+    url: https://github.com/purescript/purescript-lazy.git
+    rev: 48347841226b27af5205a1a8ec71e27a93ce86fd
+    dependencies:
+      - control
+      - foldable-traversable
+      - invariant
+      - prelude
+  lcg:
+    type: git
+    url: https://github.com/purescript/purescript-lcg.git
+    rev: 67c6c6483a563a59ae036d9dca0f1be2835326a5
+    dependencies:
+      - effect
+      - integers
+      - maybe
+      - partial
+      - prelude
+      - random
+  lists:
+    type: git
+    url: https://github.com/purescript/purescript-lists.git
+    rev: b113451e5b41cad87d669a3165f955c71cd863e2
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - lazy
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  maybe:
+    type: git
+    url: https://github.com/purescript/purescript-maybe.git
+    rev: c6f98ac1088766287106c5d9c8e30e7648d36786
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  newtype:
+    type: git
+    url: https://github.com/purescript/purescript-newtype.git
+    rev: 29d8e6dd77aec2c975c948364ec3faf26e14ee7b
+    dependencies:
+      - prelude
+      - safe-coerce
+  nonempty:
+    type: git
+    url: https://github.com/purescript/purescript-nonempty.git
+    rev: 28150ecc7419238b187abd609a92a645273348bb
+    dependencies:
+      - control
+      - foldable-traversable
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  numbers:
+    type: git
+    url: https://github.com/purescript/purescript-numbers.git
+    rev: 2a53528f18f9415334bae28e7bb3cf3be86342c2
+    dependencies:
+      - functions
+      - maybe
+  ordered-collections:
+    type: git
+    url: https://github.com/purescript/purescript-ordered-collections.git
+    rev: 9826b7632d0d0a691173bde308a634195f42a419
+    dependencies:
+      - arrays
+      - foldable-traversable
+      - gen
+      - lists
+      - maybe
+      - partial
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+  orders:
+    type: git
+    url: https://github.com/purescript/purescript-orders.git
+    rev: f86db621ec5eef1274145f8b1fd8ebbfe0ed4a2c
+    dependencies:
+      - newtype
+      - prelude
+  parallel:
+    type: git
+    url: https://github.com/purescript/purescript-parallel.git
+    rev: 85290dca837771ac4870071008c933d315ef678f
+    dependencies:
+      - control
+      - effect
+      - either
+      - foldable-traversable
+      - functors
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - refs
+      - transformers
+  partial:
+    type: git
+    url: https://github.com/purescript/purescript-partial.git
+    rev: 0fa0646f5ea1ec5f0c46dcbd770c705a6c9ad3ec
+    dependencies: []
+  prelude:
+    type: git
+    url: https://github.com/purescript/purescript-prelude.git
+    rev: 32787f4399c92459c41602131a5858559eb868c5
+    dependencies: []
+  profunctor:
+    type: git
+    url: https://github.com/purescript/purescript-profunctor.git
+    rev: 0a966a14e7b0c827d44657dc1710cdc712d2e034
+    dependencies:
+      - control
+      - distributive
+      - either
+      - exists
+      - invariant
+      - newtype
+      - prelude
+      - tuples
+  quickcheck:
+    type: git
+    url: https://github.com/purescript/purescript-quickcheck.git
+    rev: bf5029f97e6c0d7552d3a08d2ab793a19e2c5e3d
+    dependencies:
+      - arrays
+      - console
+      - control
+      - effect
+      - either
+      - enums
+      - exceptions
+      - foldable-traversable
+      - gen
+      - identity
+      - integers
+      - lazy
+      - lcg
+      - lists
+      - maybe
+      - newtype
+      - nonempty
+      - numbers
+      - partial
+      - prelude
+      - record
+      - st
+      - strings
+      - tailrec
+      - transformers
+      - tuples
+      - unfoldable
+  random:
+    type: git
+    url: https://github.com/purescript/purescript-random.git
+    rev: 9540bc965a9596da02fefd9949418bb19c92533a
+    dependencies:
+      - effect
+      - integers
+  record:
+    type: git
+    url: https://github.com/purescript/purescript-record.git
+    rev: c89cd1ada6b636692571fc374196b1c39c4c9f70
+    dependencies:
+      - functions
+      - prelude
+      - unsafe-coerce
+  refs:
+    type: git
+    url: https://github.com/purescript/purescript-refs.git
+    rev: f8e6216da4cb9309fde1f20cd6f69ac3a3b7f9e8
+    dependencies:
+      - effect
+      - prelude
+  safe-coerce:
+    type: git
+    url: https://github.com/purescript/purescript-safe-coerce.git
+    rev: 7fa799ae80a38b8d948efcb52608e58e198b3da7
+    dependencies:
+      - unsafe-coerce
+  st:
+    type: git
+    url: https://github.com/purescript/purescript-st.git
+    rev: 2cc7ae1c3318a303378c4a9f3fa0f10ee7cc3589
+    dependencies:
+      - partial
+      - prelude
+      - tailrec
+      - unsafe-coerce
+  strings:
+    type: git
+    url: https://github.com/purescript/purescript-strings.git
+    rev: 4bc6954448d056f8aa7a659695a6ad60ad4fdf19
+    dependencies:
+      - arrays
+      - control
+      - either
+      - enums
+      - foldable-traversable
+      - gen
+      - integers
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  tailrec:
+    type: git
+    url: https://github.com/purescript/purescript-tailrec.git
+    rev: 5e2104aa734b31a17074cc805bf087d72b65afd1
+    dependencies:
+      - bifunctors
+      - effect
+      - either
+      - identity
+      - maybe
+      - partial
+      - prelude
+      - refs
+  test-unit:
+    type: git
+    url: https://github.com/bodil/purescript-test-unit.git
+    rev: 3112d7ebe06d467238058a6384dc75ffd960d335
+    dependencies:
+      - aff
+      - avar
+      - effect
+      - either
+      - free
+      - js-timers
+      - lists
+      - prelude
+      - quickcheck
+      - strings
+  transformers:
+    type: git
+    url: https://github.com/purescript/purescript-transformers.git
+    rev: be72ab52357d9a665cbf93d73ba1c07c4b0957ee
+    dependencies:
+      - control
+      - distributive
+      - effect
+      - either
+      - exceptions
+      - foldable-traversable
+      - identity
+      - lazy
+      - maybe
+      - newtype
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  tuples:
+    type: git
+    url: https://github.com/purescript/purescript-tuples.git
+    rev: 4f52da2729b448c8564369378f1232d8d2dc1d8b
+    dependencies:
+      - control
+      - invariant
+      - prelude
+  type-equality:
+    type: git
+    url: https://github.com/purescript/purescript-type-equality.git
+    rev: 0525b7d39e0fbd81b4209518139fb8ab02695774
+    dependencies: []
+  unfoldable:
+    type: git
+    url: https://github.com/purescript/purescript-unfoldable.git
+    rev: 493dfe04ed590e20d8f69079df2f58486882748d
+    dependencies:
+      - foldable-traversable
+      - maybe
+      - partial
+      - prelude
+      - tuples
+  unsafe-coerce:
+    type: git
+    url: https://github.com/purescript/purescript-unsafe-coerce.git
+    rev: ab956f82e66e633f647fb3098e8ddd3ec58d689f
+    dependencies: []

--- a/exercises/chapter3/spago.lock
+++ b/exercises/chapter3/spago.lock
@@ -66,3452 +66,462 @@ workspace:
         - unsafe-coerce
   package_set:
     address:
-      url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
-    compiler: ">=0.15.0 <0.16.0"
+      registry: 10.0.0
+    compiler: ">=0.15.4 <0.16.0"
     content:
-      ace:
-        repo: https://github.com/purescript-contrib/purescript-ace.git
-        version: v9.0.0
-        dependencies:
-          - arrays
-          - effect
-          - foreign
-          - nullable
-          - prelude
-          - web-html
-          - web-uievents
-      aff:
-        repo: https://github.com/purescript-contrib/purescript-aff.git
-        version: v7.0.0
-        dependencies:
-          - datetime
-          - effect
-          - exceptions
-          - functions
-          - parallel
-          - transformers
-          - unsafe-coerce
-      aff-bus:
-        repo: https://github.com/purescript-contrib/purescript-aff-bus.git
-        version: v6.0.0
-        dependencies:
-          - aff
-          - avar
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - lists
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-      aff-coroutines:
-        repo: https://github.com/purescript-contrib/purescript-aff-coroutines.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - avar
-          - coroutines
-          - effect
-      aff-promise:
-        repo: https://github.com/nwolverson/purescript-aff-promise.git
-        version: v4.0.0
-        dependencies:
-          - aff
-          - foreign
-      aff-retry:
-        repo: https://github.com/Unisay/purescript-aff-retry.git
-        version: v2.0.0
-        dependencies:
-          - aff
-          - arrays
-          - datetime
-          - effect
-          - either
-          - exceptions
-          - integers
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - random
-          - transformers
-      affjax:
-        repo: https://github.com/purescript-contrib/purescript-affjax.git
-        version: v13.0.0
-        dependencies:
-          - aff
-          - argonaut-core
-          - arraybuffer-types
-          - foreign
-          - form-urlencoded
-          - http-methods
-          - integers
-          - media-types
-          - nullable
-          - refs
-          - unsafe-coerce
-          - web-xhr
-      affjax-node:
-        repo: https://github.com/purescript-contrib/purescript-affjax-node.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - affjax
-          - either
-          - maybe
-          - prelude
-      affjax-web:
-        repo: https://github.com/purescript-contrib/purescript-affjax-web.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - affjax
-          - either
-          - maybe
-          - prelude
-      ansi:
-        repo: https://github.com/hdgarrood/purescript-ansi.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - lists
-          - strings
-      argonaut:
-        repo: https://github.com/purescript-contrib/purescript-argonaut.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - argonaut-traversals
-      argonaut-codecs:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-codecs.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-core
-          - arrays
-          - effect
-          - foreign-object
-          - identity
-          - integers
-          - maybe
-          - nonempty
-          - ordered-collections
-          - prelude
-          - record
-      argonaut-core:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-core.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - foreign-object
-          - functions
-          - gen
-          - maybe
-          - nonempty
-          - prelude
-          - strings
-          - tailrec
-      argonaut-generic:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-generic.git
-        version: v8.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - prelude
-          - record
-      argonaut-traversals:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-traversals.git
-        version: v10.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - profunctor-lenses
-      argparse-basic:
-        repo: https://github.com/natefaubion/purescript-argparse-basic.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - record
-          - strings
-          - tuples
-          - unfoldable
-      arraybuffer:
-        repo: https://github.com/purescript-contrib/purescript-arraybuffer.git
-        version: v13.0.0
-        dependencies:
-          - arraybuffer-types
-          - arrays
-          - effect
-          - float32
-          - functions
-          - gen
-          - maybe
-          - nullable
-          - prelude
-          - tailrec
-          - uint
-          - unfoldable
-      arraybuffer-builder:
-        repo: https://github.com/jamesdbrock/purescript-arraybuffer-builder.git
-        version: v3.0.1
-        dependencies:
-          - arraybuffer
-          - arraybuffer-types
-          - effect
-          - float32
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - transformers
-          - uint
-      arraybuffer-types:
-        repo: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
-        version: v3.0.2
-        dependencies: []
-      arrays:
-        repo: https://github.com/purescript/purescript-arrays.git
-        version: v7.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - foldable-traversable
-          - maybe
-          - nonempty
-          - partial
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - unfoldable
-          - unsafe-coerce
-      arrays-zipper:
-        repo: https://github.com/JordanMartinez/purescript-arrays-zipper.git
-        version: v2.0.1
-        dependencies:
-          - arrays
-          - control
-          - quickcheck
-      ask:
-        repo: https://github.com/Mateiadrielrafael/purescript-ask.git
-        version: v1.0.0
-        dependencies:
-          - unsafe-coerce
-      assert:
-        repo: https://github.com/purescript/purescript-assert.git
-        version: v6.0.0
-        dependencies:
-          - console
-          - effect
-          - prelude
-      avar:
-        repo: https://github.com/purescript-contrib/purescript-avar.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - exceptions
-          - functions
-          - maybe
-      b64:
-        repo: https://github.com/menelaos/purescript-b64.git
-        version: v0.0.8
-        dependencies:
-          - arraybuffer-types
-          - either
-          - encoding
-          - enums
-          - exceptions
-          - functions
-          - partial
-          - prelude
-          - strings
-      barlow-lens:
-        repo: https://github.com/sigma-andex/purescript-barlow-lens.git
-        version: v0.9.0
-        dependencies:
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - profunctor-lenses
-          - tuples
-          - typelevel-prelude
-      bifunctors:
-        repo: https://github.com/purescript/purescript-bifunctors.git
-        version: v6.0.0
-        dependencies:
-          - const
-          - either
-          - newtype
-          - prelude
-          - tuples
-      bigints:
-        repo: https://github.com/sharkdp/purescript-bigints.git
-        version: v7.0.1
-        dependencies:
-          - integers
-          - maybe
-          - strings
-      bower-json:
-        repo: https://github.com/klntsky/purescript-bower-json.git
-        version: v3.0.0
-        dependencies:
-          - argonaut-codecs
-          - arrays
-          - either
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - newtype
-          - prelude
-          - tuples
-      call-by-name:
-        repo: https://github.com/natefaubion/purescript-call-by-name.git
-        version: v4.0.1
-        dependencies:
-          - control
-          - either
-          - lazy
-          - maybe
-          - unsafe-coerce
-      canvas:
-        repo: https://github.com/purescript-web/purescript-canvas.git
-        version: v6.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - exceptions
-          - functions
-          - maybe
-      canvas-action:
-        repo: https://github.com/artemisSystem/purescript-canvas-action.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - arrays
-          - canvas
-          - colors
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - maybe
-          - numbers
-          - polymorphic-vectors
-          - prelude
-          - refs
-          - run
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-html
-      cartesian:
-        repo: https://github.com/Ebmtranceboy/purescript-cartesian.git
-        version: v1.0.6
-        dependencies:
-          - console
-          - effect
-          - integers
-          - psci-support
-      catenable-lists:
-        repo: https://github.com/purescript/purescript-catenable-lists.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - lists
-          - maybe
-          - prelude
-          - tuples
-          - unfoldable
-      channel:
-        repo: https://github.com/ConnorDillon/purescript-channel.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - assert
-          - avar
-          - console
-          - contravariant
-          - control
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - lazy
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      checked-exceptions:
-        repo: https://github.com/natefaubion/purescript-checked-exceptions.git
-        version: v3.1.1
-        dependencies:
-          - prelude
-          - transformers
-          - variant
-      codec:
-        repo: https://github.com/garyb/purescript-codec.git
-        version: v5.0.0
-        dependencies:
-          - profunctor
-          - transformers
-      codec-argonaut:
-        repo: https://github.com/garyb/purescript-codec-argonaut.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-core
-          - codec
-          - ordered-collections
-          - type-equality
-          - variant
-      colors:
-        repo: https://github.com/purescript-contrib/purescript-colors.git
-        version: v7.0.1
-        dependencies:
-          - arrays
-          - integers
-          - lists
-          - numbers
-          - partial
-          - strings
-      concurrent-queues:
-        repo: https://github.com/purescript-contrib/purescript-concurrent-queues.git
-        version: v3.0.0
-        dependencies:
-          - aff
-          - avar
-          - effect
-      console:
-        repo: https://github.com/purescript/purescript-console.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - prelude
-      const:
-        repo: https://github.com/purescript/purescript-const.git
-        version: v6.0.0
-        dependencies:
-          - invariant
-          - newtype
-          - prelude
-      contravariant:
-        repo: https://github.com/purescript/purescript-contravariant.git
-        version: v6.0.0
-        dependencies:
-          - const
-          - either
-          - newtype
-          - prelude
-          - tuples
-      control:
-        repo: https://github.com/purescript/purescript-control.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      convertable-options:
-        repo: https://github.com/natefaubion/purescript-convertable-options.git
-        version: v1.0.0
-        dependencies:
-          - console
-          - effect
-          - maybe
-          - record
-      coroutines:
-        repo: https://github.com/purescript-contrib/purescript-coroutines.git
-        version: v7.0.0
-        dependencies:
-          - freet
-          - parallel
-          - profunctor
-      css:
-        repo: https://github.com/purescript-contrib/purescript-css.git
-        version: v6.0.0
-        dependencies:
-          - colors
-          - console
-          - effect
-          - nonempty
-          - profunctor
-          - strings
-          - these
-          - transformers
-      datetime:
-        repo: https://github.com/purescript/purescript-datetime.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - either
-          - enums
-          - foldable-traversable
-          - functions
-          - gen
-          - integers
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - ordered-collections
-          - partial
-          - prelude
-          - tuples
-      datetime-parsing:
-        repo: https://github.com/flounders/purescript-datetime-parsing.git
-        version: v0.2.0
-        dependencies:
-          - arrays
-          - datetime
-          - either
-          - enums
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - numbers
-          - parsing
-          - prelude
-          - strings
-          - unicode
-      debug:
-        repo: https://github.com/garyb/purescript-debug.git
-        version: v6.0.0
-        dependencies:
-          - functions
-          - prelude
-      decimals:
-        repo: https://github.com/sharkdp/purescript-decimals.git
-        version: v7.0.0
-        dependencies:
-          - maybe
-      dissect:
-        repo: https://github.com/PureFunctor/purescript-dissect.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - foreign-object
-          - functors
-          - newtype
-          - partial
-          - prelude
-          - tailrec
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - variant
-      distributive:
-        repo: https://github.com/purescript/purescript-distributive.git
-        version: v6.0.0
-        dependencies:
-          - identity
-          - newtype
-          - prelude
-          - tuples
-          - type-equality
-      dodo-printer:
-        repo: https://github.com/natefaubion/purescript-dodo-printer.git
-        version: v2.2.0
-        dependencies:
-          - aff
-          - ansi
-          - avar
-          - console
-          - effect
-          - foldable-traversable
-          - lists
-          - maybe
-          - minibench
-          - node-child-process
-          - node-fs-aff
-          - node-process
-          - psci-support
-          - strings
-      dom-indexed:
-        repo: https://github.com/purescript-halogen/purescript-dom-indexed.git
-        version: v11.0.0
-        dependencies:
-          - media-types
-          - prelude
-          - web-clipboard
-          - web-pointerevents
-          - web-touchevents
-      droplet:
-        repo: https://github.com/easafe/purescript-droplet.git
-        version: v0.4.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - bigints
-          - datetime
-          - debug
-          - effect
-          - either
-          - enums
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - integers
-          - maybe
-          - newtype
-          - nullable
-          - ordered-collections
-          - partial
-          - prelude
-          - profunctor
-          - record
-          - spec
-          - strings
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-      dynamic-buffer:
-        repo: https://github.com/kritzcreek/purescript-dynamic-buffer.git
-        version: v3.0.1
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - refs
-      effect:
-        repo: https://github.com/purescript/purescript-effect.git
-        version: v4.0.0
-        dependencies:
-          - prelude
-      either:
-        repo: https://github.com/purescript/purescript-either.git
-        version: v6.1.0
-        dependencies:
-          - control
-          - invariant
-          - maybe
-          - prelude
-      elmish:
-        repo: https://github.com/collegevine/purescript-elmish.git
-        version: v0.8.1
-        dependencies:
-          - aff
-          - argonaut-core
-          - arrays
-          - bifunctors
-          - console
-          - debug
-          - effect
-          - either
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - functions
-          - integers
-          - js-date
-          - maybe
-          - nullable
-          - partial
-          - prelude
-          - refs
-          - typelevel-prelude
-          - undefined-is-not-a-problem
-          - unsafe-coerce
-          - web-dom
-          - web-html
-      elmish-enzyme:
-        repo: https://github.com/collegevine/purescript-elmish-enzyme.git
-        version: v0.1.1
-        dependencies:
-          - aff
-          - aff-promise
-          - arrays
-          - console
-          - debug
-          - effect
-          - elmish
-          - foldable-traversable
-          - foreign
-          - functions
-          - prelude
-          - transformers
-          - unsafe-coerce
-      elmish-hooks:
-        repo: https://github.com/collegevine/purescript-elmish-hooks.git
-        version: v0.8.2
-        dependencies:
-          - aff
-          - debug
-          - elmish
-          - maybe
-          - prelude
-          - tuples
-          - undefined-is-not-a-problem
-      elmish-html:
-        repo: https://github.com/collegevine/purescript-elmish-html.git
-        version: v0.7.1
-        dependencies:
-          - effect
-          - elmish
-          - foreign
-          - foreign-object
-          - prelude
-          - record
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-html
-      email-validate:
-        repo: https://github.com/cdepillabout/purescript-email-validate.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - string-parsers
-          - transformers
-      encoding:
-        repo: https://github.com/menelaos/purescript-encoding.git
-        version: v0.0.8
-        dependencies:
-          - arraybuffer-types
-          - either
-          - exceptions
-          - functions
-          - prelude
-      enums:
-        repo: https://github.com/purescript/purescript-enums.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - either
-          - gen
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tuples
-          - unfoldable
-      exceptions:
-        repo: https://github.com/purescript/purescript-exceptions.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - either
-          - maybe
-          - prelude
-      exists:
-        repo: https://github.com/purescript/purescript-exists.git
-        version: v6.0.0
-        dependencies:
-          - unsafe-coerce
-      exitcodes:
-        repo: https://github.com/Risto-Stevcev/purescript-exitcodes.git
-        version: v4.0.0
-        dependencies:
-          - enums
-      expect-inferred:
-        repo: https://github.com/justinwoo/purescript-expect-inferred.git
-        version: v3.0.0
-        dependencies:
-          - prelude
-          - typelevel-prelude
-      fast-vect:
-        repo: https://github.com/sigma-andex/purescript-fast-vect.git
-        version: v0.7.0
-        dependencies:
-          - arrays
-          - filterable
-          - foldable-traversable
-          - lists
-          - maybe
-          - ordered-collections
-          - prelude
-          - profunctor
-          - tuples
-          - unfoldable
-      filterable:
-        repo: https://github.com/purescript/purescript-filterable.git
-        version: v5.0.0
-        dependencies:
-          - arrays
-          - either
-          - foldable-traversable
-          - identity
-          - lists
-          - ordered-collections
-      fixed-points:
-        repo: https://github.com/purescript-contrib/purescript-fixed-points.git
-        version: v7.0.0
-        dependencies:
-          - exists
-          - newtype
-          - prelude
-          - transformers
-      fixed-precision:
-        repo: https://github.com/lumihq/purescript-fixed-precision.git
-        version: v5.0.0
-        dependencies:
-          - arrays
-          - bigints
-          - control
-          - integers
-          - maybe
-          - numbers
-          - partial
-          - prelude
-          - strings
-      flame:
-        repo: https://github.com/easafe/purescript-flame.git
-        version: v1.2.0
-        dependencies:
-          - aff
-          - argonaut-codecs
-          - argonaut-core
-          - argonaut-generic
-          - arrays
-          - bifunctors
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - maybe
-          - newtype
-          - nullable
-          - partial
-          - prelude
-          - random
-          - refs
-          - spec
-          - strings
-          - tuples
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-html
-          - web-uievents
-      float32:
-        repo: https://github.com/purescript-contrib/purescript-float32.git
-        version: v2.0.0
-        dependencies:
-          - gen
-          - maybe
-          - prelude
-      foldable-traversable:
-        repo: https://github.com/purescript/purescript-foldable-traversable.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - const
-          - control
-          - either
-          - functors
-          - identity
-          - maybe
-          - newtype
-          - orders
-          - prelude
-          - tuples
-      foreign:
-        repo: https://github.com/purescript/purescript-foreign.git
-        version: v7.0.0
-        dependencies:
-          - either
-          - functions
-          - identity
-          - integers
-          - lists
-          - maybe
-          - prelude
-          - strings
-          - transformers
-      foreign-object:
-        repo: https://github.com/purescript/purescript-foreign-object.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - functions
-          - gen
-          - lists
-          - maybe
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - typelevel-prelude
-          - unfoldable
-      foreign-readwrite:
-        repo: https://github.com/artemisSystem/purescript-foreign-readwrite.git
-        version: v3.0.0
-        dependencies:
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - record
-          - safe-coerce
-          - transformers
-          - unsafe-coerce
-      fork:
-        repo: https://github.com/purescript-contrib/purescript-fork.git
-        version: v6.0.0
-        dependencies:
-          - aff
-      form-urlencoded:
-        repo: https://github.com/purescript-contrib/purescript-form-urlencoded.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - js-uri
-          - maybe
-          - newtype
-          - prelude
-          - strings
-          - tuples
-      formatters:
-        repo: https://github.com/purescript-contrib/purescript-formatters.git
-        version: v7.0.0
-        dependencies:
-          - datetime
-          - fixed-points
-          - lists
-          - numbers
-          - parsing
-          - prelude
-          - transformers
-      free:
-        repo: https://github.com/purescript/purescript-free.git
-        version: v7.0.0
-        dependencies:
-          - catenable-lists
-          - control
-          - distributive
-          - either
-          - exists
-          - foldable-traversable
-          - invariant
-          - lazy
-          - maybe
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-      freeap:
-        repo: https://github.com/ethul/purescript-freeap.git
-        version: v7.0.0
-        dependencies:
-          - const
-          - exists
-          - gen
-          - lists
-      freet:
-        repo: https://github.com/purescript-contrib/purescript-freet.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - bifunctors
-          - effect
-          - either
-          - exists
-          - free
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      functions:
-        repo: https://github.com/purescript/purescript-functions.git
-        version: v6.0.0
-        dependencies:
-          - prelude
-      functors:
-        repo: https://github.com/purescript/purescript-functors.git
-        version: v5.0.0
-        dependencies:
-          - bifunctors
-          - const
-          - contravariant
-          - control
-          - distributive
-          - either
-          - invariant
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - tuples
-          - unsafe-coerce
-      fuzzy:
-        repo: https://github.com/citizennet/purescript-fuzzy.git
-        version: v0.4.0
-        dependencies:
-          - foldable-traversable
-          - foreign-object
-          - newtype
-          - ordered-collections
-          - prelude
-          - rationals
-          - strings
-          - tuples
-      gen:
-        repo: https://github.com/purescript/purescript-gen.git
-        version: v4.0.0
-        dependencies:
-          - either
-          - foldable-traversable
-          - identity
-          - maybe
-          - newtype
-          - nonempty
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      generate-values:
-        repo: https://github.com/jordanmartinez/purescript-generate-values.git
-        version: v1.0.1
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - enums
-          - foldable-traversable
-          - gen
-          - identity
-          - integers
-          - lcg
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - partial
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      geometry-plane:
-        repo: https://github.com/Ebmtranceboy/purescript-geometry-plane.git
-        version: v1.0.3
-        dependencies:
-          - console
-          - effect
-          - psci-support
-          - sparse-polynomials
-      github-actions-toolkit:
-        repo: https://github.com/purescript-contrib/purescript-github-actions-toolkit.git
-        version: v0.5.0
-        dependencies:
-          - aff
-          - aff-promise
-          - effect
-          - foreign-object
-          - node-buffer
-          - node-path
-          - node-streams
-          - nullable
-          - transformers
-      graphs:
-        repo: https://github.com/purescript/purescript-graphs.git
-        version: v8.0.0
-        dependencies:
-          - catenable-lists
-          - ordered-collections
-      group:
-        repo: https://github.com/morganthomas/purescript-group.git
-        version: v4.1.1
-        dependencies:
-          - lists
-      halogen:
-        repo: https://github.com/purescript-halogen/purescript-halogen.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - avar
-          - console
-          - const
-          - dom-indexed
-          - effect
-          - foreign
-          - fork
-          - free
-          - freeap
-          - halogen-subscriptions
-          - halogen-vdom
-          - media-types
-          - nullable
-          - ordered-collections
-          - parallel
-          - profunctor
-          - transformers
-          - unsafe-coerce
-          - unsafe-reference
-          - web-file
-          - web-uievents
-      halogen-css:
-        repo: https://github.com/purescript-halogen/purescript-halogen-css.git
-        version: v10.0.0
-        dependencies:
-          - css
-          - halogen
-      halogen-formless:
-        repo: https://github.com/thomashoneyman/purescript-halogen-formless.git
-        version: v4.0.0
-        dependencies:
-          - convertable-options
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - halogen
-          - heterogeneous
-          - maybe
-          - prelude
-          - record
-          - safe-coerce
-          - type-equality
-          - unsafe-coerce
-          - unsafe-reference
-          - variant
-          - web-events
-          - web-uievents
-      halogen-hooks:
-        repo: https://github.com/thomashoneyman/purescript-halogen-hooks.git
-        version: v0.6.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - effect
-          - exceptions
-          - foldable-traversable
-          - foreign-object
-          - free
-          - freeap
-          - halogen
-          - halogen-subscriptions
-          - maybe
-          - newtype
-          - ordered-collections
-          - parallel
-          - partial
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-          - unsafe-reference
-          - web-dom
-          - web-html
-      halogen-hooks-extra:
-        repo: https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git
-        version: v0.9.0
-        dependencies:
-          - halogen-hooks
-      halogen-store:
-        repo: https://github.com/thomashoneyman/purescript-halogen-store.git
-        version: v0.5.0
-        dependencies:
-          - aff
-          - distributive
-          - effect
-          - fork
-          - halogen
-          - halogen-hooks
-          - halogen-subscriptions
-          - maybe
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-reference
-      halogen-storybook:
-        repo: https://github.com/rnons/purescript-halogen-storybook.git
-        version: v2.0.0
-        dependencies:
-          - foreign-object
-          - halogen
-          - prelude
-          - routing
-      halogen-subscriptions:
-        repo: https://github.com/purescript-halogen/purescript-halogen-subscriptions.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - effect
-          - foldable-traversable
-          - functors
-          - refs
-          - safe-coerce
-          - unsafe-reference
-      halogen-svg-elems:
-        repo: https://github.com/JordanMartinez/purescript-halogen-svg-elems.git
-        version: v6.0.0
-        dependencies:
-          - halogen
-      halogen-vdom:
-        repo: https://github.com/purescript-halogen/purescript-halogen-vdom.git
-        version: v8.0.0
-        dependencies:
-          - bifunctors
-          - effect
-          - foreign
-          - foreign-object
-          - maybe
-          - prelude
-          - refs
-          - tuples
-          - unsafe-coerce
-          - web-html
-      halogen-vdom-string-renderer:
-        repo: https://github.com/purescript-halogen/purescript-halogen-vdom-string-renderer.git
-        version: v0.5.0
-        dependencies:
-          - foreign
-          - halogen-vdom
-          - ordered-collections
-          - prelude
-      heckin:
-        repo: https://github.com/maxdeviant/purescript-heckin.git
-        version: v2.0.1
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - maybe
-          - prelude
-          - strings
-          - transformers
-          - tuples
-          - unicode
-      heterogeneous:
-        repo: https://github.com/natefaubion/purescript-heterogeneous.git
-        version: v0.6.0
-        dependencies:
-          - either
-          - functors
-          - prelude
-          - record
-          - tuples
-          - variant
-      heterogeneous-extrablatt:
-        repo: https://github.com/sigma-andex/purescript-heterogeneous-extrablatt.git
-        version: v0.2.1
-        dependencies:
-          - heterogeneous
-          - prelude
-          - record
-      http-methods:
-        repo: https://github.com/purescript-contrib/purescript-http-methods.git
-        version: v6.0.0
-        dependencies:
-          - either
-          - prelude
-          - strings
-      httpure:
-        repo: https://github.com/citizennet/purescript-httpure.git
-        version: v0.15.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - js-uri
-          - maybe
-          - newtype
-          - node-buffer
-          - node-fs
-          - node-http
-          - node-streams
-          - options
-          - ordered-collections
-          - prelude
-          - refs
-          - strings
-          - tuples
-          - type-equality
-      httpurple:
-        repo: https://github.com/sigma-andex/purescript-httpurple.git
-        version: v1.3.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - js-uri
-          - justifill
-          - maybe
-          - newtype
-          - node-buffer
-          - node-fs
-          - node-http
-          - node-net
-          - node-process
-          - node-streams
-          - options
-          - ordered-collections
-          - posix-types
-          - prelude
-          - profunctor
-          - record
-          - refs
-          - routing-duplex
-          - strings
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-      httpurple-argonaut:
-        repo: https://github.com/sigma-andex/purescript-httpurple-argonaut.git
-        version: v1.0.1
-        dependencies:
-          - argonaut
-          - console
-          - effect
-          - either
-          - httpurple
-          - prelude
-      httpurple-yoga-json:
-        repo: https://github.com/sigma-andex/purescript-httpurple-yoga-json.git
-        version: v1.0.0
-        dependencies:
-          - console
-          - effect
-          - either
-          - foreign
-          - httpurple
-          - lists
-          - prelude
-          - yoga-json
-      identity:
-        repo: https://github.com/purescript/purescript-identity.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - invariant
-          - newtype
-          - prelude
-      indexed-monad:
-        repo: https://github.com/garyb/purescript-indexed-monad.git
-        version: v2.1.0
-        dependencies:
-          - control
-          - newtype
-      int64:
-        repo: https://github.com/purescript-contrib/purescript-int64.git
-        version: v2.0.0
-        dependencies:
-          - effect
-          - foreign
-          - functions
-          - integers
-          - maybe
-          - nullable
-          - prelude
-          - quickcheck
-      integers:
-        repo: https://github.com/purescript/purescript-integers.git
-        version: v6.0.0
-        dependencies:
-          - maybe
-          - numbers
-          - prelude
-      interpolate:
-        repo: https://github.com/jordanmartinez/purescript-interpolate.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-      invariant:
-        repo: https://github.com/purescript/purescript-invariant.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - prelude
-      js-date:
-        repo: https://github.com/purescript-contrib/purescript-js-date.git
-        version: v8.0.0
-        dependencies:
-          - datetime
-          - effect
-          - exceptions
-          - foreign
-          - integers
-          - now
-      js-fileio:
-        repo: https://github.com/newlandsvalley/purescript-js-fileio.git
-        version: v3.0.0
-        dependencies:
-          - aff
-          - effect
-          - prelude
-      js-timers:
-        repo: https://github.com/purescript-contrib/purescript-js-timers.git
-        version: v6.1.0
-        dependencies:
-          - effect
-      js-uri:
-        repo: https://github.com/purescript-contrib/purescript-js-uri.git
-        version: v3.0.0
-        dependencies:
-          - functions
-          - maybe
-      justifill:
-        repo: https://github.com/i-am-the-slime/purescript-justifill.git
-        version: v0.5.0
-        dependencies:
-          - maybe
-          - prelude
-          - record
-          - typelevel-prelude
-      jwt:
-        repo: https://github.com/menelaos/purescript-jwt.git
-        version: v0.0.9
-        dependencies:
-          - argonaut-core
-          - arrays
-          - b64
-          - either
-          - exceptions
-          - prelude
-          - profunctor-lenses
-          - strings
-      language-cst-parser:
-        repo: https://github.com/natefaubion/purescript-language-cst-parser.git
-        version: v0.12.0
-        dependencies:
-          - arrays
-          - const
-          - control
-          - either
-          - foldable-traversable
-          - free
-          - functions
-          - functors
-          - identity
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - ordered-collections
-          - partial
-          - prelude
-          - st
-          - strings
-          - transformers
-          - tuples
-          - typelevel-prelude
-          - unfoldable
-          - unsafe-coerce
-      lazy:
-        repo: https://github.com/purescript/purescript-lazy.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - invariant
-          - prelude
-      lcg:
-        repo: https://github.com/purescript/purescript-lcg.git
-        version: v4.0.0
-        dependencies:
-          - effect
-          - integers
-          - maybe
-          - partial
-          - prelude
-          - random
-      leibniz:
-        repo: https://github.com/paf31/purescript-leibniz.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-          - unsafe-coerce
-      linalg:
-        repo: https://github.com/gbagan/purescript-linalg.git
-        version: v5.1.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - functions
-          - maybe
-          - prelude
-          - tuples
-      lists:
-        repo: https://github.com/purescript/purescript-lists.git
-        version: v7.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - foldable-traversable
-          - lazy
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      logging:
-        repo: https://github.com/rightfold/purescript-logging.git
-        version: v3.0.0
-        dependencies:
-          - console
-          - contravariant
-          - effect
-          - either
-          - prelude
-          - transformers
-          - tuples
-      machines:
-        repo: https://github.com/purescript-contrib/purescript-machines.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - lists
-          - maybe
-          - prelude
-          - profunctor
-          - tuples
-          - unfoldable
-      matrices:
-        repo: https://github.com/kRITZCREEK/purescript-matrices.git
-        version: v5.0.1
-        dependencies:
-          - arrays
-          - strings
-      matryoshka:
-        repo: https://github.com/purescript-contrib/purescript-matryoshka.git
-        version: v1.0.0
-        dependencies:
-          - fixed-points
-          - free
-          - prelude
-          - profunctor
-          - transformers
-      maybe:
-        repo: https://github.com/purescript/purescript-maybe.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - invariant
-          - newtype
-          - prelude
-      media-types:
-        repo: https://github.com/purescript-contrib/purescript-media-types.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      metadata:
-        repo: https://github.com/purescript/purescript-metadata.git
-        version: v0.15.0
-        dependencies: []
-      midi:
-        repo: https://github.com/newlandsvalley/purescript-midi.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - ordered-collections
-          - prelude
-          - signal
-          - string-parsers
-          - strings
-          - tuples
-          - unfoldable
-      minibench:
-        repo: https://github.com/purescript/purescript-minibench.git
-        version: v4.0.0
-        dependencies:
-          - console
-          - effect
-          - integers
-          - numbers
-          - partial
-          - prelude
-          - refs
-      mmorph:
-        repo: https://github.com/Thimoteus/purescript-mmorph.git
-        version: v7.0.0
-        dependencies:
-          - free
-          - functors
-          - transformers
-      monad-control:
-        repo: https://github.com/athanclark/purescript-monad-control.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - freet
-          - identity
-          - lists
-      monad-logger:
-        repo: https://github.com/cprussin/purescript-monad-logger.git
-        version: v1.3.1
-        dependencies:
-          - aff
-          - ansi
-          - argonaut
-          - arrays
-          - console
-          - control
-          - effect
-          - foldable-traversable
-          - foreign-object
-          - integers
-          - js-date
-          - maybe
-          - newtype
-          - ordered-collections
-          - prelude
-          - strings
-          - transformers
-          - tuples
-      monad-loops:
-        repo: https://github.com/mlang/purescript-monad-loops.git
-        version: v0.5.0
-        dependencies:
-          - lists
-          - maybe
-          - prelude
-          - tailrec
-          - tuples
-      monad-unlift:
-        repo: https://github.com/athanclark/purescript-monad-unlift.git
-        version: v1.0.1
-        dependencies:
-          - monad-control
-      monoidal:
-        repo: https://github.com/mcneissue/purescript-monoidal.git
-        version: v0.16.0
-        dependencies:
-          - either
-          - profunctor
-          - these
-          - tuples
-      morello:
-        repo: https://github.com/sigma-andex/purescript-morello.git
-        version: v0.3.2
-        dependencies:
-          - arrays
-          - barlow-lens
-          - foldable-traversable
-          - heterogeneous
-          - heterogeneous-extrablatt
-          - newtype
-          - prelude
-          - profunctor
-          - profunctor-lenses
-          - record
-          - tuples
-          - typelevel-prelude
-          - validation
-      motsunabe:
-        repo: https://github.com/justinwoo/purescript-motsunabe.git
-        version: v2.0.0
-        dependencies:
-          - lists
-          - strings
-      nano-id:
-        repo: https://github.com/eikooc/nano-id.git
-        version: v1.1.0
-        dependencies:
-          - aff
-          - effect
-          - lists
-          - maybe
-          - prelude
-          - random
-          - spec
-          - strings
-          - stringutils
-      naturals:
-        repo: https://github.com/LiamGoodacre/purescript-naturals.git
-        version: v3.0.0
-        dependencies:
-          - enums
-          - maybe
-          - prelude
-      nested-functor:
-        repo: https://github.com/acple/purescript-nested-functor.git
-        version: v0.2.1
-        dependencies:
-          - prelude
-          - type-equality
-      newtype:
-        repo: https://github.com/purescript/purescript-newtype.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-          - safe-coerce
-      node-buffer:
-        repo: https://github.com/purescript-node/purescript-node-buffer.git
-        version: v8.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - maybe
-          - st
-          - unsafe-coerce
-      node-buffer-blob:
-        repo: https://github.com/purescript-node/purescript-node-buffer-blob.git
-        version: v1.0.0
-        dependencies:
-          - aff-promise
-          - arraybuffer-types
-          - arrays
-          - console
-          - effect
-          - maybe
-          - media-types
-          - newtype
-          - node-buffer
-          - nullable
-          - prelude
-          - web-streams
-      node-child-process:
-        repo: https://github.com/purescript-node/purescript-node-child-process.git
-        version: v9.0.0
-        dependencies:
-          - exceptions
-          - foreign
-          - foreign-object
-          - functions
-          - node-fs
-          - node-streams
-          - nullable
-          - posix-types
-          - unsafe-coerce
-      node-fs:
-        repo: https://github.com/purescript-node/purescript-node-fs.git
-        version: v8.0.0
-        dependencies:
-          - datetime
-          - effect
-          - either
-          - enums
-          - exceptions
-          - functions
-          - integers
-          - js-date
-          - maybe
-          - node-buffer
-          - node-path
-          - node-streams
-          - nullable
-          - partial
-          - prelude
-          - strings
-          - unsafe-coerce
-      node-fs-aff:
-        repo: https://github.com/purescript-node/purescript-node-fs-aff.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - either
-          - node-fs
-          - node-path
-      node-http:
-        repo: https://github.com/purescript-node/purescript-node-http.git
-        version: v8.0.0
-        dependencies:
-          - arraybuffer-types
-          - contravariant
-          - effect
-          - foreign
-          - foreign-object
-          - maybe
-          - node-buffer
-          - node-net
-          - node-streams
-          - node-url
-          - nullable
-          - options
-          - prelude
-          - unsafe-coerce
-      node-net:
-        repo: https://github.com/purescript-node/purescript-node-net.git
-        version: v4.0.0
-        dependencies:
-          - effect
-          - either
-          - exceptions
-          - foreign
-          - maybe
-          - node-buffer
-          - node-fs
-          - nullable
-          - options
-          - prelude
-          - transformers
-      node-path:
-        repo: https://github.com/purescript-node/purescript-node-path.git
-        version: v5.0.0
-        dependencies:
-          - effect
-      node-process:
-        repo: https://github.com/purescript-node/purescript-node-process.git
-        version: v10.0.0
-        dependencies:
-          - effect
-          - foreign-object
-          - maybe
-          - node-streams
-          - posix-types
-          - prelude
-          - unsafe-coerce
-      node-readline:
-        repo: https://github.com/purescript-node/purescript-node-readline.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - foreign
-          - node-process
-          - node-streams
-          - options
-          - prelude
-      node-streams:
-        repo: https://github.com/purescript-node/purescript-node-streams.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - either
-          - exceptions
-          - node-buffer
-          - nullable
-          - prelude
-      node-streams-aff:
-        repo: https://github.com/jamesdbrock/purescript-node-streams-aff.git
-        version: v2.0.0
-        dependencies:
-          - aff
-          - arrays
-          - effect
-          - either
-          - exceptions
-          - maybe
-          - node-buffer
-          - node-streams
-          - prelude
-          - st
-          - tuples
-      node-url:
-        repo: https://github.com/purescript-node/purescript-node-url.git
-        version: v6.0.0
-        dependencies:
-          - nullable
-      nonempty:
-        repo: https://github.com/purescript/purescript-nonempty.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - maybe
-          - prelude
-          - tuples
-          - unfoldable
-      now:
-        repo: https://github.com/purescript-contrib/purescript-now.git
-        version: v6.0.0
-        dependencies:
-          - datetime
-          - effect
-      npm-package-json:
-        repo: https://github.com/maxdeviant/purescript-npm-package-json.git
-        version: v2.0.0
-        dependencies:
-          - argonaut
-          - control
-          - either
-          - foreign-object
-          - maybe
-          - ordered-collections
-          - prelude
-      nullable:
-        repo: https://github.com/purescript-contrib/purescript-nullable.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - functions
-          - maybe
-      numbers:
-        repo: https://github.com/purescript/purescript-numbers.git
-        version: v9.0.0
-        dependencies:
-          - functions
-          - maybe
-      open-folds:
-        repo: https://github.com/purescript-open-community/purescript-open-folds.git
-        version: v6.3.0
-        dependencies:
-          - bifunctors
-          - console
-          - control
-          - distributive
-          - effect
-          - either
-          - foldable-traversable
-          - identity
-          - invariant
-          - maybe
-          - newtype
-          - ordered-collections
-          - prelude
-          - profunctor
-          - psci-support
-          - tuples
-      open-memoize:
-        repo: https://github.com/purescript-open-community/purescript-open-memoize.git
-        version: v6.1.0
-        dependencies:
-          - console
-          - effect
-          - either
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - psci-support
-          - strings
-          - tuples
-      open-pairing:
-        repo: https://github.com/purescript-open-community/purescript-open-pairing.git
-        version: v6.1.0
-        dependencies:
-          - console
-          - control
-          - effect
-          - either
-          - free
-          - functors
-          - identity
-          - newtype
-          - prelude
-          - psci-support
-          - transformers
-          - tuples
-      options:
-        repo: https://github.com/purescript-contrib/purescript-options.git
-        version: v7.0.0
-        dependencies:
-          - contravariant
-          - foreign
-          - foreign-object
-          - maybe
-          - tuples
-      optparse:
-        repo: https://github.com/f-o-a-m/purescript-optparse.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - control
-          - effect
-          - either
-          - enums
-          - exists
-          - exitcodes
-          - foldable-traversable
-          - free
-          - gen
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - newtype
-          - node-buffer
-          - node-process
-          - node-streams
-          - nonempty
-          - numbers
-          - open-memoize
-          - partial
-          - prelude
-          - quickcheck
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-      ordered-collections:
-        repo: https://github.com/purescript/purescript-ordered-collections.git
-        version: v3.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - gen
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - unfoldable
-      ordered-set:
-        repo: https://github.com/flip111/purescript-ordered-set.git
-        version: v0.4.0
-        dependencies:
-          - argonaut-codecs
-          - arrays
-          - partial
-          - prelude
-          - unfoldable
-      orders:
-        repo: https://github.com/purescript/purescript-orders.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      pairs:
-        repo: https://github.com/sharkdp/purescript-pairs.git
-        version: v9.0.0
-        dependencies:
-          - console
-          - distributive
-          - foldable-traversable
-          - quickcheck
-      parallel:
-        repo: https://github.com/purescript/purescript-parallel.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - functors
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - refs
-          - transformers
-      parsing:
-        repo: https://github.com/purescript-contrib/purescript-parsing.git
-        version: v9.1.0
-        dependencies:
-          - arrays
-          - either
-          - foldable-traversable
-          - identity
-          - integers
-          - lists
-          - maybe
-          - nullable
-          - prelude
-          - strings
-          - transformers
-          - unicode
-      parsing-dataview:
-        repo: https://github.com/jamesdbrock/purescript-parsing-dataview.git
-        version: v3.1.0
-        dependencies:
-          - arraybuffer
-          - arraybuffer-types
-          - effect
-          - float32
-          - maybe
-          - parsing
-          - prelude
-          - transformers
-          - tuples
-          - uint
-      partial:
-        repo: https://github.com/purescript/purescript-partial.git
-        version: v4.0.0
-        dependencies: []
-      pathy:
-        repo: https://github.com/purescript-contrib/purescript-pathy.git
-        version: v9.0.0
-        dependencies:
-          - console
-          - exceptions
-          - lists
-          - partial
-          - profunctor
-          - strings
-          - transformers
-          - typelevel-prelude
-          - unsafe-coerce
-      pha:
-        repo: https://github.com/gbagan/purescript-pha.git
-        version: v0.9.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - datetime
-          - effect
-          - foldable-traversable
-          - free
-          - integers
-          - maybe
-          - prelude
-          - profunctor-lenses
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-          - unsafe-reference
-          - web-dom
-          - web-events
-          - web-html
-          - web-pointerevents
-          - web-uievents
-      phaser:
-        repo: https://github.com/lfarroco/purescript-phaser.git
-        version: v0.6.0
-        dependencies:
-          - canvas
-          - console
-          - effect
-          - maybe
-          - nullable
-          - options
-          - prelude
-          - web-html
-      pipes:
-        repo: https://github.com/felixschl/purescript-pipes.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - lists
-          - mmorph
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      point-free:
-        repo: https://github.com/ursi/purescript-point-free.git
-        version: v1.0.0
-        dependencies:
-          - prelude
-      polymorphic-vectors:
-        repo: https://github.com/artemisSystem/purescript-polymorphic-vectors.git
-        version: v4.0.0
-        dependencies:
-          - distributive
-          - foldable-traversable
-          - numbers
-          - prelude
-          - record
-          - safe-coerce
-          - type-equality
-          - typelevel-prelude
-      posix-types:
-        repo: https://github.com/purescript-node/purescript-posix-types.git
-        version: v6.0.0
-        dependencies:
-          - maybe
-          - prelude
-      precise:
-        repo: https://github.com/purescript-contrib/purescript-precise.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - exceptions
-          - gen
-          - integers
-          - lists
-          - numbers
-          - prelude
-          - strings
-      precise-datetime:
-        repo: https://github.com/awakesecurity/purescript-precise-datetime.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - datetime
-          - decimals
-          - either
-          - enums
-          - foldable-traversable
-          - formatters
-          - integers
-          - js-date
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - strings
-          - tuples
-          - unicode
-      prelude:
-        repo: https://github.com/purescript/purescript-prelude.git
-        version: v6.0.0
-        dependencies: []
-      prettier-printer:
-        repo: https://github.com/paulyoung/purescript-prettier-printer.git
-        version: v3.0.0
-        dependencies:
-          - console
-          - lists
-          - prelude
-          - strings
-          - tuples
-      profunctor:
-        repo: https://github.com/purescript/purescript-profunctor.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - distributive
-          - either
-          - exists
-          - invariant
-          - newtype
-          - prelude
-          - tuples
-      profunctor-lenses:
-        repo: https://github.com/purescript-contrib/purescript-profunctor-lenses.git
-        version: v8.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - const
-          - control
-          - distributive
-          - either
-          - foldable-traversable
-          - foreign-object
-          - functors
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - ordered-collections
-          - partial
-          - prelude
-          - profunctor
-          - record
-          - transformers
-          - tuples
-      protobuf:
-        repo: https://github.com/xc-jp/purescript-protobuf.git
-        version: v4.0.0
-        dependencies:
-          - arraybuffer
-          - arraybuffer-builder
-          - arraybuffer-types
-          - arrays
-          - control
-          - effect
-          - either
-          - enums
-          - exceptions
-          - float32
-          - foldable-traversable
-          - functions
-          - int64
-          - maybe
-          - newtype
-          - parsing
-          - parsing-dataview
-          - prelude
-          - record
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-          - uint
-          - web-encoding
-      ps-cst:
-        repo: https://github.com/purescript-codegen/purescript-ps-cst.git
-        version: v1.2.0
-        dependencies:
-          - ansi
-          - console
-          - dodo-printer
-          - effect
-          - node-fs-aff
-          - node-path
-          - psci-support
-          - record
-          - strings
-      psa-utils:
-        repo: https://github.com/natefaubion/purescript-psa-utils.git
-        version: v8.0.0
-        dependencies:
-          - ansi
-          - argonaut-codecs
-          - argonaut-core
-          - arrays
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - maybe
-          - node-path
-          - ordered-collections
-          - prelude
-          - strings
-          - tuples
-          - unsafe-coerce
-      psc-ide:
-        repo: https://github.com/kRITZCREEK/purescript-psc-ide.git
-        version: v19.0.0
-        dependencies:
-          - aff
-          - argonaut
-          - arrays
-          - console
-          - maybe
-          - node-child-process
-          - node-fs
-          - parallel
-          - random
-      psci-support:
-        repo: https://github.com/purescript/purescript-psci-support.git
-        version: v6.0.0
-        dependencies:
-          - console
-          - effect
-          - prelude
-      qualified-do:
-        repo: https://github.com/artemisSystem/purescript-qualified-do.git
-        version: v2.2.0
-        dependencies:
-          - arrays
-          - control
-          - foldable-traversable
-          - parallel
-          - prelude
-          - unfoldable
-      quantities:
-        repo: https://github.com/sharkdp/purescript-quantities.git
-        version: v12.0.1
-        dependencies:
-          - decimals
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - newtype
-          - nonempty
-          - numbers
-          - pairs
-          - prelude
-          - tuples
-      quickcheck:
-        repo: https://github.com/purescript/purescript-quickcheck.git
-        version: v8.0.1
-        dependencies:
-          - arrays
-          - console
-          - control
-          - effect
-          - either
-          - enums
-          - exceptions
-          - foldable-traversable
-          - gen
-          - identity
-          - integers
-          - lazy
-          - lcg
-          - lists
-          - maybe
-          - newtype
-          - nonempty
-          - numbers
-          - partial
-          - prelude
-          - record
-          - st
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-          - unfoldable
-      quickcheck-combinators:
-        repo: https://github.com/athanclark/purescript-quickcheck-combinators.git
-        version: v0.1.3
-        dependencies:
-          - quickcheck
-          - typelevel
-      quickcheck-laws:
-        repo: https://github.com/purescript-contrib/purescript-quickcheck-laws.git
-        version: v7.0.0
-        dependencies:
-          - enums
-          - quickcheck
-      quickcheck-utf8:
-        repo: https://github.com/openchronology/purescript-quickcheck-utf8.git
-        version: v0.0.0
-        dependencies:
-          - quickcheck
-      quotient:
-        repo: https://github.com/rightfold/purescript-quotient.git
-        version: v3.0.0
-        dependencies:
-          - prelude
-          - quickcheck
-      random:
-        repo: https://github.com/purescript/purescript-random.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - integers
-      rationals:
-        repo: https://github.com/anttih/purescript-rationals.git
-        version: v5.0.0
-        dependencies:
-          - integers
-          - prelude
-      react:
-        repo: https://github.com/purescript-contrib/purescript-react.git
-        version: v10.0.1
-        dependencies:
-          - effect
-          - exceptions
-          - maybe
-          - nullable
-          - prelude
-          - typelevel-prelude
-          - unsafe-coerce
-      react-basic:
-        repo: https://github.com/lumihq/purescript-react-basic.git
-        version: v17.0.0
-        dependencies:
-          - effect
-          - prelude
-          - record
-      react-basic-dom:
-        repo: https://github.com/lumihq/purescript-react-basic-dom.git
-        version: v5.0.0
-        dependencies:
-          - effect
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - nullable
-          - prelude
-          - react-basic
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-file
-          - web-html
-      react-basic-hooks:
-        repo: https://github.com/megamaddu/purescript-react-basic-hooks.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - aff-promise
-          - bifunctors
-          - console
-          - control
-          - datetime
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - functions
-          - indexed-monad
-          - integers
-          - maybe
-          - newtype
-          - now
-          - nullable
-          - ordered-collections
-          - prelude
-          - react-basic
-          - refs
-          - tuples
-          - type-equality
-          - unsafe-coerce
-          - unsafe-reference
-          - web-html
-      react-dom:
-        repo: https://github.com/purescript-contrib/purescript-react-dom.git
-        version: v8.0.0
-        dependencies:
-          - effect
-          - react
-          - web-dom
-      read:
-        repo: https://github.com/truqu/purescript-read.git
-        version: v1.0.1
-        dependencies:
-          - maybe
-          - prelude
-          - strings
-      record:
-        repo: https://github.com/purescript/purescript-record.git
-        version: v4.0.0
-        dependencies:
-          - functions
-          - prelude
-          - unsafe-coerce
-      refined:
-        repo: https://github.com/danieljharvey/purescript-refined.git
-        version: v1.0.0
-        dependencies:
-          - argonaut
-          - effect
-          - prelude
-          - quickcheck
-          - typelevel
-      refs:
-        repo: https://github.com/purescript/purescript-refs.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - prelude
-      remotedata:
-        repo: https://github.com/krisajenkins/purescript-remotedata.git
-        version: v5.0.0
-        dependencies:
-          - bifunctors
-          - either
-          - profunctor-lenses
-      resource:
-        repo: https://github.com/joneshf/purescript-resource.git
-        version: v2.0.1
-        dependencies:
-          - aff
-          - console
-          - control
-          - effect
-          - newtype
-          - prelude
-          - psci-support
-          - refs
-      resourcet:
-        repo: https://github.com/robertdp/purescript-resourcet.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - effect
-          - foldable-traversable
-          - maybe
-          - ordered-collections
-          - parallel
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-      result:
-        repo: https://github.com/ad-si/purescript-result.git
-        version: v1.0.3
-        dependencies:
-          - either
-          - foldable-traversable
-          - prelude
-      return:
-        repo: https://github.com/ursi/purescript-return.git
-        version: v0.2.0
-        dependencies:
-          - foldable-traversable
-          - point-free
-          - prelude
-      ring-modules:
-        repo: https://github.com/f-o-a-m/purescript-ring-modules.git
-        version: v5.0.1
-        dependencies:
-          - prelude
-      routing:
-        repo: https://github.com/purescript-contrib/purescript-routing.git
-        version: v11.0.0
-        dependencies:
-          - aff
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - integers
-          - js-uri
-          - lists
-          - maybe
-          - numbers
-          - partial
-          - prelude
-          - semirings
-          - tuples
-          - validation
-          - web-html
-      routing-duplex:
-        repo: https://github.com/natefaubion/purescript-routing-duplex.git
-        version: v0.6.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - js-uri
-          - lazy
-          - numbers
-          - prelude
-          - profunctor
-          - record
-          - strings
-          - typelevel-prelude
-      run:
-        repo: https://github.com/natefaubion/purescript-run.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - free
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - tailrec
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - variant
-      safe-coerce:
-        repo: https://github.com/purescript/purescript-safe-coerce.git
-        version: v2.0.0
-        dependencies:
-          - unsafe-coerce
-      safely:
-        repo: https://github.com/paf31/purescript-safely.git
-        version: v4.0.1
-        dependencies:
-          - freet
-          - lists
-      selection-foldable:
-        repo: https://github.com/jamieyung/purescript-selection-foldable.git
-        version: v0.2.0
-        dependencies:
-          - filterable
-          - foldable-traversable
-          - maybe
-          - prelude
-      semirings:
-        repo: https://github.com/purescript/purescript-semirings.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - lists
-          - newtype
-          - prelude
-      signal:
-        repo: https://github.com/bodil/purescript-signal.git
-        version: v13.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - foldable-traversable
-          - maybe
-          - prelude
-      simple-emitter:
-        repo: https://github.com/oreshinya/purescript-simple-emitter.git
-        version: v2.0.0
-        dependencies:
-          - ordered-collections
-          - refs
-      sized-matrices:
-        repo: https://github.com/csicar/purescript-sized-matrices.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - distributive
-          - foldable-traversable
-          - maybe
-          - prelude
-          - sized-vectors
-          - strings
-          - typelevel
-          - unfoldable
-          - vectorfield
-      sized-vectors:
-        repo: https://github.com/bodil/purescript-sized-vectors.git
-        version: v5.0.2
-        dependencies:
-          - argonaut
-          - arrays
-          - distributive
-          - foldable-traversable
-          - maybe
-          - prelude
-          - quickcheck
-          - typelevel
-          - unfoldable
-      slug:
-        repo: https://github.com/thomashoneyman/purescript-slug.git
-        version: v3.0.1
-        dependencies:
-          - argonaut-codecs
-          - maybe
-          - prelude
-          - strings
-          - unicode
-      soundfonts:
-        repo: https://github.com/newlandsvalley/purescript-soundfonts.git
-        version: v4.1.0
-        dependencies:
-          - aff
-          - affjax
-          - affjax-web
-          - argonaut-core
-          - arraybuffer-types
-          - arrays
-          - b64
-          - bifunctors
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign-object
-          - http-methods
-          - integers
-          - lists
-          - maybe
-          - midi
-          - ordered-collections
-          - parallel
-          - partial
-          - prelude
-          - strings
-          - transformers
-          - tuples
-      sparse-matrices:
-        repo: https://github.com/Ebmtranceboy/purescript-sparse-matrices.git
-        version: v1.2.1
-        dependencies:
-          - console
-          - effect
-          - prelude
-          - sparse-polynomials
-      sparse-polynomials:
-        repo: https://github.com/Ebmtranceboy/purescript-sparse-polynomials.git
-        version: v1.0.5
-        dependencies:
-          - cartesian
-          - console
-          - effect
-          - ordered-collections
-          - prelude
-          - rationals
-          - tuples
-      spec:
-        repo: https://github.com/purescript-spec/purescript-spec.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - ansi
-          - avar
-          - console
-          - exceptions
-          - foldable-traversable
-          - fork
-          - now
-          - pipes
-          - prelude
-          - strings
-          - transformers
-      spec-discovery:
-        repo: https://github.com/purescript-spec/purescript-spec-discovery.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - aff-promise
-          - arrays
-          - console
-          - effect
-          - foldable-traversable
-          - node-fs
-          - prelude
-          - spec
-      spec-quickcheck:
-        repo: https://github.com/purescript-spec/purescript-spec-quickcheck.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - prelude
-          - quickcheck
-          - random
-          - spec
-      ssrs:
-        repo: https://github.com/PureFunctor/purescript-ssrs.git
-        version: v1.0.0
-        dependencies:
-          - dissect
-          - either
-          - fixed-points
-          - free
-          - lists
-          - prelude
-          - safe-coerce
-          - tailrec
-          - tuples
-          - variant
-      st:
-        repo: https://github.com/purescript/purescript-st.git
-        version: v6.0.0
-        dependencies:
-          - partial
-          - prelude
-          - tailrec
-          - unsafe-coerce
-      strictlypositiveint:
-        repo: https://github.com/jamieyung/purescript-strictlypositiveint.git
-        version: v1.0.1
-        dependencies:
-          - prelude
-      string-parsers:
-        repo: https://github.com/purescript-contrib/purescript-string-parsers.git
-        version: v8.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - prelude
-          - strings
-          - tailrec
-      strings:
-        repo: https://github.com/purescript/purescript-strings.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - enums
-          - foldable-traversable
-          - gen
-          - integers
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-          - unsafe-coerce
-      strings-extra:
-        repo: https://github.com/purescript-contrib/purescript-strings-extra.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - maybe
-          - prelude
-          - strings
-          - unicode
-      stringutils:
-        repo: https://github.com/menelaos/purescript-stringutils.git
-        version: v0.0.12
-        dependencies:
-          - arrays
-          - integers
-          - maybe
-          - partial
-          - prelude
-          - strings
-      substitute:
-        repo: https://github.com/ursi/purescript-substitute.git
-        version: v0.2.3
-        dependencies:
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - prelude
-          - return
-          - strings
-      supply:
-        repo: https://github.com/ajnsit/purescript-supply.git
-        version: v0.2.0
-        dependencies:
-          - console
-          - control
-          - effect
-          - lazy
-          - prelude
-          - refs
-          - tuples
-      tailrec:
-        repo: https://github.com/purescript/purescript-tailrec.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - effect
-          - either
-          - identity
-          - maybe
-          - partial
-          - prelude
-          - refs
-      test-unit:
-        repo: https://github.com/bodil/purescript-test-unit.git
-        version: v17.0.0
-        dependencies:
-          - aff
-          - avar
-          - effect
-          - either
-          - free
-          - js-timers
-          - lists
-          - prelude
-          - quickcheck
-          - strings
-      thermite:
-        repo: https://github.com/paf31/purescript-thermite.git
-        version: v6.3.1
-        dependencies:
-          - aff
-          - coroutines
-          - freet
-          - profunctor-lenses
-          - react
-      thermite-dom:
-        repo: https://github.com/athanclark/purescript-thermite-dom.git
-        version: v0.3.1
-        dependencies:
-          - react
-          - react-dom
-          - thermite
-          - web-html
-      these:
-        repo: https://github.com/purescript-contrib/purescript-these.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - gen
-          - lists
-          - quickcheck
-          - quickcheck-laws
-          - tuples
-      transformers:
-        repo: https://github.com/purescript/purescript-transformers.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - distributive
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - identity
-          - lazy
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      tree-rose:
-        repo: https://github.com/jordanmartinez/purescript-tree-rose.git
-        version: v4.0.2
-        dependencies:
-          - control
-          - foldable-traversable
-          - free
-          - lists
-          - maybe
-          - prelude
-          - tailrec
-      tuples:
-        repo: https://github.com/purescript/purescript-tuples.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - invariant
-          - prelude
-      two-or-more:
-        repo: https://github.com/i-am-the-slime/purescript-two-or-more.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - foldable-traversable
-          - maybe
-          - partial
-          - prelude
-          - psci-support
-          - tuples
-      type-equality:
-        repo: https://github.com/purescript/purescript-type-equality.git
-        version: v4.0.1
-        dependencies: []
-      typelevel:
-        repo: https://github.com/bodil/purescript-typelevel.git
-        version: v6.0.0
-        dependencies:
-          - partial
-          - prelude
-          - tuples
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-lists:
-        repo: https://github.com/PureFunctor/purescript-typelevel-lists.git
-        version: v2.1.0
-        dependencies:
-          - prelude
-          - tuples
-          - typelevel-peano
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-peano:
-        repo: https://github.com/csicar/purescript-typelevel-peano.git
-        version: v1.0.1
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - prelude
-          - psci-support
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-prelude:
-        repo: https://github.com/purescript/purescript-typelevel-prelude.git
-        version: v7.0.0
-        dependencies:
-          - prelude
-          - type-equality
-      typelevel-rows:
-        repo: https://github.com/jordanmartinez/purescript-typelevel-rows.git
-        version: v0.1.0
-        dependencies:
-          - prelude
-      uint:
-        repo: https://github.com/purescript-contrib/purescript-uint.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - enums
-          - gen
-          - maybe
-          - numbers
-          - prelude
-      uncurried-transformers:
-        repo: https://github.com/PureFunctor/purescript-uncurried-transformers.git
-        version: v1.1.0
-        dependencies:
-          - control
-          - effect
-          - either
-          - functions
-          - identity
-          - prelude
-          - safe-coerce
-          - tailrec
-          - transformers
-          - tuples
-      undefined-is-not-a-problem:
-        repo: https://github.com/paluh/purescript-undefined-is-not-a-problem.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - assert
-          - effect
-          - either
-          - foreign
-          - maybe
-          - newtype
-          - prelude
-          - random
-          - tuples
-          - type-equality
-          - unsafe-coerce
-      unfoldable:
-        repo: https://github.com/purescript/purescript-unfoldable.git
-        version: v6.0.0
-        dependencies:
-          - foldable-traversable
-          - maybe
-          - partial
-          - prelude
-          - tuples
-      unicode:
-        repo: https://github.com/purescript-contrib/purescript-unicode.git
-        version: v6.0.0
-        dependencies:
-          - foldable-traversable
-          - maybe
-          - strings
-      unlift:
-        repo: https://github.com/tweag/purescript-unlift.git
-        version: v1.0.1
-        dependencies:
-          - aff
-          - effect
-          - either
-          - freet
-          - identity
-          - lists
-          - maybe
-          - monad-control
-          - prelude
-          - st
-          - transformers
-          - tuples
-      unsafe-coerce:
-        repo: https://github.com/purescript/purescript-unsafe-coerce.git
-        version: v6.0.0
-        dependencies: []
-      unsafe-reference:
-        repo: https://github.com/purescript-contrib/purescript-unsafe-reference.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-      uri:
-        repo: https://github.com/purescript-contrib/purescript-uri.git
-        version: v9.0.0
-        dependencies:
-          - arrays
-          - integers
-          - js-uri
-          - numbers
-          - parsing
-          - prelude
-          - profunctor-lenses
-          - these
-          - transformers
-          - unfoldable
-      validation:
-        repo: https://github.com/purescript/purescript-validation.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - newtype
-          - prelude
-      variant:
-        repo: https://github.com/natefaubion/purescript-variant.git
-        version: v8.0.0
-        dependencies:
-          - enums
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - record
-          - tuples
-          - unsafe-coerce
-      vectorfield:
-        repo: https://github.com/csicar/purescript-vectorfield.git
-        version: v1.0.1
-        dependencies:
-          - console
-          - effect
-          - group
-          - prelude
-          - psci-support
-      versions:
-        repo: https://github.com/hdgarrood/purescript-versions.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - either
-          - foldable-traversable
-          - functions
-          - integers
-          - lists
-          - maybe
-          - orders
-          - parsing
-          - partial
-          - strings
-      web-clipboard:
-        repo: https://github.com/purescript-web/purescript-web-clipboard.git
-        version: v4.0.0
-        dependencies:
-          - web-html
-      web-cssom:
-        repo: https://github.com/purescript-web/purescript-web-cssom.git
-        version: v2.0.0
-        dependencies:
-          - web-dom
-          - web-html
-          - web-uievents
-      web-dom:
-        repo: https://github.com/purescript-web/purescript-web-dom.git
-        version: v6.0.0
-        dependencies:
-          - web-events
-      web-dom-parser:
-        repo: https://github.com/purescript-web/purescript-web-dom-parser.git
-        version: v8.0.0
-        dependencies:
-          - effect
-          - partial
-          - prelude
-          - web-dom
-      web-dom-xpath:
-        repo: https://github.com/purescript-web/purescript-web-dom-xpath.git
-        version: v3.0.0
-        dependencies:
-          - web-dom
-      web-encoding:
-        repo: https://github.com/purescript-web/purescript-web-encoding.git
-        version: v3.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - newtype
-          - prelude
-      web-events:
-        repo: https://github.com/purescript-web/purescript-web-events.git
-        version: v4.0.0
-        dependencies:
-          - datetime
-          - enums
-          - foreign
-          - nullable
-      web-fetch:
-        repo: https://github.com/purescript-web/purescript-web-fetch.git
-        version: v3.0.0
-        dependencies:
-          - effect
-          - foreign-object
-          - http-methods
-          - prelude
-          - record
-          - typelevel-prelude
-          - web-file
-          - web-promise
-          - web-streams
-      web-file:
-        repo: https://github.com/purescript-web/purescript-web-file.git
-        version: v4.0.0
-        dependencies:
-          - foreign
-          - media-types
-          - web-dom
-      web-html:
-        repo: https://github.com/purescript-web/purescript-web-html.git
-        version: v4.0.0
-        dependencies:
-          - js-date
-          - web-dom
-          - web-file
-          - web-storage
-      web-page-visibility:
-        repo: https://git.sr.ht/~toastal/purescript-web-page-visibility
-        version: v2.0.0
-        dependencies:
-          - effect
-          - enums
-          - exceptions
-          - maybe
-          - prelude
-          - strings
-          - web-events
-          - web-html
-      web-pointerevents:
-        repo: https://github.com/purescript-web/purescript-web-pointerevents.git
-        version: v1.0.0
-        dependencies:
-          - effect
-          - maybe
-          - prelude
-          - web-dom
-          - web-uievents
-      web-promise:
-        repo: https://github.com/purescript-web/purescript-web-promise.git
-        version: v3.0.0
-        dependencies:
-          - effect
-          - exceptions
-          - foldable-traversable
-          - functions
-          - maybe
-          - prelude
-      web-socket:
-        repo: https://github.com/purescript-web/purescript-web-socket.git
-        version: v4.0.0
-        dependencies:
-          - arraybuffer-types
-          - web-file
-      web-storage:
-        repo: https://github.com/purescript-web/purescript-web-storage.git
-        version: v5.0.0
-        dependencies:
-          - nullable
-          - web-events
-      web-streams:
-        repo: https://github.com/purescript-web/purescript-web-streams.git
-        version: v3.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - exceptions
-          - nullable
-          - prelude
-          - tuples
-          - web-promise
-      web-touchevents:
-        repo: https://github.com/purescript-web/purescript-web-touchevents.git
-        version: v4.0.0
-        dependencies:
-          - web-uievents
-      web-uievents:
-        repo: https://github.com/purescript-web/purescript-web-uievents.git
-        version: v4.0.0
-        dependencies:
-          - web-html
-      web-workers:
-        repo: https://github.com/gbagan/purescript-web-workers.git
-        version: v1.1.0
-        dependencies:
-          - effect
-          - foreign
-          - maybe
-          - prelude
-          - unsafe-coerce
-          - web-events
-      web-xhr:
-        repo: https://github.com/purescript-web/purescript-web-xhr.git
-        version: v5.0.0
-        dependencies:
-          - arraybuffer-types
-          - datetime
-          - http-methods
-          - web-dom
-          - web-file
-          - web-html
-      yoga-fetch:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-fetch.git
-        version: v1.0.1
-        dependencies:
-          - aff
-          - aff-promise
-          - arraybuffer-types
-          - effect
-          - foreign
-          - foreign-object
-          - newtype
-          - prelude
-          - typelevel-prelude
-          - unsafe-coerce
-      yoga-json:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-json.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - identity
-          - lists
-          - maybe
-          - nullable
-          - partial
-          - prelude
-          - record
-          - transformers
-          - typelevel-prelude
-          - variant
-      yoga-postgres:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-postgres.git
-        version: v6.0.0
-        dependencies:
-          - aff
-          - arrays
-          - datetime
-          - effect
-          - either
-          - enums
-          - foldable-traversable
-          - foreign
-          - integers
-          - maybe
-          - nullable
-          - prelude
-          - transformers
-          - unsafe-coerce
+      abc-parser: 2.0.0
+      ace: 9.0.0
+      aff: 7.1.0
+      aff-bus: 6.0.0
+      aff-coroutines: 9.0.0
+      aff-promise: 4.0.0
+      aff-retry: 2.0.0
+      affjax: 13.0.0
+      affjax-node: 1.0.0
+      affjax-web: 1.0.0
+      ansi: 7.0.0
+      argonaut: 9.0.0
+      argonaut-aeson-generic: 0.4.1
+      argonaut-codecs: 9.1.0
+      argonaut-core: 7.0.0
+      argonaut-generic: 8.0.0
+      argonaut-traversals: 10.0.0
+      argparse-basic: 2.0.0
+      array-builder: 0.1.2
+      arraybuffer: 13.1.1
+      arraybuffer-builder: 3.1.0
+      arraybuffer-types: 3.0.2
+      arrays: 7.1.0
+      arrays-zipper: 2.0.1
+      ask: 1.0.0
+      assert: 6.0.0
+      avar: 5.0.0
+      b64: 0.0.8
+      barbies: 1.0.1
+      barlow-lens: 0.9.0
+      basic-auth: 3.0.1
+      bifunctors: 6.0.0
+      bigints: 7.0.1
+      bolson: 0.3.1
+      bower-json: 3.0.0
+      bucketchain: 1.0.1
+      bucketchain-basic-auth: 1.0.1
+      bucketchain-conditional: 1.0.1
+      bucketchain-cors: 1.0.1
+      bucketchain-csrf: 1.0.1
+      bucketchain-header-utils: 1.0.1
+      bucketchain-health: 1.0.1
+      bucketchain-history-api-fallback: 1.0.1
+      bucketchain-logger: 1.0.1
+      bucketchain-secure: 1.0.1
+      bucketchain-simple-api: 5.0.1
+      bucketchain-sslify: 1.0.1
+      bucketchain-static: 1.0.1
+      call-by-name: 4.0.1
+      canvas: 6.0.0
+      canvas-action: 9.0.0
+      cartesian: 1.0.6
+      catenable-lists: 7.0.0
+      channel: 1.0.0
+      checked-exceptions: 3.1.1
+      classless: 0.1.1
+      classless-arbitrary: 0.1.1
+      classless-decode-json: 0.1.1
+      classless-encode-json: 0.1.3
+      classnames: 2.0.0
+      codec: 6.0.0
+      codec-argonaut: 10.0.0
+      colors: 7.0.1
+      concur-core: 0.5.0
+      concur-react: 0.5.0
+      concurrent-queues: 3.0.0
+      console: 6.0.0
+      const: 6.0.0
+      contravariant: 6.0.0
+      control: 6.0.0
+      convertable-options: 1.0.0
+      coroutines: 7.0.0
+      crypto: 5.0.1
+      css: 6.0.0
+      datetime: 6.1.0
+      datetime-parsing: 0.2.0
+      debug: 6.0.2
+      decimals: 7.1.0
+      default-values: 1.0.1
+      deku: 0.9.9
+      deno: 0.0.5
+      dissect: 1.0.0
+      distributive: 6.0.0
+      dodo-printer: 2.2.1
+      dom-filereader: 7.0.0
+      dom-indexed: 11.0.0
+      dotenv: 3.0.0
+      droplet: 0.5.0
+      dynamic-buffer: 3.0.1
+      echarts-simple: 0.0.1
+      effect: 4.0.0
+      either: 6.1.0
+      elmish: 0.8.3
+      elmish-enzyme: 0.1.1
+      elmish-hooks: 0.9.1
+      elmish-html: 0.7.2
+      elmish-testing-library: 0.3.1
+      email-validate: 7.0.0
+      encoding: 0.0.8
+      enums: 6.0.1
+      error: 2.0.0
+      exceptions: 6.0.0
+      exists: 6.0.0
+      exitcodes: 4.0.0
+      expect-inferred: 3.0.0
+      fahrtwind: 2.0.0
+      fallback: 0.1.0
+      fast-vect: 1.1.0
+      fetch: 1.1.4
+      fetch-argonaut: 1.0.0
+      fetch-core: 4.0.4
+      fetch-yoga-json: 1.1.0
+      filterable: 5.0.0
+      fixed-points: 7.0.0
+      fixed-precision: 5.0.0
+      flame: 1.2.0
+      float32: 2.0.0
+      foldable-traversable: 6.0.0
+      foreign: 7.0.0
+      foreign-object: 4.1.0
+      foreign-readwrite: 3.4.0
+      fork: 6.0.0
+      form-urlencoded: 7.0.0
+      formatters: 7.0.0
+      framer-motion: 1.0.1
+      free: 7.0.0
+      freeap: 7.0.0
+      freer-free: 0.0.1
+      freet: 7.0.0
+      functions: 6.0.0
+      functor1: 3.0.0
+      functors: 5.0.0
+      fuzzy: 0.4.0
+      gen: 4.0.0
+      generate-values: 1.0.1
+      generic-router: 0.0.1
+      geometry-plane: 1.0.3
+      github-actions-toolkit: 0.5.0
+      grain: 3.0.0
+      grain-router: 3.0.0
+      grain-virtualized: 3.0.0
+      graphql-client: 9.3.2
+      graphs: 8.1.0
+      group: 4.1.1
+      halogen: 7.0.0
+      halogen-bootstrap5: 2.1.0
+      halogen-css: 10.0.0
+      halogen-echarts-simple: 0.0.4
+      halogen-formless: 4.0.2
+      halogen-hooks: 0.6.3
+      halogen-hooks-extra: 0.9.0
+      halogen-store: 0.5.4
+      halogen-storybook: 2.0.0
+      halogen-subscriptions: 2.0.0
+      halogen-svg-elems: 7.0.0
+      halogen-vdom: 8.0.0
+      halogen-vdom-string-renderer: 0.5.0
+      heckin: 2.0.1
+      heterogeneous: 0.6.0
+      homogeneous: 0.4.0
+      http-methods: 6.0.0
+      httpure: 0.16.0
+      httpurple: 3.0.1
+      httpurple-argonaut: 1.0.1
+      httpurple-yoga-json: 1.0.0
+      humdrum: 0.0.1
+      hyrule: 2.3.5
+      identity: 6.0.0
+      identy: 4.0.1
+      indexed-monad: 2.1.0
+      int64: 3.0.0
+      integers: 6.0.0
+      interpolate: 5.0.2
+      invariant: 6.0.0
+      jarilo: 1.0.1
+      jelly: 0.9.1
+      jelly-hooks: 0.3.1
+      jelly-router: 0.2.2
+      jelly-signal: 0.3.0
+      jest: 1.0.0
+      js-bigints: 1.2.0
+      js-date: 8.0.0
+      js-fileio: 3.0.0
+      js-promise: 1.0.0
+      js-promise-aff: 1.0.0
+      js-timers: 6.1.0
+      js-uri: 3.1.0
+      justifill: 0.5.0
+      jwt: 0.0.9
+      language-cst-parser: 0.12.1
+      lazy: 6.0.0
+      lazy-joe: 1.0.0
+      lcg: 4.0.0
+      leibniz: 5.0.0
+      linalg: 5.1.0
+      lists: 7.0.0
+      literals: 1.0.2
+      logging: 3.0.0
+      logging-journald: 0.4.0
+      machines: 7.0.0
+      marionette: 1.0.0
+      marionette-commander: 0.1.1
+      marionette-react-basic-hooks: 0.1.1
+      matrices: 5.0.1
+      matryoshka: 1.0.0
+      maybe: 6.0.0
+      mdast-util-from-markdown: 0.2.1
+      media-types: 6.0.0
+      midi: 4.0.0
+      milkis: 9.0.0
+      minibench: 4.0.1
+      mmorph: 7.0.0
+      monad-control: 5.0.0
+      monad-logger: 1.3.1
+      monad-loops: 0.5.0
+      monad-unlift: 1.0.1
+      monoid-extras: 0.0.1
+      monoidal: 0.16.0
+      morello: 0.4.0
+      mote: 3.0.0
+      motsunabe: 2.0.0
+      mysql: 6.0.1
+      n3: 0.1.0
+      nano-id: 1.1.0
+      naturals: 3.0.0
+      nested-functor: 0.2.1
+      newtype: 5.0.0
+      nextui: 0.1.0
+      node-buffer: 8.0.0
+      node-buffer-blob: 1.0.0
+      node-child-process: 9.0.0
+      node-fs: 8.1.1
+      node-fs-aff: 9.1.0
+      node-http: 8.0.0
+      node-net: 4.0.0
+      node-path: 5.0.0
+      node-process: 10.0.0
+      node-readline: 7.0.0
+      node-sqlite3: 8.0.0
+      node-streams: 7.0.0
+      node-streams-aff: 4.0.1
+      node-url: 6.0.0
+      nodemailer: 4.0.1
+      nonempty: 7.0.0
+      now: 6.0.0
+      npm-package-json: 2.0.0
+      nullable: 6.0.0
+      numbers: 9.0.0
+      object-maps: 0.1.1
+      ocarina: 1.5.2
+      open-folds: 6.3.0
+      open-memoize: 6.1.0
+      open-pairing: 6.1.0
+      options: 7.0.0
+      optparse: 5.0.0
+      ordered-collections: 3.0.0
+      ordered-set: 0.4.0
+      orders: 6.0.0
+      pairs: 9.0.0
+      parallel: 6.0.0
+      parsing: 10.2.0
+      parsing-dataview: 3.2.4
+      partial: 4.0.0
+      pathy: 9.0.0
+      pha: 0.9.0
+      phaser: 0.6.0
+      pipes: 8.0.0
+      pirates-charm: 0.0.1
+      point-free: 1.0.0
+      pointed-list: 0.5.1
+      polymorphic-vectors: 4.0.0
+      posix-types: 6.0.0
+      precise: 6.0.0
+      precise-datetime: 7.0.0
+      prelude: 6.0.1
+      prettier-printer: 3.0.0
+      profunctor: 6.0.0
+      profunctor-lenses: 8.0.0
+      protobuf: 4.2.0
+      ps-cst: 1.2.0
+      psa-utils: 8.0.0
+      psc-ide: 19.0.0
+      psci-support: 6.0.0
+      qualified-do: 2.2.0
+      quantities: 12.1.0
+      quickcheck: 8.0.1
+      quickcheck-combinators: 0.1.3
+      quickcheck-laws: 7.0.0
+      quickcheck-utf8: 0.0.0
+      random: 6.0.0
+      rationals: 5.0.1
+      rdf: 0.1.0
+      react: 10.0.1
+      react-aria: 0.2.0
+      react-basic: 17.0.0
+      react-basic-classic: 3.0.0
+      react-basic-dnd: 10.1.0
+      react-basic-dom: 6.0.0
+      react-basic-emotion: 7.1.0
+      react-basic-hooks: 8.1.2
+      react-basic-storybook: 2.0.0
+      react-dom: 8.0.0
+      react-halo: 3.0.0
+      react-icons: 1.0.8
+      react-testing-library: 4.0.1
+      react-virtuoso: 1.0.0
+      read: 1.0.1
+      record: 4.0.0
+      record-extra: 5.0.1
+      record-studio: 1.0.4
+      refs: 6.0.0
+      remotedata: 5.0.0
+      resource: 2.0.1
+      resourcet: 1.0.0
+      result: 1.0.3
+      return: 0.2.0
+      ring-modules: 5.0.1
+      rito: 0.3.2
+      routing: 11.0.0
+      routing-duplex: 0.7.0
+      run: 5.0.0
+      safe-coerce: 2.0.0
+      safely: 4.0.1
+      school-of-music: 1.3.0
+      selection-foldable: 0.2.0
+      semirings: 7.0.0
+      signal: 13.0.0
+      simple-emitter: 3.0.1
+      simple-i18n: 2.0.1
+      simple-json: 9.0.0
+      simple-jwt: 4.0.1
+      simple-ulid: 3.0.0
+      sized-matrices: 1.0.0
+      sized-vectors: 5.0.2
+      slug: 3.0.8
+      small-ffi: 4.0.1
+      soundfonts: 4.1.0
+      sparse-matrices: 1.2.1
+      sparse-polynomials: 1.0.5
+      spec: 7.2.0
+      spec-discovery: 8.0.1
+      spec-quickcheck: 5.0.0
+      splitmix: 2.1.0
+      ssrs: 1.0.0
+      st: 6.2.0
+      strictlypositiveint: 1.0.1
+      string-parsers: 8.0.0
+      strings: 6.0.1
+      strings-extra: 4.0.0
+      stringutils: 0.0.12
+      substitute: 0.2.3
+      sunde: 3.0.0
+      supply: 0.2.0
+      svg-parser: 3.0.0
+      systemd-journald: 0.3.0
+      tagged: 4.0.2
+      tailrec: 6.1.0
+      tecton: 0.1.6
+      tecton-halogen: 0.1.3
+      test-unit: 17.0.0
+      thermite: 6.3.1
+      thermite-dom: 0.3.1
+      these: 6.0.0
+      toppokki: 4.0.0
+      transformers: 6.0.0
+      tree-rose: 4.0.2
+      tuples: 7.0.0
+      two-or-more: 1.0.0
+      type-equality: 4.0.1
+      typelevel: 6.0.0
+      typelevel-lists: 2.1.0
+      typelevel-peano: 1.0.1
+      typelevel-prelude: 7.0.0
+      typelevel-rows: 0.1.0
+      uint: 7.0.0
+      ulid: 3.0.1
+      uncurried-transformers: 1.1.0
+      undefined: 2.0.0
+      undefined-is-not-a-problem: 1.1.0
+      unfoldable: 6.0.0
+      unicode: 6.0.0
+      unlift: 1.0.1
+      unordered-collections: 3.0.1
+      unsafe-coerce: 6.0.0
+      unsafe-reference: 5.0.0
+      untagged-to-tagged: 0.1.4
+      untagged-union: 1.0.0
+      uri: 9.0.0
+      uuid: 9.0.0
+      uuidv4: 1.0.0
+      validation: 6.0.0
+      variant: 8.0.0
+      vectorfield: 1.0.1
+      vectors: 2.1.0
+      versions: 7.0.0
+      visx: 0.0.2
+      web-clipboard: 5.0.0
+      web-cssom: 2.0.0
+      web-dom: 6.0.0
+      web-dom-parser: 8.0.0
+      web-dom-xpath: 3.0.0
+      web-encoding: 3.0.0
+      web-events: 4.0.0
+      web-fetch: 3.0.0
+      web-file: 4.0.0
+      web-html: 4.1.0
+      web-pointerevents: 1.0.0
+      web-proletarian: 1.0.0
+      web-promise: 3.1.0
+      web-resize-observer: 2.0.0
+      web-router: 1.0.0
+      web-socket: 4.0.0
+      web-storage: 5.0.0
+      web-streams: 3.0.0
+      web-touchevents: 4.0.0
+      web-uievents: 4.0.0
+      web-url: 2.0.0
+      web-workers: 1.1.0
+      web-xhr: 5.0.0
+      which: 2.0.0
+      yoga-fetch: 1.0.1
+      yoga-json: 4.0.1
+      yoga-om: 0.1.0
+      yoga-postgres: 6.0.0
+      yoga-tree: 1.0.0
   extra_packages: {}
 packages:
   aff:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-aff.git
-    rev: 2d44d9f9d0d6a416a4103fba2fb39e5160f80e36
+    type: registry
+    version: 7.1.0
+    integrity: sha256-7hOC6uQO9XBAI5FD8F33ChLjFAiZVfd4BJMqlMh7TNU=
     dependencies:
+      - arrays
+      - bifunctors
+      - control
       - datetime
       - effect
+      - either
       - exceptions
+      - foldable-traversable
       - functions
+      - maybe
+      - newtype
       - parallel
+      - prelude
+      - refs
+      - tailrec
       - transformers
       - unsafe-coerce
   arrays:
-    type: git
-    url: https://github.com/purescript/purescript-arrays.git
-    rev: d20bae2f76db6cf29b7b75e26e82b8a54c32295e
+    type: registry
+    version: 7.1.0
+    integrity: sha256-Rvb3AVLal0ZLpmpABgOPIUeYHa4M+c5GwcUP5rQ2trA=
     dependencies:
       - bifunctors
       - control
@@ -3520,15 +530,16 @@ packages:
       - nonempty
       - partial
       - prelude
+      - safe-coerce
       - st
       - tailrec
       - tuples
       - unfoldable
       - unsafe-coerce
   avar:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-avar.git
-    rev: d00f5784d9cc8f079babd62740f5c52b87e5caa5
+    type: registry
+    version: 5.0.0
+    integrity: sha256-e7hf0x4hEpcygXP0LtvfvAQ49Bbj2aWtZT3gqM///0A=
     dependencies:
       - aff
       - effect
@@ -3537,9 +548,9 @@ packages:
       - functions
       - maybe
   bifunctors:
-    type: git
-    url: https://github.com/purescript/purescript-bifunctors.git
-    rev: 16ba2fb6dd7f05528ebd9e2f9ca3a068b325e5b3
+    type: registry
+    version: 6.0.0
+    integrity: sha256-/gZwC9YhNxZNQpnHa5BIYerCGM2jeX9ukZiEvYxm5Nw=
     dependencies:
       - const
       - either
@@ -3547,9 +558,9 @@ packages:
       - prelude
       - tuples
   catenable-lists:
-    type: git
-    url: https://github.com/purescript/purescript-catenable-lists.git
-    rev: 09abe1f4888bc00841ad2b59e56a9e7ce7ebd4ab
+    type: registry
+    version: 7.0.0
+    integrity: sha256-76vYENhwF4BWTBsjeLuErCH2jqVT4M3R1HX+4RwSftA=
     dependencies:
       - control
       - foldable-traversable
@@ -3559,24 +570,24 @@ packages:
       - tuples
       - unfoldable
   console:
-    type: git
-    url: https://github.com/purescript/purescript-console.git
-    rev: 3b83d7b792d03872afeea5e62b4f686ab0f09842
+    type: registry
+    version: 6.0.0
+    integrity: sha256-gJpJ53fCDAL8BiCiJXH0HNAJ9K3gJtLo8GDaCK6hA5U=
     dependencies:
       - effect
       - prelude
   const:
-    type: git
-    url: https://github.com/purescript/purescript-const.git
-    rev: ab9570cf2b6e67f7e441178211db1231cfd75c37
+    type: registry
+    version: 6.0.0
+    integrity: sha256-tNrxDW8D8H4jdHE2HiPzpLy08zkzJMmGHdRqt5BQuTc=
     dependencies:
       - invariant
       - newtype
       - prelude
   contravariant:
-    type: git
-    url: https://github.com/purescript/purescript-contravariant.git
-    rev: 9ad3e105b8855bcc25f4e0893c784789d05a58de
+    type: registry
+    version: 6.0.0
+    integrity: sha256-TP+ooAp3vvmdjfQsQJSichF5B4BPDHp3wAJoWchip6c=
     dependencies:
       - const
       - either
@@ -3584,16 +595,16 @@ packages:
       - prelude
       - tuples
   control:
-    type: git
-    url: https://github.com/purescript/purescript-control.git
-    rev: a6033808790879a17b2729e73747a9ed3fb2264e
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sH7Pg9E96JCPF9PIA6oQ8+BjTyO/BH1ZuE/bOcyj4Jk=
     dependencies:
       - newtype
       - prelude
   datetime:
-    type: git
-    url: https://github.com/purescript/purescript-datetime.git
-    rev: a6a0cf1b0324964ad1854bc3377ed8766ba90e6f
+    type: registry
+    version: 6.1.0
+    integrity: sha256-g/5X5BBegQWLpI9IWD+sY6mcaYpzzlW5lz5NBzaMtyI=
     dependencies:
       - bifunctors
       - control
@@ -3612,9 +623,9 @@ packages:
       - prelude
       - tuples
   distributive:
-    type: git
-    url: https://github.com/purescript/purescript-distributive.git
-    rev: 6005e513642e855ebf6f884d24a35c2803ca252a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-HTDdmEnzigMl+02SJB88j+gAXDx9VKsbvR4MJGDPbOQ=
     dependencies:
       - identity
       - newtype
@@ -3622,24 +633,24 @@ packages:
       - tuples
       - type-equality
   effect:
-    type: git
-    url: https://github.com/purescript/purescript-effect.git
-    rev: a192ddb923027d426d6ea3d8deb030c9aa7c7dda
+    type: registry
+    version: 4.0.0
+    integrity: sha256-eBtZu+HZcMa5HilvI6kaDyVX3ji8p0W9MGKy2K4T6+M=
     dependencies:
       - prelude
   either:
-    type: git
-    url: https://github.com/purescript/purescript-either.git
-    rev: af655a04ed2fd694b6688af39ee20d7907ad0763
+    type: registry
+    version: 6.1.0
+    integrity: sha256-6hgTPisnMWVwQivOu2PKYcH8uqjEOOqDyaDQVUchTpY=
     dependencies:
       - control
       - invariant
       - maybe
       - prelude
   enums:
-    type: git
-    url: https://github.com/purescript/purescript-enums.git
-    rev: bae47961d401f9acf88da38f32e87403e5f0cf2f
+    type: registry
+    version: 6.0.1
+    integrity: sha256-HWaD73JFLorc4A6trKIRUeDMdzE+GpkJaEOM1nTNkC8=
     dependencies:
       - control
       - either
@@ -3652,24 +663,24 @@ packages:
       - tuples
       - unfoldable
   exceptions:
-    type: git
-    url: https://github.com/purescript/purescript-exceptions.git
-    rev: afab3c07c820bb49b6c5be50049db46a964a6161
+    type: registry
+    version: 6.0.0
+    integrity: sha256-y/xTAEIZIARCE+50/u1di0ncebJ+CIwNOLswyOWzMTw=
     dependencies:
       - effect
       - either
       - maybe
       - prelude
   exists:
-    type: git
-    url: https://github.com/purescript/purescript-exists.git
-    rev: f765b4ace7869c27b9c05949e18c843881f9173b
+    type: registry
+    version: 6.0.0
+    integrity: sha256-A0JQHpTfo1dNOj9U5/Fd3xndlRSE0g2IQWOGor2yXn8=
     dependencies:
       - unsafe-coerce
   foldable-traversable:
-    type: git
-    url: https://github.com/purescript/purescript-foldable-traversable.git
-    rev: b3926f870532d287ea59e2d5cd3873b81ef2a93a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-fLeqRYM4jUrZD5H4WqcwUgzU7XfYkzO4zhgtNc3jcWM=
     dependencies:
       - bifunctors
       - const
@@ -3683,9 +694,9 @@ packages:
       - prelude
       - tuples
   free:
-    type: git
-    url: https://github.com/purescript/purescript-free.git
-    rev: e2d8fa8023a864363857834e11393483bced5e38
+    type: registry
+    version: 7.0.0
+    integrity: sha256-72auTIZAG6fhz4F94rxyDwgfnHwp+/89rujZpZWrV0w=
     dependencies:
       - catenable-lists
       - control
@@ -3702,15 +713,15 @@ packages:
       - tuples
       - unsafe-coerce
   functions:
-    type: git
-    url: https://github.com/purescript/purescript-functions.git
-    rev: f626f20580483977c5b27a01aac6471e28aff367
+    type: registry
+    version: 6.0.0
+    integrity: sha256-adMyJNEnhGde2unHHAP79gPtlNjNqzgLB8arEOn9hLI=
     dependencies:
       - prelude
   functors:
-    type: git
-    url: https://github.com/purescript/purescript-functors.git
-    rev: 022ffd7a2a7ec12080314f3d217b400674a247b4
+    type: registry
+    version: 5.0.0
+    integrity: sha256-zfPWWYisbD84MqwpJSZFlvM6v86McM68ob8p9s27ywU=
     dependencies:
       - bifunctors
       - const
@@ -3726,9 +737,9 @@ packages:
       - tuples
       - unsafe-coerce
   gen:
-    type: git
-    url: https://github.com/purescript/purescript-gen.git
-    rev: 9fbcc2a1261c32e30d79c5418edef4d96fe76931
+    type: registry
+    version: 4.0.0
+    integrity: sha256-f7yzAXWwr+xnaqEOcvyO3ezKdoes8+WXWdXIHDBCAPI=
     dependencies:
       - either
       - foldable-traversable
@@ -3741,48 +752,48 @@ packages:
       - tuples
       - unfoldable
   identity:
-    type: git
-    url: https://github.com/purescript/purescript-identity.git
-    rev: ef6768f8a52ab0bc943a85f5761ba07c257f639f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-4wY0XZbAksjY6UAg99WkuKyJlQlWAfTi2ssadH0wVMY=
     dependencies:
       - control
       - invariant
       - newtype
       - prelude
   integers:
-    type: git
-    url: https://github.com/purescript/purescript-integers.git
-    rev: 54d712b25c594833083d15dc9ff2418eb9c52822
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sf+sK26R1hzwl3NhXR7WAu9zCDjQnfoXwcyGoseX158=
     dependencies:
       - maybe
       - numbers
       - prelude
   invariant:
-    type: git
-    url: https://github.com/purescript/purescript-invariant.git
-    rev: 1d2a196d51e90623adb88496c2cfd759c6736894
+    type: registry
+    version: 6.0.0
+    integrity: sha256-RGWWyYrz0Hs1KjPDA+87Kia67ZFBhfJ5lMGOMCEFoLo=
     dependencies:
       - control
       - prelude
   js-timers:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-js-timers.git
-    rev: 7cb728b3e6dc29f355143617e6e9ac770ecd9273
+    type: registry
+    version: 6.1.0
+    integrity: sha256-znHWLSSOYw15P5DTcsAdal2lf7nGA2yayLdOZ2t5r7o=
     dependencies:
       - effect
   lazy:
-    type: git
-    url: https://github.com/purescript/purescript-lazy.git
-    rev: 48347841226b27af5205a1a8ec71e27a93ce86fd
+    type: registry
+    version: 6.0.0
+    integrity: sha256-lMsfFOnlqfe4KzRRiW8ot5ge6HtcU3Eyh2XkXcP5IgU=
     dependencies:
       - control
       - foldable-traversable
       - invariant
       - prelude
   lcg:
-    type: git
-    url: https://github.com/purescript/purescript-lcg.git
-    rev: 67c6c6483a563a59ae036d9dca0f1be2835326a5
+    type: registry
+    version: 4.0.0
+    integrity: sha256-h7ME5cthLfbgJOJdsZcSfFpwXsx4rf8YmhebU+3iSYg=
     dependencies:
       - effect
       - integers
@@ -3791,9 +802,9 @@ packages:
       - prelude
       - random
   lists:
-    type: git
-    url: https://github.com/purescript/purescript-lists.git
-    rev: b113451e5b41cad87d669a3165f955c71cd863e2
+    type: registry
+    version: 7.0.0
+    integrity: sha256-EKF15qYqucuXP2lT/xPxhqy58f0FFT6KHdIB/yBOayI=
     dependencies:
       - bifunctors
       - control
@@ -3808,25 +819,25 @@ packages:
       - tuples
       - unfoldable
   maybe:
-    type: git
-    url: https://github.com/purescript/purescript-maybe.git
-    rev: c6f98ac1088766287106c5d9c8e30e7648d36786
+    type: registry
+    version: 6.0.0
+    integrity: sha256-5cCIb0wPwbat2PRkQhUeZO0jcAmf8jCt2qE0wbC3v2Q=
     dependencies:
       - control
       - invariant
       - newtype
       - prelude
   newtype:
-    type: git
-    url: https://github.com/purescript/purescript-newtype.git
-    rev: 29d8e6dd77aec2c975c948364ec3faf26e14ee7b
+    type: registry
+    version: 5.0.0
+    integrity: sha256-gdrQu8oGe9eZE6L3wOI8ql/igOg+zEGB5ITh2g+uttw=
     dependencies:
       - prelude
       - safe-coerce
   nonempty:
-    type: git
-    url: https://github.com/purescript/purescript-nonempty.git
-    rev: 28150ecc7419238b187abd609a92a645273348bb
+    type: registry
+    version: 7.0.0
+    integrity: sha256-54ablJZUHGvvlTJzi3oXyPCuvY6zsrWJuH/dMJ/MFLs=
     dependencies:
       - control
       - foldable-traversable
@@ -3835,16 +846,16 @@ packages:
       - tuples
       - unfoldable
   numbers:
-    type: git
-    url: https://github.com/purescript/purescript-numbers.git
-    rev: 2a53528f18f9415334bae28e7bb3cf3be86342c2
+    type: registry
+    version: 9.0.0
+    integrity: sha256-fDKXExFxMRFgy+v+kbjVbGBIOOQkWGnmm0vtnE3zWRE=
     dependencies:
       - functions
       - maybe
   ordered-collections:
-    type: git
-    url: https://github.com/purescript/purescript-ordered-collections.git
-    rev: 9826b7632d0d0a691173bde308a634195f42a419
+    type: registry
+    version: 3.0.0
+    integrity: sha256-R9WddNBRPkY37gw8XkDCLX2vJ5eI9qdaWDdCp61r2+M=
     dependencies:
       - arrays
       - foldable-traversable
@@ -3858,16 +869,16 @@ packages:
       - tuples
       - unfoldable
   orders:
-    type: git
-    url: https://github.com/purescript/purescript-orders.git
-    rev: f86db621ec5eef1274145f8b1fd8ebbfe0ed4a2c
+    type: registry
+    version: 6.0.0
+    integrity: sha256-nBA0g3/ai0euH8q9pSbGqk53W2q6agm/dECZTHcoink=
     dependencies:
       - newtype
       - prelude
   parallel:
-    type: git
-    url: https://github.com/purescript/purescript-parallel.git
-    rev: 85290dca837771ac4870071008c933d315ef678f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-VJbkGD0rAKX+NUEeBJbYJ78bEKaZbgow+QwQEfPB6ko=
     dependencies:
       - control
       - effect
@@ -3881,19 +892,19 @@ packages:
       - refs
       - transformers
   partial:
-    type: git
-    url: https://github.com/purescript/purescript-partial.git
-    rev: 0fa0646f5ea1ec5f0c46dcbd770c705a6c9ad3ec
+    type: registry
+    version: 4.0.0
+    integrity: sha256-fwXerld6Xw1VkReh8yeQsdtLVrjfGiVuC5bA1Wyo/J4=
     dependencies: []
   prelude:
-    type: git
-    url: https://github.com/purescript/purescript-prelude.git
-    rev: 32787f4399c92459c41602131a5858559eb868c5
+    type: registry
+    version: 6.0.1
+    integrity: sha256-o8p6SLYmVPqzXZhQFd2hGAWEwBoXl1swxLG/scpJ0V0=
     dependencies: []
   profunctor:
-    type: git
-    url: https://github.com/purescript/purescript-profunctor.git
-    rev: 0a966a14e7b0c827d44657dc1710cdc712d2e034
+    type: registry
+    version: 6.0.0
+    integrity: sha256-99NzxFgTr4CGlCSRYG1kShL+JhYbihhHtbOk1/0R5zI=
     dependencies:
       - control
       - distributive
@@ -3904,9 +915,9 @@ packages:
       - prelude
       - tuples
   quickcheck:
-    type: git
-    url: https://github.com/purescript/purescript-quickcheck.git
-    rev: bf5029f97e6c0d7552d3a08d2ab793a19e2c5e3d
+    type: registry
+    version: 8.0.1
+    integrity: sha256-ZvpccKQCvgslTXZCNmpYW4bUsFzhZd/kQUr2WmxFTGY=
     dependencies:
       - arrays
       - console
@@ -3936,46 +947,46 @@ packages:
       - tuples
       - unfoldable
   random:
-    type: git
-    url: https://github.com/purescript/purescript-random.git
-    rev: 9540bc965a9596da02fefd9949418bb19c92533a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-CJ611a35MPCE7XQMp0rdC6MCn76znlhisiCRgboAG+Q=
     dependencies:
       - effect
       - integers
   record:
-    type: git
-    url: https://github.com/purescript/purescript-record.git
-    rev: c89cd1ada6b636692571fc374196b1c39c4c9f70
+    type: registry
+    version: 4.0.0
+    integrity: sha256-Za5U85bTRJEfGK5Sk4hM41oXy84YQI0I8TL3WUn1Qzg=
     dependencies:
       - functions
       - prelude
       - unsafe-coerce
   refs:
-    type: git
-    url: https://github.com/purescript/purescript-refs.git
-    rev: f8e6216da4cb9309fde1f20cd6f69ac3a3b7f9e8
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Vgwne7jIbD3ZMoLNNETLT8Litw6lIYo3MfYNdtYWj9s=
     dependencies:
       - effect
       - prelude
   safe-coerce:
-    type: git
-    url: https://github.com/purescript/purescript-safe-coerce.git
-    rev: 7fa799ae80a38b8d948efcb52608e58e198b3da7
+    type: registry
+    version: 2.0.0
+    integrity: sha256-a1ibQkiUcbODbLE/WAq7Ttbbh9ex+x33VCQ7GngKudU=
     dependencies:
       - unsafe-coerce
   st:
-    type: git
-    url: https://github.com/purescript/purescript-st.git
-    rev: 2cc7ae1c3318a303378c4a9f3fa0f10ee7cc3589
+    type: registry
+    version: 6.2.0
+    integrity: sha256-z9X0WsOUlPwNx9GlCC+YccCyz8MejC8Wb0C4+9fiBRY=
     dependencies:
       - partial
       - prelude
       - tailrec
       - unsafe-coerce
   strings:
-    type: git
-    url: https://github.com/purescript/purescript-strings.git
-    rev: 4bc6954448d056f8aa7a659695a6ad60ad4fdf19
+    type: registry
+    version: 6.0.1
+    integrity: sha256-WssD3DbX4OPzxSdjvRMX0yvc9+pS7n5gyPv5I2Trb7k=
     dependencies:
       - arrays
       - control
@@ -3994,9 +1005,9 @@ packages:
       - unfoldable
       - unsafe-coerce
   tailrec:
-    type: git
-    url: https://github.com/purescript/purescript-tailrec.git
-    rev: 5e2104aa734b31a17074cc805bf087d72b65afd1
+    type: registry
+    version: 6.1.0
+    integrity: sha256-Xx19ECVDRrDWpz9D2GxQHHV89vd61dnXxQm0IcYQHGk=
     dependencies:
       - bifunctors
       - effect
@@ -4007,9 +1018,9 @@ packages:
       - prelude
       - refs
   test-unit:
-    type: git
-    url: https://github.com/bodil/purescript-test-unit.git
-    rev: 3112d7ebe06d467238058a6384dc75ffd960d335
+    type: registry
+    version: 17.0.0
+    integrity: sha256-aITJ2KngFFjASmG0JjnjybaKWl9dn7Hf2B3Wk4engNs=
     dependencies:
       - aff
       - avar
@@ -4022,9 +1033,9 @@ packages:
       - quickcheck
       - strings
   transformers:
-    type: git
-    url: https://github.com/purescript/purescript-transformers.git
-    rev: be72ab52357d9a665cbf93d73ba1c07c4b0957ee
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Pzw40HjthX77tdPAYzjx43LK3X5Bb7ZspYAp27wksFA=
     dependencies:
       - control
       - distributive
@@ -4041,22 +1052,22 @@ packages:
       - tuples
       - unfoldable
   tuples:
-    type: git
-    url: https://github.com/purescript/purescript-tuples.git
-    rev: 4f52da2729b448c8564369378f1232d8d2dc1d8b
+    type: registry
+    version: 7.0.0
+    integrity: sha256-1rXgTomes9105BjgXqIw0FL6Fz1lqqUTLWOumhWec1M=
     dependencies:
       - control
       - invariant
       - prelude
   type-equality:
-    type: git
-    url: https://github.com/purescript/purescript-type-equality.git
-    rev: 0525b7d39e0fbd81b4209518139fb8ab02695774
+    type: registry
+    version: 4.0.1
+    integrity: sha256-Hs9D6Y71zFi/b+qu5NSbuadUQXe5iv5iWx0226vOHUw=
     dependencies: []
   unfoldable:
-    type: git
-    url: https://github.com/purescript/purescript-unfoldable.git
-    rev: 493dfe04ed590e20d8f69079df2f58486882748d
+    type: registry
+    version: 6.0.0
+    integrity: sha256-JtikvJdktRap7vr/K4ITlxUX1QexpnqBq0G/InLr6eg=
     dependencies:
       - foldable-traversable
       - maybe
@@ -4064,7 +1075,7 @@ packages:
       - prelude
       - tuples
   unsafe-coerce:
-    type: git
-    url: https://github.com/purescript/purescript-unsafe-coerce.git
-    rev: ab956f82e66e633f647fb3098e8ddd3ec58d689f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-IqIYW4Vkevn8sI+6aUwRGvd87tVL36BBeOr0cGAE7t0=
     dependencies: []

--- a/exercises/chapter3/spago.yaml
+++ b/exercises/chapter3/spago.yaml
@@ -1,0 +1,14 @@
+package:
+  dependencies:
+    - console
+    - control
+    - effect
+    - lists
+    - maybe
+    - prelude
+    - test-unit
+  name: my-project
+workspace:
+  extraPackages: {}
+  packageSet:
+    url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json

--- a/exercises/chapter3/spago.yaml
+++ b/exercises/chapter3/spago.yaml
@@ -11,4 +11,4 @@ package:
 workspace:
   extraPackages: {}
   packageSet:
-    url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
+    registry: 10.0.0

--- a/exercises/chapter4/spago.lock
+++ b/exercises/chapter4/spago.lock
@@ -1,0 +1,4073 @@
+workspace:
+  packages:
+    my-project:
+      path: ./
+      dependencies:
+        - arrays
+        - console
+        - effect
+        - foldable-traversable
+        - integers
+        - maybe
+        - numbers
+        - partial
+        - prelude
+        - test-unit
+      test_dependencies: []
+      build_plan:
+        - aff
+        - arrays
+        - avar
+        - bifunctors
+        - catenable-lists
+        - console
+        - const
+        - contravariant
+        - control
+        - datetime
+        - distributive
+        - effect
+        - either
+        - enums
+        - exceptions
+        - exists
+        - foldable-traversable
+        - free
+        - functions
+        - functors
+        - gen
+        - identity
+        - integers
+        - invariant
+        - js-timers
+        - lazy
+        - lcg
+        - lists
+        - maybe
+        - newtype
+        - nonempty
+        - numbers
+        - ordered-collections
+        - orders
+        - parallel
+        - partial
+        - prelude
+        - profunctor
+        - quickcheck
+        - random
+        - record
+        - refs
+        - safe-coerce
+        - st
+        - strings
+        - tailrec
+        - test-unit
+        - transformers
+        - tuples
+        - type-equality
+        - unfoldable
+        - unsafe-coerce
+  package_set:
+    address:
+      url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
+    compiler: ">=0.15.0 <0.16.0"
+    content:
+      ace:
+        repo: https://github.com/purescript-contrib/purescript-ace.git
+        version: v9.0.0
+        dependencies:
+          - arrays
+          - effect
+          - foreign
+          - nullable
+          - prelude
+          - web-html
+          - web-uievents
+      aff:
+        repo: https://github.com/purescript-contrib/purescript-aff.git
+        version: v7.0.0
+        dependencies:
+          - datetime
+          - effect
+          - exceptions
+          - functions
+          - parallel
+          - transformers
+          - unsafe-coerce
+      aff-bus:
+        repo: https://github.com/purescript-contrib/purescript-aff-bus.git
+        version: v6.0.0
+        dependencies:
+          - aff
+          - avar
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - lists
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+      aff-coroutines:
+        repo: https://github.com/purescript-contrib/purescript-aff-coroutines.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - avar
+          - coroutines
+          - effect
+      aff-promise:
+        repo: https://github.com/nwolverson/purescript-aff-promise.git
+        version: v4.0.0
+        dependencies:
+          - aff
+          - foreign
+      aff-retry:
+        repo: https://github.com/Unisay/purescript-aff-retry.git
+        version: v2.0.0
+        dependencies:
+          - aff
+          - arrays
+          - datetime
+          - effect
+          - either
+          - exceptions
+          - integers
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - random
+          - transformers
+      affjax:
+        repo: https://github.com/purescript-contrib/purescript-affjax.git
+        version: v13.0.0
+        dependencies:
+          - aff
+          - argonaut-core
+          - arraybuffer-types
+          - foreign
+          - form-urlencoded
+          - http-methods
+          - integers
+          - media-types
+          - nullable
+          - refs
+          - unsafe-coerce
+          - web-xhr
+      affjax-node:
+        repo: https://github.com/purescript-contrib/purescript-affjax-node.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - affjax
+          - either
+          - maybe
+          - prelude
+      affjax-web:
+        repo: https://github.com/purescript-contrib/purescript-affjax-web.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - affjax
+          - either
+          - maybe
+          - prelude
+      ansi:
+        repo: https://github.com/hdgarrood/purescript-ansi.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - lists
+          - strings
+      argonaut:
+        repo: https://github.com/purescript-contrib/purescript-argonaut.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - argonaut-traversals
+      argonaut-codecs:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-codecs.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-core
+          - arrays
+          - effect
+          - foreign-object
+          - identity
+          - integers
+          - maybe
+          - nonempty
+          - ordered-collections
+          - prelude
+          - record
+      argonaut-core:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-core.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - foreign-object
+          - functions
+          - gen
+          - maybe
+          - nonempty
+          - prelude
+          - strings
+          - tailrec
+      argonaut-generic:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-generic.git
+        version: v8.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - prelude
+          - record
+      argonaut-traversals:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-traversals.git
+        version: v10.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - profunctor-lenses
+      argparse-basic:
+        repo: https://github.com/natefaubion/purescript-argparse-basic.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - record
+          - strings
+          - tuples
+          - unfoldable
+      arraybuffer:
+        repo: https://github.com/purescript-contrib/purescript-arraybuffer.git
+        version: v13.0.0
+        dependencies:
+          - arraybuffer-types
+          - arrays
+          - effect
+          - float32
+          - functions
+          - gen
+          - maybe
+          - nullable
+          - prelude
+          - tailrec
+          - uint
+          - unfoldable
+      arraybuffer-builder:
+        repo: https://github.com/jamesdbrock/purescript-arraybuffer-builder.git
+        version: v3.0.1
+        dependencies:
+          - arraybuffer
+          - arraybuffer-types
+          - effect
+          - float32
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - transformers
+          - uint
+      arraybuffer-types:
+        repo: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
+        version: v3.0.2
+        dependencies: []
+      arrays:
+        repo: https://github.com/purescript/purescript-arrays.git
+        version: v7.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - foldable-traversable
+          - maybe
+          - nonempty
+          - partial
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - unfoldable
+          - unsafe-coerce
+      arrays-zipper:
+        repo: https://github.com/JordanMartinez/purescript-arrays-zipper.git
+        version: v2.0.1
+        dependencies:
+          - arrays
+          - control
+          - quickcheck
+      ask:
+        repo: https://github.com/Mateiadrielrafael/purescript-ask.git
+        version: v1.0.0
+        dependencies:
+          - unsafe-coerce
+      assert:
+        repo: https://github.com/purescript/purescript-assert.git
+        version: v6.0.0
+        dependencies:
+          - console
+          - effect
+          - prelude
+      avar:
+        repo: https://github.com/purescript-contrib/purescript-avar.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - exceptions
+          - functions
+          - maybe
+      b64:
+        repo: https://github.com/menelaos/purescript-b64.git
+        version: v0.0.8
+        dependencies:
+          - arraybuffer-types
+          - either
+          - encoding
+          - enums
+          - exceptions
+          - functions
+          - partial
+          - prelude
+          - strings
+      barlow-lens:
+        repo: https://github.com/sigma-andex/purescript-barlow-lens.git
+        version: v0.9.0
+        dependencies:
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - profunctor-lenses
+          - tuples
+          - typelevel-prelude
+      bifunctors:
+        repo: https://github.com/purescript/purescript-bifunctors.git
+        version: v6.0.0
+        dependencies:
+          - const
+          - either
+          - newtype
+          - prelude
+          - tuples
+      bigints:
+        repo: https://github.com/sharkdp/purescript-bigints.git
+        version: v7.0.1
+        dependencies:
+          - integers
+          - maybe
+          - strings
+      bower-json:
+        repo: https://github.com/klntsky/purescript-bower-json.git
+        version: v3.0.0
+        dependencies:
+          - argonaut-codecs
+          - arrays
+          - either
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - newtype
+          - prelude
+          - tuples
+      call-by-name:
+        repo: https://github.com/natefaubion/purescript-call-by-name.git
+        version: v4.0.1
+        dependencies:
+          - control
+          - either
+          - lazy
+          - maybe
+          - unsafe-coerce
+      canvas:
+        repo: https://github.com/purescript-web/purescript-canvas.git
+        version: v6.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - exceptions
+          - functions
+          - maybe
+      canvas-action:
+        repo: https://github.com/artemisSystem/purescript-canvas-action.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - arrays
+          - canvas
+          - colors
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - maybe
+          - numbers
+          - polymorphic-vectors
+          - prelude
+          - refs
+          - run
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-html
+      cartesian:
+        repo: https://github.com/Ebmtranceboy/purescript-cartesian.git
+        version: v1.0.6
+        dependencies:
+          - console
+          - effect
+          - integers
+          - psci-support
+      catenable-lists:
+        repo: https://github.com/purescript/purescript-catenable-lists.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - lists
+          - maybe
+          - prelude
+          - tuples
+          - unfoldable
+      channel:
+        repo: https://github.com/ConnorDillon/purescript-channel.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - assert
+          - avar
+          - console
+          - contravariant
+          - control
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - lazy
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      checked-exceptions:
+        repo: https://github.com/natefaubion/purescript-checked-exceptions.git
+        version: v3.1.1
+        dependencies:
+          - prelude
+          - transformers
+          - variant
+      codec:
+        repo: https://github.com/garyb/purescript-codec.git
+        version: v5.0.0
+        dependencies:
+          - profunctor
+          - transformers
+      codec-argonaut:
+        repo: https://github.com/garyb/purescript-codec-argonaut.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-core
+          - codec
+          - ordered-collections
+          - type-equality
+          - variant
+      colors:
+        repo: https://github.com/purescript-contrib/purescript-colors.git
+        version: v7.0.1
+        dependencies:
+          - arrays
+          - integers
+          - lists
+          - numbers
+          - partial
+          - strings
+      concurrent-queues:
+        repo: https://github.com/purescript-contrib/purescript-concurrent-queues.git
+        version: v3.0.0
+        dependencies:
+          - aff
+          - avar
+          - effect
+      console:
+        repo: https://github.com/purescript/purescript-console.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - prelude
+      const:
+        repo: https://github.com/purescript/purescript-const.git
+        version: v6.0.0
+        dependencies:
+          - invariant
+          - newtype
+          - prelude
+      contravariant:
+        repo: https://github.com/purescript/purescript-contravariant.git
+        version: v6.0.0
+        dependencies:
+          - const
+          - either
+          - newtype
+          - prelude
+          - tuples
+      control:
+        repo: https://github.com/purescript/purescript-control.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      convertable-options:
+        repo: https://github.com/natefaubion/purescript-convertable-options.git
+        version: v1.0.0
+        dependencies:
+          - console
+          - effect
+          - maybe
+          - record
+      coroutines:
+        repo: https://github.com/purescript-contrib/purescript-coroutines.git
+        version: v7.0.0
+        dependencies:
+          - freet
+          - parallel
+          - profunctor
+      css:
+        repo: https://github.com/purescript-contrib/purescript-css.git
+        version: v6.0.0
+        dependencies:
+          - colors
+          - console
+          - effect
+          - nonempty
+          - profunctor
+          - strings
+          - these
+          - transformers
+      datetime:
+        repo: https://github.com/purescript/purescript-datetime.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - either
+          - enums
+          - foldable-traversable
+          - functions
+          - gen
+          - integers
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - ordered-collections
+          - partial
+          - prelude
+          - tuples
+      datetime-parsing:
+        repo: https://github.com/flounders/purescript-datetime-parsing.git
+        version: v0.2.0
+        dependencies:
+          - arrays
+          - datetime
+          - either
+          - enums
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - numbers
+          - parsing
+          - prelude
+          - strings
+          - unicode
+      debug:
+        repo: https://github.com/garyb/purescript-debug.git
+        version: v6.0.0
+        dependencies:
+          - functions
+          - prelude
+      decimals:
+        repo: https://github.com/sharkdp/purescript-decimals.git
+        version: v7.0.0
+        dependencies:
+          - maybe
+      dissect:
+        repo: https://github.com/PureFunctor/purescript-dissect.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - foreign-object
+          - functors
+          - newtype
+          - partial
+          - prelude
+          - tailrec
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - variant
+      distributive:
+        repo: https://github.com/purescript/purescript-distributive.git
+        version: v6.0.0
+        dependencies:
+          - identity
+          - newtype
+          - prelude
+          - tuples
+          - type-equality
+      dodo-printer:
+        repo: https://github.com/natefaubion/purescript-dodo-printer.git
+        version: v2.2.0
+        dependencies:
+          - aff
+          - ansi
+          - avar
+          - console
+          - effect
+          - foldable-traversable
+          - lists
+          - maybe
+          - minibench
+          - node-child-process
+          - node-fs-aff
+          - node-process
+          - psci-support
+          - strings
+      dom-indexed:
+        repo: https://github.com/purescript-halogen/purescript-dom-indexed.git
+        version: v11.0.0
+        dependencies:
+          - media-types
+          - prelude
+          - web-clipboard
+          - web-pointerevents
+          - web-touchevents
+      droplet:
+        repo: https://github.com/easafe/purescript-droplet.git
+        version: v0.4.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - bigints
+          - datetime
+          - debug
+          - effect
+          - either
+          - enums
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - integers
+          - maybe
+          - newtype
+          - nullable
+          - ordered-collections
+          - partial
+          - prelude
+          - profunctor
+          - record
+          - spec
+          - strings
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+      dynamic-buffer:
+        repo: https://github.com/kritzcreek/purescript-dynamic-buffer.git
+        version: v3.0.1
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - refs
+      effect:
+        repo: https://github.com/purescript/purescript-effect.git
+        version: v4.0.0
+        dependencies:
+          - prelude
+      either:
+        repo: https://github.com/purescript/purescript-either.git
+        version: v6.1.0
+        dependencies:
+          - control
+          - invariant
+          - maybe
+          - prelude
+      elmish:
+        repo: https://github.com/collegevine/purescript-elmish.git
+        version: v0.8.1
+        dependencies:
+          - aff
+          - argonaut-core
+          - arrays
+          - bifunctors
+          - console
+          - debug
+          - effect
+          - either
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - functions
+          - integers
+          - js-date
+          - maybe
+          - nullable
+          - partial
+          - prelude
+          - refs
+          - typelevel-prelude
+          - undefined-is-not-a-problem
+          - unsafe-coerce
+          - web-dom
+          - web-html
+      elmish-enzyme:
+        repo: https://github.com/collegevine/purescript-elmish-enzyme.git
+        version: v0.1.1
+        dependencies:
+          - aff
+          - aff-promise
+          - arrays
+          - console
+          - debug
+          - effect
+          - elmish
+          - foldable-traversable
+          - foreign
+          - functions
+          - prelude
+          - transformers
+          - unsafe-coerce
+      elmish-hooks:
+        repo: https://github.com/collegevine/purescript-elmish-hooks.git
+        version: v0.8.2
+        dependencies:
+          - aff
+          - debug
+          - elmish
+          - maybe
+          - prelude
+          - tuples
+          - undefined-is-not-a-problem
+      elmish-html:
+        repo: https://github.com/collegevine/purescript-elmish-html.git
+        version: v0.7.1
+        dependencies:
+          - effect
+          - elmish
+          - foreign
+          - foreign-object
+          - prelude
+          - record
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-html
+      email-validate:
+        repo: https://github.com/cdepillabout/purescript-email-validate.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - string-parsers
+          - transformers
+      encoding:
+        repo: https://github.com/menelaos/purescript-encoding.git
+        version: v0.0.8
+        dependencies:
+          - arraybuffer-types
+          - either
+          - exceptions
+          - functions
+          - prelude
+      enums:
+        repo: https://github.com/purescript/purescript-enums.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - either
+          - gen
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tuples
+          - unfoldable
+      exceptions:
+        repo: https://github.com/purescript/purescript-exceptions.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - either
+          - maybe
+          - prelude
+      exists:
+        repo: https://github.com/purescript/purescript-exists.git
+        version: v6.0.0
+        dependencies:
+          - unsafe-coerce
+      exitcodes:
+        repo: https://github.com/Risto-Stevcev/purescript-exitcodes.git
+        version: v4.0.0
+        dependencies:
+          - enums
+      expect-inferred:
+        repo: https://github.com/justinwoo/purescript-expect-inferred.git
+        version: v3.0.0
+        dependencies:
+          - prelude
+          - typelevel-prelude
+      fast-vect:
+        repo: https://github.com/sigma-andex/purescript-fast-vect.git
+        version: v0.7.0
+        dependencies:
+          - arrays
+          - filterable
+          - foldable-traversable
+          - lists
+          - maybe
+          - ordered-collections
+          - prelude
+          - profunctor
+          - tuples
+          - unfoldable
+      filterable:
+        repo: https://github.com/purescript/purescript-filterable.git
+        version: v5.0.0
+        dependencies:
+          - arrays
+          - either
+          - foldable-traversable
+          - identity
+          - lists
+          - ordered-collections
+      fixed-points:
+        repo: https://github.com/purescript-contrib/purescript-fixed-points.git
+        version: v7.0.0
+        dependencies:
+          - exists
+          - newtype
+          - prelude
+          - transformers
+      fixed-precision:
+        repo: https://github.com/lumihq/purescript-fixed-precision.git
+        version: v5.0.0
+        dependencies:
+          - arrays
+          - bigints
+          - control
+          - integers
+          - maybe
+          - numbers
+          - partial
+          - prelude
+          - strings
+      flame:
+        repo: https://github.com/easafe/purescript-flame.git
+        version: v1.2.0
+        dependencies:
+          - aff
+          - argonaut-codecs
+          - argonaut-core
+          - argonaut-generic
+          - arrays
+          - bifunctors
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - maybe
+          - newtype
+          - nullable
+          - partial
+          - prelude
+          - random
+          - refs
+          - spec
+          - strings
+          - tuples
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-html
+          - web-uievents
+      float32:
+        repo: https://github.com/purescript-contrib/purescript-float32.git
+        version: v2.0.0
+        dependencies:
+          - gen
+          - maybe
+          - prelude
+      foldable-traversable:
+        repo: https://github.com/purescript/purescript-foldable-traversable.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - const
+          - control
+          - either
+          - functors
+          - identity
+          - maybe
+          - newtype
+          - orders
+          - prelude
+          - tuples
+      foreign:
+        repo: https://github.com/purescript/purescript-foreign.git
+        version: v7.0.0
+        dependencies:
+          - either
+          - functions
+          - identity
+          - integers
+          - lists
+          - maybe
+          - prelude
+          - strings
+          - transformers
+      foreign-object:
+        repo: https://github.com/purescript/purescript-foreign-object.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - functions
+          - gen
+          - lists
+          - maybe
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - typelevel-prelude
+          - unfoldable
+      foreign-readwrite:
+        repo: https://github.com/artemisSystem/purescript-foreign-readwrite.git
+        version: v3.0.0
+        dependencies:
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - record
+          - safe-coerce
+          - transformers
+          - unsafe-coerce
+      fork:
+        repo: https://github.com/purescript-contrib/purescript-fork.git
+        version: v6.0.0
+        dependencies:
+          - aff
+      form-urlencoded:
+        repo: https://github.com/purescript-contrib/purescript-form-urlencoded.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - js-uri
+          - maybe
+          - newtype
+          - prelude
+          - strings
+          - tuples
+      formatters:
+        repo: https://github.com/purescript-contrib/purescript-formatters.git
+        version: v7.0.0
+        dependencies:
+          - datetime
+          - fixed-points
+          - lists
+          - numbers
+          - parsing
+          - prelude
+          - transformers
+      free:
+        repo: https://github.com/purescript/purescript-free.git
+        version: v7.0.0
+        dependencies:
+          - catenable-lists
+          - control
+          - distributive
+          - either
+          - exists
+          - foldable-traversable
+          - invariant
+          - lazy
+          - maybe
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+      freeap:
+        repo: https://github.com/ethul/purescript-freeap.git
+        version: v7.0.0
+        dependencies:
+          - const
+          - exists
+          - gen
+          - lists
+      freet:
+        repo: https://github.com/purescript-contrib/purescript-freet.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - bifunctors
+          - effect
+          - either
+          - exists
+          - free
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      functions:
+        repo: https://github.com/purescript/purescript-functions.git
+        version: v6.0.0
+        dependencies:
+          - prelude
+      functors:
+        repo: https://github.com/purescript/purescript-functors.git
+        version: v5.0.0
+        dependencies:
+          - bifunctors
+          - const
+          - contravariant
+          - control
+          - distributive
+          - either
+          - invariant
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - tuples
+          - unsafe-coerce
+      fuzzy:
+        repo: https://github.com/citizennet/purescript-fuzzy.git
+        version: v0.4.0
+        dependencies:
+          - foldable-traversable
+          - foreign-object
+          - newtype
+          - ordered-collections
+          - prelude
+          - rationals
+          - strings
+          - tuples
+      gen:
+        repo: https://github.com/purescript/purescript-gen.git
+        version: v4.0.0
+        dependencies:
+          - either
+          - foldable-traversable
+          - identity
+          - maybe
+          - newtype
+          - nonempty
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      generate-values:
+        repo: https://github.com/jordanmartinez/purescript-generate-values.git
+        version: v1.0.1
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - enums
+          - foldable-traversable
+          - gen
+          - identity
+          - integers
+          - lcg
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - partial
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      geometry-plane:
+        repo: https://github.com/Ebmtranceboy/purescript-geometry-plane.git
+        version: v1.0.3
+        dependencies:
+          - console
+          - effect
+          - psci-support
+          - sparse-polynomials
+      github-actions-toolkit:
+        repo: https://github.com/purescript-contrib/purescript-github-actions-toolkit.git
+        version: v0.5.0
+        dependencies:
+          - aff
+          - aff-promise
+          - effect
+          - foreign-object
+          - node-buffer
+          - node-path
+          - node-streams
+          - nullable
+          - transformers
+      graphs:
+        repo: https://github.com/purescript/purescript-graphs.git
+        version: v8.0.0
+        dependencies:
+          - catenable-lists
+          - ordered-collections
+      group:
+        repo: https://github.com/morganthomas/purescript-group.git
+        version: v4.1.1
+        dependencies:
+          - lists
+      halogen:
+        repo: https://github.com/purescript-halogen/purescript-halogen.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - avar
+          - console
+          - const
+          - dom-indexed
+          - effect
+          - foreign
+          - fork
+          - free
+          - freeap
+          - halogen-subscriptions
+          - halogen-vdom
+          - media-types
+          - nullable
+          - ordered-collections
+          - parallel
+          - profunctor
+          - transformers
+          - unsafe-coerce
+          - unsafe-reference
+          - web-file
+          - web-uievents
+      halogen-css:
+        repo: https://github.com/purescript-halogen/purescript-halogen-css.git
+        version: v10.0.0
+        dependencies:
+          - css
+          - halogen
+      halogen-formless:
+        repo: https://github.com/thomashoneyman/purescript-halogen-formless.git
+        version: v4.0.0
+        dependencies:
+          - convertable-options
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - halogen
+          - heterogeneous
+          - maybe
+          - prelude
+          - record
+          - safe-coerce
+          - type-equality
+          - unsafe-coerce
+          - unsafe-reference
+          - variant
+          - web-events
+          - web-uievents
+      halogen-hooks:
+        repo: https://github.com/thomashoneyman/purescript-halogen-hooks.git
+        version: v0.6.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - effect
+          - exceptions
+          - foldable-traversable
+          - foreign-object
+          - free
+          - freeap
+          - halogen
+          - halogen-subscriptions
+          - maybe
+          - newtype
+          - ordered-collections
+          - parallel
+          - partial
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+          - unsafe-reference
+          - web-dom
+          - web-html
+      halogen-hooks-extra:
+        repo: https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git
+        version: v0.9.0
+        dependencies:
+          - halogen-hooks
+      halogen-store:
+        repo: https://github.com/thomashoneyman/purescript-halogen-store.git
+        version: v0.5.0
+        dependencies:
+          - aff
+          - distributive
+          - effect
+          - fork
+          - halogen
+          - halogen-hooks
+          - halogen-subscriptions
+          - maybe
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-reference
+      halogen-storybook:
+        repo: https://github.com/rnons/purescript-halogen-storybook.git
+        version: v2.0.0
+        dependencies:
+          - foreign-object
+          - halogen
+          - prelude
+          - routing
+      halogen-subscriptions:
+        repo: https://github.com/purescript-halogen/purescript-halogen-subscriptions.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - effect
+          - foldable-traversable
+          - functors
+          - refs
+          - safe-coerce
+          - unsafe-reference
+      halogen-svg-elems:
+        repo: https://github.com/JordanMartinez/purescript-halogen-svg-elems.git
+        version: v6.0.0
+        dependencies:
+          - halogen
+      halogen-vdom:
+        repo: https://github.com/purescript-halogen/purescript-halogen-vdom.git
+        version: v8.0.0
+        dependencies:
+          - bifunctors
+          - effect
+          - foreign
+          - foreign-object
+          - maybe
+          - prelude
+          - refs
+          - tuples
+          - unsafe-coerce
+          - web-html
+      halogen-vdom-string-renderer:
+        repo: https://github.com/purescript-halogen/purescript-halogen-vdom-string-renderer.git
+        version: v0.5.0
+        dependencies:
+          - foreign
+          - halogen-vdom
+          - ordered-collections
+          - prelude
+      heckin:
+        repo: https://github.com/maxdeviant/purescript-heckin.git
+        version: v2.0.1
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - maybe
+          - prelude
+          - strings
+          - transformers
+          - tuples
+          - unicode
+      heterogeneous:
+        repo: https://github.com/natefaubion/purescript-heterogeneous.git
+        version: v0.6.0
+        dependencies:
+          - either
+          - functors
+          - prelude
+          - record
+          - tuples
+          - variant
+      heterogeneous-extrablatt:
+        repo: https://github.com/sigma-andex/purescript-heterogeneous-extrablatt.git
+        version: v0.2.1
+        dependencies:
+          - heterogeneous
+          - prelude
+          - record
+      http-methods:
+        repo: https://github.com/purescript-contrib/purescript-http-methods.git
+        version: v6.0.0
+        dependencies:
+          - either
+          - prelude
+          - strings
+      httpure:
+        repo: https://github.com/citizennet/purescript-httpure.git
+        version: v0.15.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - js-uri
+          - maybe
+          - newtype
+          - node-buffer
+          - node-fs
+          - node-http
+          - node-streams
+          - options
+          - ordered-collections
+          - prelude
+          - refs
+          - strings
+          - tuples
+          - type-equality
+      httpurple:
+        repo: https://github.com/sigma-andex/purescript-httpurple.git
+        version: v1.3.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - js-uri
+          - justifill
+          - maybe
+          - newtype
+          - node-buffer
+          - node-fs
+          - node-http
+          - node-net
+          - node-process
+          - node-streams
+          - options
+          - ordered-collections
+          - posix-types
+          - prelude
+          - profunctor
+          - record
+          - refs
+          - routing-duplex
+          - strings
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+      httpurple-argonaut:
+        repo: https://github.com/sigma-andex/purescript-httpurple-argonaut.git
+        version: v1.0.1
+        dependencies:
+          - argonaut
+          - console
+          - effect
+          - either
+          - httpurple
+          - prelude
+      httpurple-yoga-json:
+        repo: https://github.com/sigma-andex/purescript-httpurple-yoga-json.git
+        version: v1.0.0
+        dependencies:
+          - console
+          - effect
+          - either
+          - foreign
+          - httpurple
+          - lists
+          - prelude
+          - yoga-json
+      identity:
+        repo: https://github.com/purescript/purescript-identity.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - invariant
+          - newtype
+          - prelude
+      indexed-monad:
+        repo: https://github.com/garyb/purescript-indexed-monad.git
+        version: v2.1.0
+        dependencies:
+          - control
+          - newtype
+      int64:
+        repo: https://github.com/purescript-contrib/purescript-int64.git
+        version: v2.0.0
+        dependencies:
+          - effect
+          - foreign
+          - functions
+          - integers
+          - maybe
+          - nullable
+          - prelude
+          - quickcheck
+      integers:
+        repo: https://github.com/purescript/purescript-integers.git
+        version: v6.0.0
+        dependencies:
+          - maybe
+          - numbers
+          - prelude
+      interpolate:
+        repo: https://github.com/jordanmartinez/purescript-interpolate.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+      invariant:
+        repo: https://github.com/purescript/purescript-invariant.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - prelude
+      js-date:
+        repo: https://github.com/purescript-contrib/purescript-js-date.git
+        version: v8.0.0
+        dependencies:
+          - datetime
+          - effect
+          - exceptions
+          - foreign
+          - integers
+          - now
+      js-fileio:
+        repo: https://github.com/newlandsvalley/purescript-js-fileio.git
+        version: v3.0.0
+        dependencies:
+          - aff
+          - effect
+          - prelude
+      js-timers:
+        repo: https://github.com/purescript-contrib/purescript-js-timers.git
+        version: v6.1.0
+        dependencies:
+          - effect
+      js-uri:
+        repo: https://github.com/purescript-contrib/purescript-js-uri.git
+        version: v3.0.0
+        dependencies:
+          - functions
+          - maybe
+      justifill:
+        repo: https://github.com/i-am-the-slime/purescript-justifill.git
+        version: v0.5.0
+        dependencies:
+          - maybe
+          - prelude
+          - record
+          - typelevel-prelude
+      jwt:
+        repo: https://github.com/menelaos/purescript-jwt.git
+        version: v0.0.9
+        dependencies:
+          - argonaut-core
+          - arrays
+          - b64
+          - either
+          - exceptions
+          - prelude
+          - profunctor-lenses
+          - strings
+      language-cst-parser:
+        repo: https://github.com/natefaubion/purescript-language-cst-parser.git
+        version: v0.12.0
+        dependencies:
+          - arrays
+          - const
+          - control
+          - either
+          - foldable-traversable
+          - free
+          - functions
+          - functors
+          - identity
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - ordered-collections
+          - partial
+          - prelude
+          - st
+          - strings
+          - transformers
+          - tuples
+          - typelevel-prelude
+          - unfoldable
+          - unsafe-coerce
+      lazy:
+        repo: https://github.com/purescript/purescript-lazy.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - invariant
+          - prelude
+      lcg:
+        repo: https://github.com/purescript/purescript-lcg.git
+        version: v4.0.0
+        dependencies:
+          - effect
+          - integers
+          - maybe
+          - partial
+          - prelude
+          - random
+      leibniz:
+        repo: https://github.com/paf31/purescript-leibniz.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+          - unsafe-coerce
+      linalg:
+        repo: https://github.com/gbagan/purescript-linalg.git
+        version: v5.1.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - functions
+          - maybe
+          - prelude
+          - tuples
+      lists:
+        repo: https://github.com/purescript/purescript-lists.git
+        version: v7.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - foldable-traversable
+          - lazy
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      logging:
+        repo: https://github.com/rightfold/purescript-logging.git
+        version: v3.0.0
+        dependencies:
+          - console
+          - contravariant
+          - effect
+          - either
+          - prelude
+          - transformers
+          - tuples
+      machines:
+        repo: https://github.com/purescript-contrib/purescript-machines.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - lists
+          - maybe
+          - prelude
+          - profunctor
+          - tuples
+          - unfoldable
+      matrices:
+        repo: https://github.com/kRITZCREEK/purescript-matrices.git
+        version: v5.0.1
+        dependencies:
+          - arrays
+          - strings
+      matryoshka:
+        repo: https://github.com/purescript-contrib/purescript-matryoshka.git
+        version: v1.0.0
+        dependencies:
+          - fixed-points
+          - free
+          - prelude
+          - profunctor
+          - transformers
+      maybe:
+        repo: https://github.com/purescript/purescript-maybe.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - invariant
+          - newtype
+          - prelude
+      media-types:
+        repo: https://github.com/purescript-contrib/purescript-media-types.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      metadata:
+        repo: https://github.com/purescript/purescript-metadata.git
+        version: v0.15.0
+        dependencies: []
+      midi:
+        repo: https://github.com/newlandsvalley/purescript-midi.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - ordered-collections
+          - prelude
+          - signal
+          - string-parsers
+          - strings
+          - tuples
+          - unfoldable
+      minibench:
+        repo: https://github.com/purescript/purescript-minibench.git
+        version: v4.0.0
+        dependencies:
+          - console
+          - effect
+          - integers
+          - numbers
+          - partial
+          - prelude
+          - refs
+      mmorph:
+        repo: https://github.com/Thimoteus/purescript-mmorph.git
+        version: v7.0.0
+        dependencies:
+          - free
+          - functors
+          - transformers
+      monad-control:
+        repo: https://github.com/athanclark/purescript-monad-control.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - freet
+          - identity
+          - lists
+      monad-logger:
+        repo: https://github.com/cprussin/purescript-monad-logger.git
+        version: v1.3.1
+        dependencies:
+          - aff
+          - ansi
+          - argonaut
+          - arrays
+          - console
+          - control
+          - effect
+          - foldable-traversable
+          - foreign-object
+          - integers
+          - js-date
+          - maybe
+          - newtype
+          - ordered-collections
+          - prelude
+          - strings
+          - transformers
+          - tuples
+      monad-loops:
+        repo: https://github.com/mlang/purescript-monad-loops.git
+        version: v0.5.0
+        dependencies:
+          - lists
+          - maybe
+          - prelude
+          - tailrec
+          - tuples
+      monad-unlift:
+        repo: https://github.com/athanclark/purescript-monad-unlift.git
+        version: v1.0.1
+        dependencies:
+          - monad-control
+      monoidal:
+        repo: https://github.com/mcneissue/purescript-monoidal.git
+        version: v0.16.0
+        dependencies:
+          - either
+          - profunctor
+          - these
+          - tuples
+      morello:
+        repo: https://github.com/sigma-andex/purescript-morello.git
+        version: v0.3.2
+        dependencies:
+          - arrays
+          - barlow-lens
+          - foldable-traversable
+          - heterogeneous
+          - heterogeneous-extrablatt
+          - newtype
+          - prelude
+          - profunctor
+          - profunctor-lenses
+          - record
+          - tuples
+          - typelevel-prelude
+          - validation
+      motsunabe:
+        repo: https://github.com/justinwoo/purescript-motsunabe.git
+        version: v2.0.0
+        dependencies:
+          - lists
+          - strings
+      nano-id:
+        repo: https://github.com/eikooc/nano-id.git
+        version: v1.1.0
+        dependencies:
+          - aff
+          - effect
+          - lists
+          - maybe
+          - prelude
+          - random
+          - spec
+          - strings
+          - stringutils
+      naturals:
+        repo: https://github.com/LiamGoodacre/purescript-naturals.git
+        version: v3.0.0
+        dependencies:
+          - enums
+          - maybe
+          - prelude
+      nested-functor:
+        repo: https://github.com/acple/purescript-nested-functor.git
+        version: v0.2.1
+        dependencies:
+          - prelude
+          - type-equality
+      newtype:
+        repo: https://github.com/purescript/purescript-newtype.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+          - safe-coerce
+      node-buffer:
+        repo: https://github.com/purescript-node/purescript-node-buffer.git
+        version: v8.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - maybe
+          - st
+          - unsafe-coerce
+      node-buffer-blob:
+        repo: https://github.com/purescript-node/purescript-node-buffer-blob.git
+        version: v1.0.0
+        dependencies:
+          - aff-promise
+          - arraybuffer-types
+          - arrays
+          - console
+          - effect
+          - maybe
+          - media-types
+          - newtype
+          - node-buffer
+          - nullable
+          - prelude
+          - web-streams
+      node-child-process:
+        repo: https://github.com/purescript-node/purescript-node-child-process.git
+        version: v9.0.0
+        dependencies:
+          - exceptions
+          - foreign
+          - foreign-object
+          - functions
+          - node-fs
+          - node-streams
+          - nullable
+          - posix-types
+          - unsafe-coerce
+      node-fs:
+        repo: https://github.com/purescript-node/purescript-node-fs.git
+        version: v8.0.0
+        dependencies:
+          - datetime
+          - effect
+          - either
+          - enums
+          - exceptions
+          - functions
+          - integers
+          - js-date
+          - maybe
+          - node-buffer
+          - node-path
+          - node-streams
+          - nullable
+          - partial
+          - prelude
+          - strings
+          - unsafe-coerce
+      node-fs-aff:
+        repo: https://github.com/purescript-node/purescript-node-fs-aff.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - either
+          - node-fs
+          - node-path
+      node-http:
+        repo: https://github.com/purescript-node/purescript-node-http.git
+        version: v8.0.0
+        dependencies:
+          - arraybuffer-types
+          - contravariant
+          - effect
+          - foreign
+          - foreign-object
+          - maybe
+          - node-buffer
+          - node-net
+          - node-streams
+          - node-url
+          - nullable
+          - options
+          - prelude
+          - unsafe-coerce
+      node-net:
+        repo: https://github.com/purescript-node/purescript-node-net.git
+        version: v4.0.0
+        dependencies:
+          - effect
+          - either
+          - exceptions
+          - foreign
+          - maybe
+          - node-buffer
+          - node-fs
+          - nullable
+          - options
+          - prelude
+          - transformers
+      node-path:
+        repo: https://github.com/purescript-node/purescript-node-path.git
+        version: v5.0.0
+        dependencies:
+          - effect
+      node-process:
+        repo: https://github.com/purescript-node/purescript-node-process.git
+        version: v10.0.0
+        dependencies:
+          - effect
+          - foreign-object
+          - maybe
+          - node-streams
+          - posix-types
+          - prelude
+          - unsafe-coerce
+      node-readline:
+        repo: https://github.com/purescript-node/purescript-node-readline.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - foreign
+          - node-process
+          - node-streams
+          - options
+          - prelude
+      node-streams:
+        repo: https://github.com/purescript-node/purescript-node-streams.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - either
+          - exceptions
+          - node-buffer
+          - nullable
+          - prelude
+      node-streams-aff:
+        repo: https://github.com/jamesdbrock/purescript-node-streams-aff.git
+        version: v2.0.0
+        dependencies:
+          - aff
+          - arrays
+          - effect
+          - either
+          - exceptions
+          - maybe
+          - node-buffer
+          - node-streams
+          - prelude
+          - st
+          - tuples
+      node-url:
+        repo: https://github.com/purescript-node/purescript-node-url.git
+        version: v6.0.0
+        dependencies:
+          - nullable
+      nonempty:
+        repo: https://github.com/purescript/purescript-nonempty.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - maybe
+          - prelude
+          - tuples
+          - unfoldable
+      now:
+        repo: https://github.com/purescript-contrib/purescript-now.git
+        version: v6.0.0
+        dependencies:
+          - datetime
+          - effect
+      npm-package-json:
+        repo: https://github.com/maxdeviant/purescript-npm-package-json.git
+        version: v2.0.0
+        dependencies:
+          - argonaut
+          - control
+          - either
+          - foreign-object
+          - maybe
+          - ordered-collections
+          - prelude
+      nullable:
+        repo: https://github.com/purescript-contrib/purescript-nullable.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - functions
+          - maybe
+      numbers:
+        repo: https://github.com/purescript/purescript-numbers.git
+        version: v9.0.0
+        dependencies:
+          - functions
+          - maybe
+      open-folds:
+        repo: https://github.com/purescript-open-community/purescript-open-folds.git
+        version: v6.3.0
+        dependencies:
+          - bifunctors
+          - console
+          - control
+          - distributive
+          - effect
+          - either
+          - foldable-traversable
+          - identity
+          - invariant
+          - maybe
+          - newtype
+          - ordered-collections
+          - prelude
+          - profunctor
+          - psci-support
+          - tuples
+      open-memoize:
+        repo: https://github.com/purescript-open-community/purescript-open-memoize.git
+        version: v6.1.0
+        dependencies:
+          - console
+          - effect
+          - either
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - psci-support
+          - strings
+          - tuples
+      open-pairing:
+        repo: https://github.com/purescript-open-community/purescript-open-pairing.git
+        version: v6.1.0
+        dependencies:
+          - console
+          - control
+          - effect
+          - either
+          - free
+          - functors
+          - identity
+          - newtype
+          - prelude
+          - psci-support
+          - transformers
+          - tuples
+      options:
+        repo: https://github.com/purescript-contrib/purescript-options.git
+        version: v7.0.0
+        dependencies:
+          - contravariant
+          - foreign
+          - foreign-object
+          - maybe
+          - tuples
+      optparse:
+        repo: https://github.com/f-o-a-m/purescript-optparse.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - control
+          - effect
+          - either
+          - enums
+          - exists
+          - exitcodes
+          - foldable-traversable
+          - free
+          - gen
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - newtype
+          - node-buffer
+          - node-process
+          - node-streams
+          - nonempty
+          - numbers
+          - open-memoize
+          - partial
+          - prelude
+          - quickcheck
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+      ordered-collections:
+        repo: https://github.com/purescript/purescript-ordered-collections.git
+        version: v3.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - gen
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - unfoldable
+      ordered-set:
+        repo: https://github.com/flip111/purescript-ordered-set.git
+        version: v0.4.0
+        dependencies:
+          - argonaut-codecs
+          - arrays
+          - partial
+          - prelude
+          - unfoldable
+      orders:
+        repo: https://github.com/purescript/purescript-orders.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      pairs:
+        repo: https://github.com/sharkdp/purescript-pairs.git
+        version: v9.0.0
+        dependencies:
+          - console
+          - distributive
+          - foldable-traversable
+          - quickcheck
+      parallel:
+        repo: https://github.com/purescript/purescript-parallel.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - functors
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - refs
+          - transformers
+      parsing:
+        repo: https://github.com/purescript-contrib/purescript-parsing.git
+        version: v9.1.0
+        dependencies:
+          - arrays
+          - either
+          - foldable-traversable
+          - identity
+          - integers
+          - lists
+          - maybe
+          - nullable
+          - prelude
+          - strings
+          - transformers
+          - unicode
+      parsing-dataview:
+        repo: https://github.com/jamesdbrock/purescript-parsing-dataview.git
+        version: v3.1.0
+        dependencies:
+          - arraybuffer
+          - arraybuffer-types
+          - effect
+          - float32
+          - maybe
+          - parsing
+          - prelude
+          - transformers
+          - tuples
+          - uint
+      partial:
+        repo: https://github.com/purescript/purescript-partial.git
+        version: v4.0.0
+        dependencies: []
+      pathy:
+        repo: https://github.com/purescript-contrib/purescript-pathy.git
+        version: v9.0.0
+        dependencies:
+          - console
+          - exceptions
+          - lists
+          - partial
+          - profunctor
+          - strings
+          - transformers
+          - typelevel-prelude
+          - unsafe-coerce
+      pha:
+        repo: https://github.com/gbagan/purescript-pha.git
+        version: v0.9.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - datetime
+          - effect
+          - foldable-traversable
+          - free
+          - integers
+          - maybe
+          - prelude
+          - profunctor-lenses
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+          - unsafe-reference
+          - web-dom
+          - web-events
+          - web-html
+          - web-pointerevents
+          - web-uievents
+      phaser:
+        repo: https://github.com/lfarroco/purescript-phaser.git
+        version: v0.6.0
+        dependencies:
+          - canvas
+          - console
+          - effect
+          - maybe
+          - nullable
+          - options
+          - prelude
+          - web-html
+      pipes:
+        repo: https://github.com/felixschl/purescript-pipes.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - lists
+          - mmorph
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      point-free:
+        repo: https://github.com/ursi/purescript-point-free.git
+        version: v1.0.0
+        dependencies:
+          - prelude
+      polymorphic-vectors:
+        repo: https://github.com/artemisSystem/purescript-polymorphic-vectors.git
+        version: v4.0.0
+        dependencies:
+          - distributive
+          - foldable-traversable
+          - numbers
+          - prelude
+          - record
+          - safe-coerce
+          - type-equality
+          - typelevel-prelude
+      posix-types:
+        repo: https://github.com/purescript-node/purescript-posix-types.git
+        version: v6.0.0
+        dependencies:
+          - maybe
+          - prelude
+      precise:
+        repo: https://github.com/purescript-contrib/purescript-precise.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - exceptions
+          - gen
+          - integers
+          - lists
+          - numbers
+          - prelude
+          - strings
+      precise-datetime:
+        repo: https://github.com/awakesecurity/purescript-precise-datetime.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - datetime
+          - decimals
+          - either
+          - enums
+          - foldable-traversable
+          - formatters
+          - integers
+          - js-date
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - strings
+          - tuples
+          - unicode
+      prelude:
+        repo: https://github.com/purescript/purescript-prelude.git
+        version: v6.0.0
+        dependencies: []
+      prettier-printer:
+        repo: https://github.com/paulyoung/purescript-prettier-printer.git
+        version: v3.0.0
+        dependencies:
+          - console
+          - lists
+          - prelude
+          - strings
+          - tuples
+      profunctor:
+        repo: https://github.com/purescript/purescript-profunctor.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - distributive
+          - either
+          - exists
+          - invariant
+          - newtype
+          - prelude
+          - tuples
+      profunctor-lenses:
+        repo: https://github.com/purescript-contrib/purescript-profunctor-lenses.git
+        version: v8.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - const
+          - control
+          - distributive
+          - either
+          - foldable-traversable
+          - foreign-object
+          - functors
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - ordered-collections
+          - partial
+          - prelude
+          - profunctor
+          - record
+          - transformers
+          - tuples
+      protobuf:
+        repo: https://github.com/xc-jp/purescript-protobuf.git
+        version: v4.0.0
+        dependencies:
+          - arraybuffer
+          - arraybuffer-builder
+          - arraybuffer-types
+          - arrays
+          - control
+          - effect
+          - either
+          - enums
+          - exceptions
+          - float32
+          - foldable-traversable
+          - functions
+          - int64
+          - maybe
+          - newtype
+          - parsing
+          - parsing-dataview
+          - prelude
+          - record
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+          - uint
+          - web-encoding
+      ps-cst:
+        repo: https://github.com/purescript-codegen/purescript-ps-cst.git
+        version: v1.2.0
+        dependencies:
+          - ansi
+          - console
+          - dodo-printer
+          - effect
+          - node-fs-aff
+          - node-path
+          - psci-support
+          - record
+          - strings
+      psa-utils:
+        repo: https://github.com/natefaubion/purescript-psa-utils.git
+        version: v8.0.0
+        dependencies:
+          - ansi
+          - argonaut-codecs
+          - argonaut-core
+          - arrays
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - maybe
+          - node-path
+          - ordered-collections
+          - prelude
+          - strings
+          - tuples
+          - unsafe-coerce
+      psc-ide:
+        repo: https://github.com/kRITZCREEK/purescript-psc-ide.git
+        version: v19.0.0
+        dependencies:
+          - aff
+          - argonaut
+          - arrays
+          - console
+          - maybe
+          - node-child-process
+          - node-fs
+          - parallel
+          - random
+      psci-support:
+        repo: https://github.com/purescript/purescript-psci-support.git
+        version: v6.0.0
+        dependencies:
+          - console
+          - effect
+          - prelude
+      qualified-do:
+        repo: https://github.com/artemisSystem/purescript-qualified-do.git
+        version: v2.2.0
+        dependencies:
+          - arrays
+          - control
+          - foldable-traversable
+          - parallel
+          - prelude
+          - unfoldable
+      quantities:
+        repo: https://github.com/sharkdp/purescript-quantities.git
+        version: v12.0.1
+        dependencies:
+          - decimals
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - newtype
+          - nonempty
+          - numbers
+          - pairs
+          - prelude
+          - tuples
+      quickcheck:
+        repo: https://github.com/purescript/purescript-quickcheck.git
+        version: v8.0.1
+        dependencies:
+          - arrays
+          - console
+          - control
+          - effect
+          - either
+          - enums
+          - exceptions
+          - foldable-traversable
+          - gen
+          - identity
+          - integers
+          - lazy
+          - lcg
+          - lists
+          - maybe
+          - newtype
+          - nonempty
+          - numbers
+          - partial
+          - prelude
+          - record
+          - st
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+          - unfoldable
+      quickcheck-combinators:
+        repo: https://github.com/athanclark/purescript-quickcheck-combinators.git
+        version: v0.1.3
+        dependencies:
+          - quickcheck
+          - typelevel
+      quickcheck-laws:
+        repo: https://github.com/purescript-contrib/purescript-quickcheck-laws.git
+        version: v7.0.0
+        dependencies:
+          - enums
+          - quickcheck
+      quickcheck-utf8:
+        repo: https://github.com/openchronology/purescript-quickcheck-utf8.git
+        version: v0.0.0
+        dependencies:
+          - quickcheck
+      quotient:
+        repo: https://github.com/rightfold/purescript-quotient.git
+        version: v3.0.0
+        dependencies:
+          - prelude
+          - quickcheck
+      random:
+        repo: https://github.com/purescript/purescript-random.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - integers
+      rationals:
+        repo: https://github.com/anttih/purescript-rationals.git
+        version: v5.0.0
+        dependencies:
+          - integers
+          - prelude
+      react:
+        repo: https://github.com/purescript-contrib/purescript-react.git
+        version: v10.0.1
+        dependencies:
+          - effect
+          - exceptions
+          - maybe
+          - nullable
+          - prelude
+          - typelevel-prelude
+          - unsafe-coerce
+      react-basic:
+        repo: https://github.com/lumihq/purescript-react-basic.git
+        version: v17.0.0
+        dependencies:
+          - effect
+          - prelude
+          - record
+      react-basic-dom:
+        repo: https://github.com/lumihq/purescript-react-basic-dom.git
+        version: v5.0.0
+        dependencies:
+          - effect
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - nullable
+          - prelude
+          - react-basic
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-file
+          - web-html
+      react-basic-hooks:
+        repo: https://github.com/megamaddu/purescript-react-basic-hooks.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - aff-promise
+          - bifunctors
+          - console
+          - control
+          - datetime
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - functions
+          - indexed-monad
+          - integers
+          - maybe
+          - newtype
+          - now
+          - nullable
+          - ordered-collections
+          - prelude
+          - react-basic
+          - refs
+          - tuples
+          - type-equality
+          - unsafe-coerce
+          - unsafe-reference
+          - web-html
+      react-dom:
+        repo: https://github.com/purescript-contrib/purescript-react-dom.git
+        version: v8.0.0
+        dependencies:
+          - effect
+          - react
+          - web-dom
+      read:
+        repo: https://github.com/truqu/purescript-read.git
+        version: v1.0.1
+        dependencies:
+          - maybe
+          - prelude
+          - strings
+      record:
+        repo: https://github.com/purescript/purescript-record.git
+        version: v4.0.0
+        dependencies:
+          - functions
+          - prelude
+          - unsafe-coerce
+      refined:
+        repo: https://github.com/danieljharvey/purescript-refined.git
+        version: v1.0.0
+        dependencies:
+          - argonaut
+          - effect
+          - prelude
+          - quickcheck
+          - typelevel
+      refs:
+        repo: https://github.com/purescript/purescript-refs.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - prelude
+      remotedata:
+        repo: https://github.com/krisajenkins/purescript-remotedata.git
+        version: v5.0.0
+        dependencies:
+          - bifunctors
+          - either
+          - profunctor-lenses
+      resource:
+        repo: https://github.com/joneshf/purescript-resource.git
+        version: v2.0.1
+        dependencies:
+          - aff
+          - console
+          - control
+          - effect
+          - newtype
+          - prelude
+          - psci-support
+          - refs
+      resourcet:
+        repo: https://github.com/robertdp/purescript-resourcet.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - effect
+          - foldable-traversable
+          - maybe
+          - ordered-collections
+          - parallel
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+      result:
+        repo: https://github.com/ad-si/purescript-result.git
+        version: v1.0.3
+        dependencies:
+          - either
+          - foldable-traversable
+          - prelude
+      return:
+        repo: https://github.com/ursi/purescript-return.git
+        version: v0.2.0
+        dependencies:
+          - foldable-traversable
+          - point-free
+          - prelude
+      ring-modules:
+        repo: https://github.com/f-o-a-m/purescript-ring-modules.git
+        version: v5.0.1
+        dependencies:
+          - prelude
+      routing:
+        repo: https://github.com/purescript-contrib/purescript-routing.git
+        version: v11.0.0
+        dependencies:
+          - aff
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - integers
+          - js-uri
+          - lists
+          - maybe
+          - numbers
+          - partial
+          - prelude
+          - semirings
+          - tuples
+          - validation
+          - web-html
+      routing-duplex:
+        repo: https://github.com/natefaubion/purescript-routing-duplex.git
+        version: v0.6.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - js-uri
+          - lazy
+          - numbers
+          - prelude
+          - profunctor
+          - record
+          - strings
+          - typelevel-prelude
+      run:
+        repo: https://github.com/natefaubion/purescript-run.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - free
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - tailrec
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - variant
+      safe-coerce:
+        repo: https://github.com/purescript/purescript-safe-coerce.git
+        version: v2.0.0
+        dependencies:
+          - unsafe-coerce
+      safely:
+        repo: https://github.com/paf31/purescript-safely.git
+        version: v4.0.1
+        dependencies:
+          - freet
+          - lists
+      selection-foldable:
+        repo: https://github.com/jamieyung/purescript-selection-foldable.git
+        version: v0.2.0
+        dependencies:
+          - filterable
+          - foldable-traversable
+          - maybe
+          - prelude
+      semirings:
+        repo: https://github.com/purescript/purescript-semirings.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - lists
+          - newtype
+          - prelude
+      signal:
+        repo: https://github.com/bodil/purescript-signal.git
+        version: v13.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - foldable-traversable
+          - maybe
+          - prelude
+      simple-emitter:
+        repo: https://github.com/oreshinya/purescript-simple-emitter.git
+        version: v2.0.0
+        dependencies:
+          - ordered-collections
+          - refs
+      sized-matrices:
+        repo: https://github.com/csicar/purescript-sized-matrices.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - distributive
+          - foldable-traversable
+          - maybe
+          - prelude
+          - sized-vectors
+          - strings
+          - typelevel
+          - unfoldable
+          - vectorfield
+      sized-vectors:
+        repo: https://github.com/bodil/purescript-sized-vectors.git
+        version: v5.0.2
+        dependencies:
+          - argonaut
+          - arrays
+          - distributive
+          - foldable-traversable
+          - maybe
+          - prelude
+          - quickcheck
+          - typelevel
+          - unfoldable
+      slug:
+        repo: https://github.com/thomashoneyman/purescript-slug.git
+        version: v3.0.1
+        dependencies:
+          - argonaut-codecs
+          - maybe
+          - prelude
+          - strings
+          - unicode
+      soundfonts:
+        repo: https://github.com/newlandsvalley/purescript-soundfonts.git
+        version: v4.1.0
+        dependencies:
+          - aff
+          - affjax
+          - affjax-web
+          - argonaut-core
+          - arraybuffer-types
+          - arrays
+          - b64
+          - bifunctors
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign-object
+          - http-methods
+          - integers
+          - lists
+          - maybe
+          - midi
+          - ordered-collections
+          - parallel
+          - partial
+          - prelude
+          - strings
+          - transformers
+          - tuples
+      sparse-matrices:
+        repo: https://github.com/Ebmtranceboy/purescript-sparse-matrices.git
+        version: v1.2.1
+        dependencies:
+          - console
+          - effect
+          - prelude
+          - sparse-polynomials
+      sparse-polynomials:
+        repo: https://github.com/Ebmtranceboy/purescript-sparse-polynomials.git
+        version: v1.0.5
+        dependencies:
+          - cartesian
+          - console
+          - effect
+          - ordered-collections
+          - prelude
+          - rationals
+          - tuples
+      spec:
+        repo: https://github.com/purescript-spec/purescript-spec.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - ansi
+          - avar
+          - console
+          - exceptions
+          - foldable-traversable
+          - fork
+          - now
+          - pipes
+          - prelude
+          - strings
+          - transformers
+      spec-discovery:
+        repo: https://github.com/purescript-spec/purescript-spec-discovery.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - aff-promise
+          - arrays
+          - console
+          - effect
+          - foldable-traversable
+          - node-fs
+          - prelude
+          - spec
+      spec-quickcheck:
+        repo: https://github.com/purescript-spec/purescript-spec-quickcheck.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - prelude
+          - quickcheck
+          - random
+          - spec
+      ssrs:
+        repo: https://github.com/PureFunctor/purescript-ssrs.git
+        version: v1.0.0
+        dependencies:
+          - dissect
+          - either
+          - fixed-points
+          - free
+          - lists
+          - prelude
+          - safe-coerce
+          - tailrec
+          - tuples
+          - variant
+      st:
+        repo: https://github.com/purescript/purescript-st.git
+        version: v6.0.0
+        dependencies:
+          - partial
+          - prelude
+          - tailrec
+          - unsafe-coerce
+      strictlypositiveint:
+        repo: https://github.com/jamieyung/purescript-strictlypositiveint.git
+        version: v1.0.1
+        dependencies:
+          - prelude
+      string-parsers:
+        repo: https://github.com/purescript-contrib/purescript-string-parsers.git
+        version: v8.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - prelude
+          - strings
+          - tailrec
+      strings:
+        repo: https://github.com/purescript/purescript-strings.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - enums
+          - foldable-traversable
+          - gen
+          - integers
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+          - unsafe-coerce
+      strings-extra:
+        repo: https://github.com/purescript-contrib/purescript-strings-extra.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - maybe
+          - prelude
+          - strings
+          - unicode
+      stringutils:
+        repo: https://github.com/menelaos/purescript-stringutils.git
+        version: v0.0.12
+        dependencies:
+          - arrays
+          - integers
+          - maybe
+          - partial
+          - prelude
+          - strings
+      substitute:
+        repo: https://github.com/ursi/purescript-substitute.git
+        version: v0.2.3
+        dependencies:
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - prelude
+          - return
+          - strings
+      supply:
+        repo: https://github.com/ajnsit/purescript-supply.git
+        version: v0.2.0
+        dependencies:
+          - console
+          - control
+          - effect
+          - lazy
+          - prelude
+          - refs
+          - tuples
+      tailrec:
+        repo: https://github.com/purescript/purescript-tailrec.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - effect
+          - either
+          - identity
+          - maybe
+          - partial
+          - prelude
+          - refs
+      test-unit:
+        repo: https://github.com/bodil/purescript-test-unit.git
+        version: v17.0.0
+        dependencies:
+          - aff
+          - avar
+          - effect
+          - either
+          - free
+          - js-timers
+          - lists
+          - prelude
+          - quickcheck
+          - strings
+      thermite:
+        repo: https://github.com/paf31/purescript-thermite.git
+        version: v6.3.1
+        dependencies:
+          - aff
+          - coroutines
+          - freet
+          - profunctor-lenses
+          - react
+      thermite-dom:
+        repo: https://github.com/athanclark/purescript-thermite-dom.git
+        version: v0.3.1
+        dependencies:
+          - react
+          - react-dom
+          - thermite
+          - web-html
+      these:
+        repo: https://github.com/purescript-contrib/purescript-these.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - gen
+          - lists
+          - quickcheck
+          - quickcheck-laws
+          - tuples
+      transformers:
+        repo: https://github.com/purescript/purescript-transformers.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - distributive
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - identity
+          - lazy
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      tree-rose:
+        repo: https://github.com/jordanmartinez/purescript-tree-rose.git
+        version: v4.0.2
+        dependencies:
+          - control
+          - foldable-traversable
+          - free
+          - lists
+          - maybe
+          - prelude
+          - tailrec
+      tuples:
+        repo: https://github.com/purescript/purescript-tuples.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - invariant
+          - prelude
+      two-or-more:
+        repo: https://github.com/i-am-the-slime/purescript-two-or-more.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - foldable-traversable
+          - maybe
+          - partial
+          - prelude
+          - psci-support
+          - tuples
+      type-equality:
+        repo: https://github.com/purescript/purescript-type-equality.git
+        version: v4.0.1
+        dependencies: []
+      typelevel:
+        repo: https://github.com/bodil/purescript-typelevel.git
+        version: v6.0.0
+        dependencies:
+          - partial
+          - prelude
+          - tuples
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-lists:
+        repo: https://github.com/PureFunctor/purescript-typelevel-lists.git
+        version: v2.1.0
+        dependencies:
+          - prelude
+          - tuples
+          - typelevel-peano
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-peano:
+        repo: https://github.com/csicar/purescript-typelevel-peano.git
+        version: v1.0.1
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - prelude
+          - psci-support
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-prelude:
+        repo: https://github.com/purescript/purescript-typelevel-prelude.git
+        version: v7.0.0
+        dependencies:
+          - prelude
+          - type-equality
+      typelevel-rows:
+        repo: https://github.com/jordanmartinez/purescript-typelevel-rows.git
+        version: v0.1.0
+        dependencies:
+          - prelude
+      uint:
+        repo: https://github.com/purescript-contrib/purescript-uint.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - enums
+          - gen
+          - maybe
+          - numbers
+          - prelude
+      uncurried-transformers:
+        repo: https://github.com/PureFunctor/purescript-uncurried-transformers.git
+        version: v1.1.0
+        dependencies:
+          - control
+          - effect
+          - either
+          - functions
+          - identity
+          - prelude
+          - safe-coerce
+          - tailrec
+          - transformers
+          - tuples
+      undefined-is-not-a-problem:
+        repo: https://github.com/paluh/purescript-undefined-is-not-a-problem.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - assert
+          - effect
+          - either
+          - foreign
+          - maybe
+          - newtype
+          - prelude
+          - random
+          - tuples
+          - type-equality
+          - unsafe-coerce
+      unfoldable:
+        repo: https://github.com/purescript/purescript-unfoldable.git
+        version: v6.0.0
+        dependencies:
+          - foldable-traversable
+          - maybe
+          - partial
+          - prelude
+          - tuples
+      unicode:
+        repo: https://github.com/purescript-contrib/purescript-unicode.git
+        version: v6.0.0
+        dependencies:
+          - foldable-traversable
+          - maybe
+          - strings
+      unlift:
+        repo: https://github.com/tweag/purescript-unlift.git
+        version: v1.0.1
+        dependencies:
+          - aff
+          - effect
+          - either
+          - freet
+          - identity
+          - lists
+          - maybe
+          - monad-control
+          - prelude
+          - st
+          - transformers
+          - tuples
+      unsafe-coerce:
+        repo: https://github.com/purescript/purescript-unsafe-coerce.git
+        version: v6.0.0
+        dependencies: []
+      unsafe-reference:
+        repo: https://github.com/purescript-contrib/purescript-unsafe-reference.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+      uri:
+        repo: https://github.com/purescript-contrib/purescript-uri.git
+        version: v9.0.0
+        dependencies:
+          - arrays
+          - integers
+          - js-uri
+          - numbers
+          - parsing
+          - prelude
+          - profunctor-lenses
+          - these
+          - transformers
+          - unfoldable
+      validation:
+        repo: https://github.com/purescript/purescript-validation.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - newtype
+          - prelude
+      variant:
+        repo: https://github.com/natefaubion/purescript-variant.git
+        version: v8.0.0
+        dependencies:
+          - enums
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - record
+          - tuples
+          - unsafe-coerce
+      vectorfield:
+        repo: https://github.com/csicar/purescript-vectorfield.git
+        version: v1.0.1
+        dependencies:
+          - console
+          - effect
+          - group
+          - prelude
+          - psci-support
+      versions:
+        repo: https://github.com/hdgarrood/purescript-versions.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - either
+          - foldable-traversable
+          - functions
+          - integers
+          - lists
+          - maybe
+          - orders
+          - parsing
+          - partial
+          - strings
+      web-clipboard:
+        repo: https://github.com/purescript-web/purescript-web-clipboard.git
+        version: v4.0.0
+        dependencies:
+          - web-html
+      web-cssom:
+        repo: https://github.com/purescript-web/purescript-web-cssom.git
+        version: v2.0.0
+        dependencies:
+          - web-dom
+          - web-html
+          - web-uievents
+      web-dom:
+        repo: https://github.com/purescript-web/purescript-web-dom.git
+        version: v6.0.0
+        dependencies:
+          - web-events
+      web-dom-parser:
+        repo: https://github.com/purescript-web/purescript-web-dom-parser.git
+        version: v8.0.0
+        dependencies:
+          - effect
+          - partial
+          - prelude
+          - web-dom
+      web-dom-xpath:
+        repo: https://github.com/purescript-web/purescript-web-dom-xpath.git
+        version: v3.0.0
+        dependencies:
+          - web-dom
+      web-encoding:
+        repo: https://github.com/purescript-web/purescript-web-encoding.git
+        version: v3.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - newtype
+          - prelude
+      web-events:
+        repo: https://github.com/purescript-web/purescript-web-events.git
+        version: v4.0.0
+        dependencies:
+          - datetime
+          - enums
+          - foreign
+          - nullable
+      web-fetch:
+        repo: https://github.com/purescript-web/purescript-web-fetch.git
+        version: v3.0.0
+        dependencies:
+          - effect
+          - foreign-object
+          - http-methods
+          - prelude
+          - record
+          - typelevel-prelude
+          - web-file
+          - web-promise
+          - web-streams
+      web-file:
+        repo: https://github.com/purescript-web/purescript-web-file.git
+        version: v4.0.0
+        dependencies:
+          - foreign
+          - media-types
+          - web-dom
+      web-html:
+        repo: https://github.com/purescript-web/purescript-web-html.git
+        version: v4.0.0
+        dependencies:
+          - js-date
+          - web-dom
+          - web-file
+          - web-storage
+      web-page-visibility:
+        repo: https://git.sr.ht/~toastal/purescript-web-page-visibility
+        version: v2.0.0
+        dependencies:
+          - effect
+          - enums
+          - exceptions
+          - maybe
+          - prelude
+          - strings
+          - web-events
+          - web-html
+      web-pointerevents:
+        repo: https://github.com/purescript-web/purescript-web-pointerevents.git
+        version: v1.0.0
+        dependencies:
+          - effect
+          - maybe
+          - prelude
+          - web-dom
+          - web-uievents
+      web-promise:
+        repo: https://github.com/purescript-web/purescript-web-promise.git
+        version: v3.0.0
+        dependencies:
+          - effect
+          - exceptions
+          - foldable-traversable
+          - functions
+          - maybe
+          - prelude
+      web-socket:
+        repo: https://github.com/purescript-web/purescript-web-socket.git
+        version: v4.0.0
+        dependencies:
+          - arraybuffer-types
+          - web-file
+      web-storage:
+        repo: https://github.com/purescript-web/purescript-web-storage.git
+        version: v5.0.0
+        dependencies:
+          - nullable
+          - web-events
+      web-streams:
+        repo: https://github.com/purescript-web/purescript-web-streams.git
+        version: v3.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - exceptions
+          - nullable
+          - prelude
+          - tuples
+          - web-promise
+      web-touchevents:
+        repo: https://github.com/purescript-web/purescript-web-touchevents.git
+        version: v4.0.0
+        dependencies:
+          - web-uievents
+      web-uievents:
+        repo: https://github.com/purescript-web/purescript-web-uievents.git
+        version: v4.0.0
+        dependencies:
+          - web-html
+      web-workers:
+        repo: https://github.com/gbagan/purescript-web-workers.git
+        version: v1.1.0
+        dependencies:
+          - effect
+          - foreign
+          - maybe
+          - prelude
+          - unsafe-coerce
+          - web-events
+      web-xhr:
+        repo: https://github.com/purescript-web/purescript-web-xhr.git
+        version: v5.0.0
+        dependencies:
+          - arraybuffer-types
+          - datetime
+          - http-methods
+          - web-dom
+          - web-file
+          - web-html
+      yoga-fetch:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-fetch.git
+        version: v1.0.1
+        dependencies:
+          - aff
+          - aff-promise
+          - arraybuffer-types
+          - effect
+          - foreign
+          - foreign-object
+          - newtype
+          - prelude
+          - typelevel-prelude
+          - unsafe-coerce
+      yoga-json:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-json.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - identity
+          - lists
+          - maybe
+          - nullable
+          - partial
+          - prelude
+          - record
+          - transformers
+          - typelevel-prelude
+          - variant
+      yoga-postgres:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-postgres.git
+        version: v6.0.0
+        dependencies:
+          - aff
+          - arrays
+          - datetime
+          - effect
+          - either
+          - enums
+          - foldable-traversable
+          - foreign
+          - integers
+          - maybe
+          - nullable
+          - prelude
+          - transformers
+          - unsafe-coerce
+  extra_packages: {}
+packages:
+  aff:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-aff.git
+    rev: 2d44d9f9d0d6a416a4103fba2fb39e5160f80e36
+    dependencies:
+      - datetime
+      - effect
+      - exceptions
+      - functions
+      - parallel
+      - transformers
+      - unsafe-coerce
+  arrays:
+    type: git
+    url: https://github.com/purescript/purescript-arrays.git
+    rev: d20bae2f76db6cf29b7b75e26e82b8a54c32295e
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - maybe
+      - nonempty
+      - partial
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  avar:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-avar.git
+    rev: d00f5784d9cc8f079babd62740f5c52b87e5caa5
+    dependencies:
+      - aff
+      - effect
+      - either
+      - exceptions
+      - functions
+      - maybe
+  bifunctors:
+    type: git
+    url: https://github.com/purescript/purescript-bifunctors.git
+    rev: 16ba2fb6dd7f05528ebd9e2f9ca3a068b325e5b3
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  catenable-lists:
+    type: git
+    url: https://github.com/purescript/purescript-catenable-lists.git
+    rev: 09abe1f4888bc00841ad2b59e56a9e7ce7ebd4ab
+    dependencies:
+      - control
+      - foldable-traversable
+      - lists
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  console:
+    type: git
+    url: https://github.com/purescript/purescript-console.git
+    rev: 3b83d7b792d03872afeea5e62b4f686ab0f09842
+    dependencies:
+      - effect
+      - prelude
+  const:
+    type: git
+    url: https://github.com/purescript/purescript-const.git
+    rev: ab9570cf2b6e67f7e441178211db1231cfd75c37
+    dependencies:
+      - invariant
+      - newtype
+      - prelude
+  contravariant:
+    type: git
+    url: https://github.com/purescript/purescript-contravariant.git
+    rev: 9ad3e105b8855bcc25f4e0893c784789d05a58de
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  control:
+    type: git
+    url: https://github.com/purescript/purescript-control.git
+    rev: a6033808790879a17b2729e73747a9ed3fb2264e
+    dependencies:
+      - newtype
+      - prelude
+  datetime:
+    type: git
+    url: https://github.com/purescript/purescript-datetime.git
+    rev: a6a0cf1b0324964ad1854bc3377ed8766ba90e6f
+    dependencies:
+      - bifunctors
+      - control
+      - either
+      - enums
+      - foldable-traversable
+      - functions
+      - gen
+      - integers
+      - lists
+      - maybe
+      - newtype
+      - numbers
+      - ordered-collections
+      - partial
+      - prelude
+      - tuples
+  distributive:
+    type: git
+    url: https://github.com/purescript/purescript-distributive.git
+    rev: 6005e513642e855ebf6f884d24a35c2803ca252a
+    dependencies:
+      - identity
+      - newtype
+      - prelude
+      - tuples
+      - type-equality
+  effect:
+    type: git
+    url: https://github.com/purescript/purescript-effect.git
+    rev: a192ddb923027d426d6ea3d8deb030c9aa7c7dda
+    dependencies:
+      - prelude
+  either:
+    type: git
+    url: https://github.com/purescript/purescript-either.git
+    rev: af655a04ed2fd694b6688af39ee20d7907ad0763
+    dependencies:
+      - control
+      - invariant
+      - maybe
+      - prelude
+  enums:
+    type: git
+    url: https://github.com/purescript/purescript-enums.git
+    rev: bae47961d401f9acf88da38f32e87403e5f0cf2f
+    dependencies:
+      - control
+      - either
+      - gen
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tuples
+      - unfoldable
+  exceptions:
+    type: git
+    url: https://github.com/purescript/purescript-exceptions.git
+    rev: afab3c07c820bb49b6c5be50049db46a964a6161
+    dependencies:
+      - effect
+      - either
+      - maybe
+      - prelude
+  exists:
+    type: git
+    url: https://github.com/purescript/purescript-exists.git
+    rev: f765b4ace7869c27b9c05949e18c843881f9173b
+    dependencies:
+      - unsafe-coerce
+  foldable-traversable:
+    type: git
+    url: https://github.com/purescript/purescript-foldable-traversable.git
+    rev: b3926f870532d287ea59e2d5cd3873b81ef2a93a
+    dependencies:
+      - bifunctors
+      - const
+      - control
+      - either
+      - functors
+      - identity
+      - maybe
+      - newtype
+      - orders
+      - prelude
+      - tuples
+  free:
+    type: git
+    url: https://github.com/purescript/purescript-free.git
+    rev: e2d8fa8023a864363857834e11393483bced5e38
+    dependencies:
+      - catenable-lists
+      - control
+      - distributive
+      - either
+      - exists
+      - foldable-traversable
+      - invariant
+      - lazy
+      - maybe
+      - prelude
+      - tailrec
+      - transformers
+      - tuples
+      - unsafe-coerce
+  functions:
+    type: git
+    url: https://github.com/purescript/purescript-functions.git
+    rev: f626f20580483977c5b27a01aac6471e28aff367
+    dependencies:
+      - prelude
+  functors:
+    type: git
+    url: https://github.com/purescript/purescript-functors.git
+    rev: 022ffd7a2a7ec12080314f3d217b400674a247b4
+    dependencies:
+      - bifunctors
+      - const
+      - contravariant
+      - control
+      - distributive
+      - either
+      - invariant
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - tuples
+      - unsafe-coerce
+  gen:
+    type: git
+    url: https://github.com/purescript/purescript-gen.git
+    rev: 9fbcc2a1261c32e30d79c5418edef4d96fe76931
+    dependencies:
+      - either
+      - foldable-traversable
+      - identity
+      - maybe
+      - newtype
+      - nonempty
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  identity:
+    type: git
+    url: https://github.com/purescript/purescript-identity.git
+    rev: ef6768f8a52ab0bc943a85f5761ba07c257f639f
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  integers:
+    type: git
+    url: https://github.com/purescript/purescript-integers.git
+    rev: 54d712b25c594833083d15dc9ff2418eb9c52822
+    dependencies:
+      - maybe
+      - numbers
+      - prelude
+  invariant:
+    type: git
+    url: https://github.com/purescript/purescript-invariant.git
+    rev: 1d2a196d51e90623adb88496c2cfd759c6736894
+    dependencies:
+      - control
+      - prelude
+  js-timers:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-js-timers.git
+    rev: 7cb728b3e6dc29f355143617e6e9ac770ecd9273
+    dependencies:
+      - effect
+  lazy:
+    type: git
+    url: https://github.com/purescript/purescript-lazy.git
+    rev: 48347841226b27af5205a1a8ec71e27a93ce86fd
+    dependencies:
+      - control
+      - foldable-traversable
+      - invariant
+      - prelude
+  lcg:
+    type: git
+    url: https://github.com/purescript/purescript-lcg.git
+    rev: 67c6c6483a563a59ae036d9dca0f1be2835326a5
+    dependencies:
+      - effect
+      - integers
+      - maybe
+      - partial
+      - prelude
+      - random
+  lists:
+    type: git
+    url: https://github.com/purescript/purescript-lists.git
+    rev: b113451e5b41cad87d669a3165f955c71cd863e2
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - lazy
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  maybe:
+    type: git
+    url: https://github.com/purescript/purescript-maybe.git
+    rev: c6f98ac1088766287106c5d9c8e30e7648d36786
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  newtype:
+    type: git
+    url: https://github.com/purescript/purescript-newtype.git
+    rev: 29d8e6dd77aec2c975c948364ec3faf26e14ee7b
+    dependencies:
+      - prelude
+      - safe-coerce
+  nonempty:
+    type: git
+    url: https://github.com/purescript/purescript-nonempty.git
+    rev: 28150ecc7419238b187abd609a92a645273348bb
+    dependencies:
+      - control
+      - foldable-traversable
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  numbers:
+    type: git
+    url: https://github.com/purescript/purescript-numbers.git
+    rev: 2a53528f18f9415334bae28e7bb3cf3be86342c2
+    dependencies:
+      - functions
+      - maybe
+  ordered-collections:
+    type: git
+    url: https://github.com/purescript/purescript-ordered-collections.git
+    rev: 9826b7632d0d0a691173bde308a634195f42a419
+    dependencies:
+      - arrays
+      - foldable-traversable
+      - gen
+      - lists
+      - maybe
+      - partial
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+  orders:
+    type: git
+    url: https://github.com/purescript/purescript-orders.git
+    rev: f86db621ec5eef1274145f8b1fd8ebbfe0ed4a2c
+    dependencies:
+      - newtype
+      - prelude
+  parallel:
+    type: git
+    url: https://github.com/purescript/purescript-parallel.git
+    rev: 85290dca837771ac4870071008c933d315ef678f
+    dependencies:
+      - control
+      - effect
+      - either
+      - foldable-traversable
+      - functors
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - refs
+      - transformers
+  partial:
+    type: git
+    url: https://github.com/purescript/purescript-partial.git
+    rev: 0fa0646f5ea1ec5f0c46dcbd770c705a6c9ad3ec
+    dependencies: []
+  prelude:
+    type: git
+    url: https://github.com/purescript/purescript-prelude.git
+    rev: 32787f4399c92459c41602131a5858559eb868c5
+    dependencies: []
+  profunctor:
+    type: git
+    url: https://github.com/purescript/purescript-profunctor.git
+    rev: 0a966a14e7b0c827d44657dc1710cdc712d2e034
+    dependencies:
+      - control
+      - distributive
+      - either
+      - exists
+      - invariant
+      - newtype
+      - prelude
+      - tuples
+  quickcheck:
+    type: git
+    url: https://github.com/purescript/purescript-quickcheck.git
+    rev: bf5029f97e6c0d7552d3a08d2ab793a19e2c5e3d
+    dependencies:
+      - arrays
+      - console
+      - control
+      - effect
+      - either
+      - enums
+      - exceptions
+      - foldable-traversable
+      - gen
+      - identity
+      - integers
+      - lazy
+      - lcg
+      - lists
+      - maybe
+      - newtype
+      - nonempty
+      - numbers
+      - partial
+      - prelude
+      - record
+      - st
+      - strings
+      - tailrec
+      - transformers
+      - tuples
+      - unfoldable
+  random:
+    type: git
+    url: https://github.com/purescript/purescript-random.git
+    rev: 9540bc965a9596da02fefd9949418bb19c92533a
+    dependencies:
+      - effect
+      - integers
+  record:
+    type: git
+    url: https://github.com/purescript/purescript-record.git
+    rev: c89cd1ada6b636692571fc374196b1c39c4c9f70
+    dependencies:
+      - functions
+      - prelude
+      - unsafe-coerce
+  refs:
+    type: git
+    url: https://github.com/purescript/purescript-refs.git
+    rev: f8e6216da4cb9309fde1f20cd6f69ac3a3b7f9e8
+    dependencies:
+      - effect
+      - prelude
+  safe-coerce:
+    type: git
+    url: https://github.com/purescript/purescript-safe-coerce.git
+    rev: 7fa799ae80a38b8d948efcb52608e58e198b3da7
+    dependencies:
+      - unsafe-coerce
+  st:
+    type: git
+    url: https://github.com/purescript/purescript-st.git
+    rev: 2cc7ae1c3318a303378c4a9f3fa0f10ee7cc3589
+    dependencies:
+      - partial
+      - prelude
+      - tailrec
+      - unsafe-coerce
+  strings:
+    type: git
+    url: https://github.com/purescript/purescript-strings.git
+    rev: 4bc6954448d056f8aa7a659695a6ad60ad4fdf19
+    dependencies:
+      - arrays
+      - control
+      - either
+      - enums
+      - foldable-traversable
+      - gen
+      - integers
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  tailrec:
+    type: git
+    url: https://github.com/purescript/purescript-tailrec.git
+    rev: 5e2104aa734b31a17074cc805bf087d72b65afd1
+    dependencies:
+      - bifunctors
+      - effect
+      - either
+      - identity
+      - maybe
+      - partial
+      - prelude
+      - refs
+  test-unit:
+    type: git
+    url: https://github.com/bodil/purescript-test-unit.git
+    rev: 3112d7ebe06d467238058a6384dc75ffd960d335
+    dependencies:
+      - aff
+      - avar
+      - effect
+      - either
+      - free
+      - js-timers
+      - lists
+      - prelude
+      - quickcheck
+      - strings
+  transformers:
+    type: git
+    url: https://github.com/purescript/purescript-transformers.git
+    rev: be72ab52357d9a665cbf93d73ba1c07c4b0957ee
+    dependencies:
+      - control
+      - distributive
+      - effect
+      - either
+      - exceptions
+      - foldable-traversable
+      - identity
+      - lazy
+      - maybe
+      - newtype
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  tuples:
+    type: git
+    url: https://github.com/purescript/purescript-tuples.git
+    rev: 4f52da2729b448c8564369378f1232d8d2dc1d8b
+    dependencies:
+      - control
+      - invariant
+      - prelude
+  type-equality:
+    type: git
+    url: https://github.com/purescript/purescript-type-equality.git
+    rev: 0525b7d39e0fbd81b4209518139fb8ab02695774
+    dependencies: []
+  unfoldable:
+    type: git
+    url: https://github.com/purescript/purescript-unfoldable.git
+    rev: 493dfe04ed590e20d8f69079df2f58486882748d
+    dependencies:
+      - foldable-traversable
+      - maybe
+      - partial
+      - prelude
+      - tuples
+  unsafe-coerce:
+    type: git
+    url: https://github.com/purescript/purescript-unsafe-coerce.git
+    rev: ab956f82e66e633f647fb3098e8ddd3ec58d689f
+    dependencies: []

--- a/exercises/chapter4/spago.lock
+++ b/exercises/chapter4/spago.lock
@@ -69,3452 +69,462 @@ workspace:
         - unsafe-coerce
   package_set:
     address:
-      url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
-    compiler: ">=0.15.0 <0.16.0"
+      registry: 10.0.0
+    compiler: ">=0.15.4 <0.16.0"
     content:
-      ace:
-        repo: https://github.com/purescript-contrib/purescript-ace.git
-        version: v9.0.0
-        dependencies:
-          - arrays
-          - effect
-          - foreign
-          - nullable
-          - prelude
-          - web-html
-          - web-uievents
-      aff:
-        repo: https://github.com/purescript-contrib/purescript-aff.git
-        version: v7.0.0
-        dependencies:
-          - datetime
-          - effect
-          - exceptions
-          - functions
-          - parallel
-          - transformers
-          - unsafe-coerce
-      aff-bus:
-        repo: https://github.com/purescript-contrib/purescript-aff-bus.git
-        version: v6.0.0
-        dependencies:
-          - aff
-          - avar
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - lists
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-      aff-coroutines:
-        repo: https://github.com/purescript-contrib/purescript-aff-coroutines.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - avar
-          - coroutines
-          - effect
-      aff-promise:
-        repo: https://github.com/nwolverson/purescript-aff-promise.git
-        version: v4.0.0
-        dependencies:
-          - aff
-          - foreign
-      aff-retry:
-        repo: https://github.com/Unisay/purescript-aff-retry.git
-        version: v2.0.0
-        dependencies:
-          - aff
-          - arrays
-          - datetime
-          - effect
-          - either
-          - exceptions
-          - integers
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - random
-          - transformers
-      affjax:
-        repo: https://github.com/purescript-contrib/purescript-affjax.git
-        version: v13.0.0
-        dependencies:
-          - aff
-          - argonaut-core
-          - arraybuffer-types
-          - foreign
-          - form-urlencoded
-          - http-methods
-          - integers
-          - media-types
-          - nullable
-          - refs
-          - unsafe-coerce
-          - web-xhr
-      affjax-node:
-        repo: https://github.com/purescript-contrib/purescript-affjax-node.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - affjax
-          - either
-          - maybe
-          - prelude
-      affjax-web:
-        repo: https://github.com/purescript-contrib/purescript-affjax-web.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - affjax
-          - either
-          - maybe
-          - prelude
-      ansi:
-        repo: https://github.com/hdgarrood/purescript-ansi.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - lists
-          - strings
-      argonaut:
-        repo: https://github.com/purescript-contrib/purescript-argonaut.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - argonaut-traversals
-      argonaut-codecs:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-codecs.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-core
-          - arrays
-          - effect
-          - foreign-object
-          - identity
-          - integers
-          - maybe
-          - nonempty
-          - ordered-collections
-          - prelude
-          - record
-      argonaut-core:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-core.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - foreign-object
-          - functions
-          - gen
-          - maybe
-          - nonempty
-          - prelude
-          - strings
-          - tailrec
-      argonaut-generic:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-generic.git
-        version: v8.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - prelude
-          - record
-      argonaut-traversals:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-traversals.git
-        version: v10.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - profunctor-lenses
-      argparse-basic:
-        repo: https://github.com/natefaubion/purescript-argparse-basic.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - record
-          - strings
-          - tuples
-          - unfoldable
-      arraybuffer:
-        repo: https://github.com/purescript-contrib/purescript-arraybuffer.git
-        version: v13.0.0
-        dependencies:
-          - arraybuffer-types
-          - arrays
-          - effect
-          - float32
-          - functions
-          - gen
-          - maybe
-          - nullable
-          - prelude
-          - tailrec
-          - uint
-          - unfoldable
-      arraybuffer-builder:
-        repo: https://github.com/jamesdbrock/purescript-arraybuffer-builder.git
-        version: v3.0.1
-        dependencies:
-          - arraybuffer
-          - arraybuffer-types
-          - effect
-          - float32
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - transformers
-          - uint
-      arraybuffer-types:
-        repo: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
-        version: v3.0.2
-        dependencies: []
-      arrays:
-        repo: https://github.com/purescript/purescript-arrays.git
-        version: v7.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - foldable-traversable
-          - maybe
-          - nonempty
-          - partial
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - unfoldable
-          - unsafe-coerce
-      arrays-zipper:
-        repo: https://github.com/JordanMartinez/purescript-arrays-zipper.git
-        version: v2.0.1
-        dependencies:
-          - arrays
-          - control
-          - quickcheck
-      ask:
-        repo: https://github.com/Mateiadrielrafael/purescript-ask.git
-        version: v1.0.0
-        dependencies:
-          - unsafe-coerce
-      assert:
-        repo: https://github.com/purescript/purescript-assert.git
-        version: v6.0.0
-        dependencies:
-          - console
-          - effect
-          - prelude
-      avar:
-        repo: https://github.com/purescript-contrib/purescript-avar.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - exceptions
-          - functions
-          - maybe
-      b64:
-        repo: https://github.com/menelaos/purescript-b64.git
-        version: v0.0.8
-        dependencies:
-          - arraybuffer-types
-          - either
-          - encoding
-          - enums
-          - exceptions
-          - functions
-          - partial
-          - prelude
-          - strings
-      barlow-lens:
-        repo: https://github.com/sigma-andex/purescript-barlow-lens.git
-        version: v0.9.0
-        dependencies:
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - profunctor-lenses
-          - tuples
-          - typelevel-prelude
-      bifunctors:
-        repo: https://github.com/purescript/purescript-bifunctors.git
-        version: v6.0.0
-        dependencies:
-          - const
-          - either
-          - newtype
-          - prelude
-          - tuples
-      bigints:
-        repo: https://github.com/sharkdp/purescript-bigints.git
-        version: v7.0.1
-        dependencies:
-          - integers
-          - maybe
-          - strings
-      bower-json:
-        repo: https://github.com/klntsky/purescript-bower-json.git
-        version: v3.0.0
-        dependencies:
-          - argonaut-codecs
-          - arrays
-          - either
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - newtype
-          - prelude
-          - tuples
-      call-by-name:
-        repo: https://github.com/natefaubion/purescript-call-by-name.git
-        version: v4.0.1
-        dependencies:
-          - control
-          - either
-          - lazy
-          - maybe
-          - unsafe-coerce
-      canvas:
-        repo: https://github.com/purescript-web/purescript-canvas.git
-        version: v6.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - exceptions
-          - functions
-          - maybe
-      canvas-action:
-        repo: https://github.com/artemisSystem/purescript-canvas-action.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - arrays
-          - canvas
-          - colors
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - maybe
-          - numbers
-          - polymorphic-vectors
-          - prelude
-          - refs
-          - run
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-html
-      cartesian:
-        repo: https://github.com/Ebmtranceboy/purescript-cartesian.git
-        version: v1.0.6
-        dependencies:
-          - console
-          - effect
-          - integers
-          - psci-support
-      catenable-lists:
-        repo: https://github.com/purescript/purescript-catenable-lists.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - lists
-          - maybe
-          - prelude
-          - tuples
-          - unfoldable
-      channel:
-        repo: https://github.com/ConnorDillon/purescript-channel.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - assert
-          - avar
-          - console
-          - contravariant
-          - control
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - lazy
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      checked-exceptions:
-        repo: https://github.com/natefaubion/purescript-checked-exceptions.git
-        version: v3.1.1
-        dependencies:
-          - prelude
-          - transformers
-          - variant
-      codec:
-        repo: https://github.com/garyb/purescript-codec.git
-        version: v5.0.0
-        dependencies:
-          - profunctor
-          - transformers
-      codec-argonaut:
-        repo: https://github.com/garyb/purescript-codec-argonaut.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-core
-          - codec
-          - ordered-collections
-          - type-equality
-          - variant
-      colors:
-        repo: https://github.com/purescript-contrib/purescript-colors.git
-        version: v7.0.1
-        dependencies:
-          - arrays
-          - integers
-          - lists
-          - numbers
-          - partial
-          - strings
-      concurrent-queues:
-        repo: https://github.com/purescript-contrib/purescript-concurrent-queues.git
-        version: v3.0.0
-        dependencies:
-          - aff
-          - avar
-          - effect
-      console:
-        repo: https://github.com/purescript/purescript-console.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - prelude
-      const:
-        repo: https://github.com/purescript/purescript-const.git
-        version: v6.0.0
-        dependencies:
-          - invariant
-          - newtype
-          - prelude
-      contravariant:
-        repo: https://github.com/purescript/purescript-contravariant.git
-        version: v6.0.0
-        dependencies:
-          - const
-          - either
-          - newtype
-          - prelude
-          - tuples
-      control:
-        repo: https://github.com/purescript/purescript-control.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      convertable-options:
-        repo: https://github.com/natefaubion/purescript-convertable-options.git
-        version: v1.0.0
-        dependencies:
-          - console
-          - effect
-          - maybe
-          - record
-      coroutines:
-        repo: https://github.com/purescript-contrib/purescript-coroutines.git
-        version: v7.0.0
-        dependencies:
-          - freet
-          - parallel
-          - profunctor
-      css:
-        repo: https://github.com/purescript-contrib/purescript-css.git
-        version: v6.0.0
-        dependencies:
-          - colors
-          - console
-          - effect
-          - nonempty
-          - profunctor
-          - strings
-          - these
-          - transformers
-      datetime:
-        repo: https://github.com/purescript/purescript-datetime.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - either
-          - enums
-          - foldable-traversable
-          - functions
-          - gen
-          - integers
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - ordered-collections
-          - partial
-          - prelude
-          - tuples
-      datetime-parsing:
-        repo: https://github.com/flounders/purescript-datetime-parsing.git
-        version: v0.2.0
-        dependencies:
-          - arrays
-          - datetime
-          - either
-          - enums
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - numbers
-          - parsing
-          - prelude
-          - strings
-          - unicode
-      debug:
-        repo: https://github.com/garyb/purescript-debug.git
-        version: v6.0.0
-        dependencies:
-          - functions
-          - prelude
-      decimals:
-        repo: https://github.com/sharkdp/purescript-decimals.git
-        version: v7.0.0
-        dependencies:
-          - maybe
-      dissect:
-        repo: https://github.com/PureFunctor/purescript-dissect.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - foreign-object
-          - functors
-          - newtype
-          - partial
-          - prelude
-          - tailrec
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - variant
-      distributive:
-        repo: https://github.com/purescript/purescript-distributive.git
-        version: v6.0.0
-        dependencies:
-          - identity
-          - newtype
-          - prelude
-          - tuples
-          - type-equality
-      dodo-printer:
-        repo: https://github.com/natefaubion/purescript-dodo-printer.git
-        version: v2.2.0
-        dependencies:
-          - aff
-          - ansi
-          - avar
-          - console
-          - effect
-          - foldable-traversable
-          - lists
-          - maybe
-          - minibench
-          - node-child-process
-          - node-fs-aff
-          - node-process
-          - psci-support
-          - strings
-      dom-indexed:
-        repo: https://github.com/purescript-halogen/purescript-dom-indexed.git
-        version: v11.0.0
-        dependencies:
-          - media-types
-          - prelude
-          - web-clipboard
-          - web-pointerevents
-          - web-touchevents
-      droplet:
-        repo: https://github.com/easafe/purescript-droplet.git
-        version: v0.4.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - bigints
-          - datetime
-          - debug
-          - effect
-          - either
-          - enums
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - integers
-          - maybe
-          - newtype
-          - nullable
-          - ordered-collections
-          - partial
-          - prelude
-          - profunctor
-          - record
-          - spec
-          - strings
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-      dynamic-buffer:
-        repo: https://github.com/kritzcreek/purescript-dynamic-buffer.git
-        version: v3.0.1
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - refs
-      effect:
-        repo: https://github.com/purescript/purescript-effect.git
-        version: v4.0.0
-        dependencies:
-          - prelude
-      either:
-        repo: https://github.com/purescript/purescript-either.git
-        version: v6.1.0
-        dependencies:
-          - control
-          - invariant
-          - maybe
-          - prelude
-      elmish:
-        repo: https://github.com/collegevine/purescript-elmish.git
-        version: v0.8.1
-        dependencies:
-          - aff
-          - argonaut-core
-          - arrays
-          - bifunctors
-          - console
-          - debug
-          - effect
-          - either
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - functions
-          - integers
-          - js-date
-          - maybe
-          - nullable
-          - partial
-          - prelude
-          - refs
-          - typelevel-prelude
-          - undefined-is-not-a-problem
-          - unsafe-coerce
-          - web-dom
-          - web-html
-      elmish-enzyme:
-        repo: https://github.com/collegevine/purescript-elmish-enzyme.git
-        version: v0.1.1
-        dependencies:
-          - aff
-          - aff-promise
-          - arrays
-          - console
-          - debug
-          - effect
-          - elmish
-          - foldable-traversable
-          - foreign
-          - functions
-          - prelude
-          - transformers
-          - unsafe-coerce
-      elmish-hooks:
-        repo: https://github.com/collegevine/purescript-elmish-hooks.git
-        version: v0.8.2
-        dependencies:
-          - aff
-          - debug
-          - elmish
-          - maybe
-          - prelude
-          - tuples
-          - undefined-is-not-a-problem
-      elmish-html:
-        repo: https://github.com/collegevine/purescript-elmish-html.git
-        version: v0.7.1
-        dependencies:
-          - effect
-          - elmish
-          - foreign
-          - foreign-object
-          - prelude
-          - record
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-html
-      email-validate:
-        repo: https://github.com/cdepillabout/purescript-email-validate.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - string-parsers
-          - transformers
-      encoding:
-        repo: https://github.com/menelaos/purescript-encoding.git
-        version: v0.0.8
-        dependencies:
-          - arraybuffer-types
-          - either
-          - exceptions
-          - functions
-          - prelude
-      enums:
-        repo: https://github.com/purescript/purescript-enums.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - either
-          - gen
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tuples
-          - unfoldable
-      exceptions:
-        repo: https://github.com/purescript/purescript-exceptions.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - either
-          - maybe
-          - prelude
-      exists:
-        repo: https://github.com/purescript/purescript-exists.git
-        version: v6.0.0
-        dependencies:
-          - unsafe-coerce
-      exitcodes:
-        repo: https://github.com/Risto-Stevcev/purescript-exitcodes.git
-        version: v4.0.0
-        dependencies:
-          - enums
-      expect-inferred:
-        repo: https://github.com/justinwoo/purescript-expect-inferred.git
-        version: v3.0.0
-        dependencies:
-          - prelude
-          - typelevel-prelude
-      fast-vect:
-        repo: https://github.com/sigma-andex/purescript-fast-vect.git
-        version: v0.7.0
-        dependencies:
-          - arrays
-          - filterable
-          - foldable-traversable
-          - lists
-          - maybe
-          - ordered-collections
-          - prelude
-          - profunctor
-          - tuples
-          - unfoldable
-      filterable:
-        repo: https://github.com/purescript/purescript-filterable.git
-        version: v5.0.0
-        dependencies:
-          - arrays
-          - either
-          - foldable-traversable
-          - identity
-          - lists
-          - ordered-collections
-      fixed-points:
-        repo: https://github.com/purescript-contrib/purescript-fixed-points.git
-        version: v7.0.0
-        dependencies:
-          - exists
-          - newtype
-          - prelude
-          - transformers
-      fixed-precision:
-        repo: https://github.com/lumihq/purescript-fixed-precision.git
-        version: v5.0.0
-        dependencies:
-          - arrays
-          - bigints
-          - control
-          - integers
-          - maybe
-          - numbers
-          - partial
-          - prelude
-          - strings
-      flame:
-        repo: https://github.com/easafe/purescript-flame.git
-        version: v1.2.0
-        dependencies:
-          - aff
-          - argonaut-codecs
-          - argonaut-core
-          - argonaut-generic
-          - arrays
-          - bifunctors
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - maybe
-          - newtype
-          - nullable
-          - partial
-          - prelude
-          - random
-          - refs
-          - spec
-          - strings
-          - tuples
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-html
-          - web-uievents
-      float32:
-        repo: https://github.com/purescript-contrib/purescript-float32.git
-        version: v2.0.0
-        dependencies:
-          - gen
-          - maybe
-          - prelude
-      foldable-traversable:
-        repo: https://github.com/purescript/purescript-foldable-traversable.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - const
-          - control
-          - either
-          - functors
-          - identity
-          - maybe
-          - newtype
-          - orders
-          - prelude
-          - tuples
-      foreign:
-        repo: https://github.com/purescript/purescript-foreign.git
-        version: v7.0.0
-        dependencies:
-          - either
-          - functions
-          - identity
-          - integers
-          - lists
-          - maybe
-          - prelude
-          - strings
-          - transformers
-      foreign-object:
-        repo: https://github.com/purescript/purescript-foreign-object.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - functions
-          - gen
-          - lists
-          - maybe
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - typelevel-prelude
-          - unfoldable
-      foreign-readwrite:
-        repo: https://github.com/artemisSystem/purescript-foreign-readwrite.git
-        version: v3.0.0
-        dependencies:
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - record
-          - safe-coerce
-          - transformers
-          - unsafe-coerce
-      fork:
-        repo: https://github.com/purescript-contrib/purescript-fork.git
-        version: v6.0.0
-        dependencies:
-          - aff
-      form-urlencoded:
-        repo: https://github.com/purescript-contrib/purescript-form-urlencoded.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - js-uri
-          - maybe
-          - newtype
-          - prelude
-          - strings
-          - tuples
-      formatters:
-        repo: https://github.com/purescript-contrib/purescript-formatters.git
-        version: v7.0.0
-        dependencies:
-          - datetime
-          - fixed-points
-          - lists
-          - numbers
-          - parsing
-          - prelude
-          - transformers
-      free:
-        repo: https://github.com/purescript/purescript-free.git
-        version: v7.0.0
-        dependencies:
-          - catenable-lists
-          - control
-          - distributive
-          - either
-          - exists
-          - foldable-traversable
-          - invariant
-          - lazy
-          - maybe
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-      freeap:
-        repo: https://github.com/ethul/purescript-freeap.git
-        version: v7.0.0
-        dependencies:
-          - const
-          - exists
-          - gen
-          - lists
-      freet:
-        repo: https://github.com/purescript-contrib/purescript-freet.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - bifunctors
-          - effect
-          - either
-          - exists
-          - free
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      functions:
-        repo: https://github.com/purescript/purescript-functions.git
-        version: v6.0.0
-        dependencies:
-          - prelude
-      functors:
-        repo: https://github.com/purescript/purescript-functors.git
-        version: v5.0.0
-        dependencies:
-          - bifunctors
-          - const
-          - contravariant
-          - control
-          - distributive
-          - either
-          - invariant
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - tuples
-          - unsafe-coerce
-      fuzzy:
-        repo: https://github.com/citizennet/purescript-fuzzy.git
-        version: v0.4.0
-        dependencies:
-          - foldable-traversable
-          - foreign-object
-          - newtype
-          - ordered-collections
-          - prelude
-          - rationals
-          - strings
-          - tuples
-      gen:
-        repo: https://github.com/purescript/purescript-gen.git
-        version: v4.0.0
-        dependencies:
-          - either
-          - foldable-traversable
-          - identity
-          - maybe
-          - newtype
-          - nonempty
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      generate-values:
-        repo: https://github.com/jordanmartinez/purescript-generate-values.git
-        version: v1.0.1
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - enums
-          - foldable-traversable
-          - gen
-          - identity
-          - integers
-          - lcg
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - partial
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      geometry-plane:
-        repo: https://github.com/Ebmtranceboy/purescript-geometry-plane.git
-        version: v1.0.3
-        dependencies:
-          - console
-          - effect
-          - psci-support
-          - sparse-polynomials
-      github-actions-toolkit:
-        repo: https://github.com/purescript-contrib/purescript-github-actions-toolkit.git
-        version: v0.5.0
-        dependencies:
-          - aff
-          - aff-promise
-          - effect
-          - foreign-object
-          - node-buffer
-          - node-path
-          - node-streams
-          - nullable
-          - transformers
-      graphs:
-        repo: https://github.com/purescript/purescript-graphs.git
-        version: v8.0.0
-        dependencies:
-          - catenable-lists
-          - ordered-collections
-      group:
-        repo: https://github.com/morganthomas/purescript-group.git
-        version: v4.1.1
-        dependencies:
-          - lists
-      halogen:
-        repo: https://github.com/purescript-halogen/purescript-halogen.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - avar
-          - console
-          - const
-          - dom-indexed
-          - effect
-          - foreign
-          - fork
-          - free
-          - freeap
-          - halogen-subscriptions
-          - halogen-vdom
-          - media-types
-          - nullable
-          - ordered-collections
-          - parallel
-          - profunctor
-          - transformers
-          - unsafe-coerce
-          - unsafe-reference
-          - web-file
-          - web-uievents
-      halogen-css:
-        repo: https://github.com/purescript-halogen/purescript-halogen-css.git
-        version: v10.0.0
-        dependencies:
-          - css
-          - halogen
-      halogen-formless:
-        repo: https://github.com/thomashoneyman/purescript-halogen-formless.git
-        version: v4.0.0
-        dependencies:
-          - convertable-options
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - halogen
-          - heterogeneous
-          - maybe
-          - prelude
-          - record
-          - safe-coerce
-          - type-equality
-          - unsafe-coerce
-          - unsafe-reference
-          - variant
-          - web-events
-          - web-uievents
-      halogen-hooks:
-        repo: https://github.com/thomashoneyman/purescript-halogen-hooks.git
-        version: v0.6.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - effect
-          - exceptions
-          - foldable-traversable
-          - foreign-object
-          - free
-          - freeap
-          - halogen
-          - halogen-subscriptions
-          - maybe
-          - newtype
-          - ordered-collections
-          - parallel
-          - partial
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-          - unsafe-reference
-          - web-dom
-          - web-html
-      halogen-hooks-extra:
-        repo: https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git
-        version: v0.9.0
-        dependencies:
-          - halogen-hooks
-      halogen-store:
-        repo: https://github.com/thomashoneyman/purescript-halogen-store.git
-        version: v0.5.0
-        dependencies:
-          - aff
-          - distributive
-          - effect
-          - fork
-          - halogen
-          - halogen-hooks
-          - halogen-subscriptions
-          - maybe
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-reference
-      halogen-storybook:
-        repo: https://github.com/rnons/purescript-halogen-storybook.git
-        version: v2.0.0
-        dependencies:
-          - foreign-object
-          - halogen
-          - prelude
-          - routing
-      halogen-subscriptions:
-        repo: https://github.com/purescript-halogen/purescript-halogen-subscriptions.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - effect
-          - foldable-traversable
-          - functors
-          - refs
-          - safe-coerce
-          - unsafe-reference
-      halogen-svg-elems:
-        repo: https://github.com/JordanMartinez/purescript-halogen-svg-elems.git
-        version: v6.0.0
-        dependencies:
-          - halogen
-      halogen-vdom:
-        repo: https://github.com/purescript-halogen/purescript-halogen-vdom.git
-        version: v8.0.0
-        dependencies:
-          - bifunctors
-          - effect
-          - foreign
-          - foreign-object
-          - maybe
-          - prelude
-          - refs
-          - tuples
-          - unsafe-coerce
-          - web-html
-      halogen-vdom-string-renderer:
-        repo: https://github.com/purescript-halogen/purescript-halogen-vdom-string-renderer.git
-        version: v0.5.0
-        dependencies:
-          - foreign
-          - halogen-vdom
-          - ordered-collections
-          - prelude
-      heckin:
-        repo: https://github.com/maxdeviant/purescript-heckin.git
-        version: v2.0.1
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - maybe
-          - prelude
-          - strings
-          - transformers
-          - tuples
-          - unicode
-      heterogeneous:
-        repo: https://github.com/natefaubion/purescript-heterogeneous.git
-        version: v0.6.0
-        dependencies:
-          - either
-          - functors
-          - prelude
-          - record
-          - tuples
-          - variant
-      heterogeneous-extrablatt:
-        repo: https://github.com/sigma-andex/purescript-heterogeneous-extrablatt.git
-        version: v0.2.1
-        dependencies:
-          - heterogeneous
-          - prelude
-          - record
-      http-methods:
-        repo: https://github.com/purescript-contrib/purescript-http-methods.git
-        version: v6.0.0
-        dependencies:
-          - either
-          - prelude
-          - strings
-      httpure:
-        repo: https://github.com/citizennet/purescript-httpure.git
-        version: v0.15.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - js-uri
-          - maybe
-          - newtype
-          - node-buffer
-          - node-fs
-          - node-http
-          - node-streams
-          - options
-          - ordered-collections
-          - prelude
-          - refs
-          - strings
-          - tuples
-          - type-equality
-      httpurple:
-        repo: https://github.com/sigma-andex/purescript-httpurple.git
-        version: v1.3.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - js-uri
-          - justifill
-          - maybe
-          - newtype
-          - node-buffer
-          - node-fs
-          - node-http
-          - node-net
-          - node-process
-          - node-streams
-          - options
-          - ordered-collections
-          - posix-types
-          - prelude
-          - profunctor
-          - record
-          - refs
-          - routing-duplex
-          - strings
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-      httpurple-argonaut:
-        repo: https://github.com/sigma-andex/purescript-httpurple-argonaut.git
-        version: v1.0.1
-        dependencies:
-          - argonaut
-          - console
-          - effect
-          - either
-          - httpurple
-          - prelude
-      httpurple-yoga-json:
-        repo: https://github.com/sigma-andex/purescript-httpurple-yoga-json.git
-        version: v1.0.0
-        dependencies:
-          - console
-          - effect
-          - either
-          - foreign
-          - httpurple
-          - lists
-          - prelude
-          - yoga-json
-      identity:
-        repo: https://github.com/purescript/purescript-identity.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - invariant
-          - newtype
-          - prelude
-      indexed-monad:
-        repo: https://github.com/garyb/purescript-indexed-monad.git
-        version: v2.1.0
-        dependencies:
-          - control
-          - newtype
-      int64:
-        repo: https://github.com/purescript-contrib/purescript-int64.git
-        version: v2.0.0
-        dependencies:
-          - effect
-          - foreign
-          - functions
-          - integers
-          - maybe
-          - nullable
-          - prelude
-          - quickcheck
-      integers:
-        repo: https://github.com/purescript/purescript-integers.git
-        version: v6.0.0
-        dependencies:
-          - maybe
-          - numbers
-          - prelude
-      interpolate:
-        repo: https://github.com/jordanmartinez/purescript-interpolate.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-      invariant:
-        repo: https://github.com/purescript/purescript-invariant.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - prelude
-      js-date:
-        repo: https://github.com/purescript-contrib/purescript-js-date.git
-        version: v8.0.0
-        dependencies:
-          - datetime
-          - effect
-          - exceptions
-          - foreign
-          - integers
-          - now
-      js-fileio:
-        repo: https://github.com/newlandsvalley/purescript-js-fileio.git
-        version: v3.0.0
-        dependencies:
-          - aff
-          - effect
-          - prelude
-      js-timers:
-        repo: https://github.com/purescript-contrib/purescript-js-timers.git
-        version: v6.1.0
-        dependencies:
-          - effect
-      js-uri:
-        repo: https://github.com/purescript-contrib/purescript-js-uri.git
-        version: v3.0.0
-        dependencies:
-          - functions
-          - maybe
-      justifill:
-        repo: https://github.com/i-am-the-slime/purescript-justifill.git
-        version: v0.5.0
-        dependencies:
-          - maybe
-          - prelude
-          - record
-          - typelevel-prelude
-      jwt:
-        repo: https://github.com/menelaos/purescript-jwt.git
-        version: v0.0.9
-        dependencies:
-          - argonaut-core
-          - arrays
-          - b64
-          - either
-          - exceptions
-          - prelude
-          - profunctor-lenses
-          - strings
-      language-cst-parser:
-        repo: https://github.com/natefaubion/purescript-language-cst-parser.git
-        version: v0.12.0
-        dependencies:
-          - arrays
-          - const
-          - control
-          - either
-          - foldable-traversable
-          - free
-          - functions
-          - functors
-          - identity
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - ordered-collections
-          - partial
-          - prelude
-          - st
-          - strings
-          - transformers
-          - tuples
-          - typelevel-prelude
-          - unfoldable
-          - unsafe-coerce
-      lazy:
-        repo: https://github.com/purescript/purescript-lazy.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - invariant
-          - prelude
-      lcg:
-        repo: https://github.com/purescript/purescript-lcg.git
-        version: v4.0.0
-        dependencies:
-          - effect
-          - integers
-          - maybe
-          - partial
-          - prelude
-          - random
-      leibniz:
-        repo: https://github.com/paf31/purescript-leibniz.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-          - unsafe-coerce
-      linalg:
-        repo: https://github.com/gbagan/purescript-linalg.git
-        version: v5.1.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - functions
-          - maybe
-          - prelude
-          - tuples
-      lists:
-        repo: https://github.com/purescript/purescript-lists.git
-        version: v7.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - foldable-traversable
-          - lazy
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      logging:
-        repo: https://github.com/rightfold/purescript-logging.git
-        version: v3.0.0
-        dependencies:
-          - console
-          - contravariant
-          - effect
-          - either
-          - prelude
-          - transformers
-          - tuples
-      machines:
-        repo: https://github.com/purescript-contrib/purescript-machines.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - lists
-          - maybe
-          - prelude
-          - profunctor
-          - tuples
-          - unfoldable
-      matrices:
-        repo: https://github.com/kRITZCREEK/purescript-matrices.git
-        version: v5.0.1
-        dependencies:
-          - arrays
-          - strings
-      matryoshka:
-        repo: https://github.com/purescript-contrib/purescript-matryoshka.git
-        version: v1.0.0
-        dependencies:
-          - fixed-points
-          - free
-          - prelude
-          - profunctor
-          - transformers
-      maybe:
-        repo: https://github.com/purescript/purescript-maybe.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - invariant
-          - newtype
-          - prelude
-      media-types:
-        repo: https://github.com/purescript-contrib/purescript-media-types.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      metadata:
-        repo: https://github.com/purescript/purescript-metadata.git
-        version: v0.15.0
-        dependencies: []
-      midi:
-        repo: https://github.com/newlandsvalley/purescript-midi.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - ordered-collections
-          - prelude
-          - signal
-          - string-parsers
-          - strings
-          - tuples
-          - unfoldable
-      minibench:
-        repo: https://github.com/purescript/purescript-minibench.git
-        version: v4.0.0
-        dependencies:
-          - console
-          - effect
-          - integers
-          - numbers
-          - partial
-          - prelude
-          - refs
-      mmorph:
-        repo: https://github.com/Thimoteus/purescript-mmorph.git
-        version: v7.0.0
-        dependencies:
-          - free
-          - functors
-          - transformers
-      monad-control:
-        repo: https://github.com/athanclark/purescript-monad-control.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - freet
-          - identity
-          - lists
-      monad-logger:
-        repo: https://github.com/cprussin/purescript-monad-logger.git
-        version: v1.3.1
-        dependencies:
-          - aff
-          - ansi
-          - argonaut
-          - arrays
-          - console
-          - control
-          - effect
-          - foldable-traversable
-          - foreign-object
-          - integers
-          - js-date
-          - maybe
-          - newtype
-          - ordered-collections
-          - prelude
-          - strings
-          - transformers
-          - tuples
-      monad-loops:
-        repo: https://github.com/mlang/purescript-monad-loops.git
-        version: v0.5.0
-        dependencies:
-          - lists
-          - maybe
-          - prelude
-          - tailrec
-          - tuples
-      monad-unlift:
-        repo: https://github.com/athanclark/purescript-monad-unlift.git
-        version: v1.0.1
-        dependencies:
-          - monad-control
-      monoidal:
-        repo: https://github.com/mcneissue/purescript-monoidal.git
-        version: v0.16.0
-        dependencies:
-          - either
-          - profunctor
-          - these
-          - tuples
-      morello:
-        repo: https://github.com/sigma-andex/purescript-morello.git
-        version: v0.3.2
-        dependencies:
-          - arrays
-          - barlow-lens
-          - foldable-traversable
-          - heterogeneous
-          - heterogeneous-extrablatt
-          - newtype
-          - prelude
-          - profunctor
-          - profunctor-lenses
-          - record
-          - tuples
-          - typelevel-prelude
-          - validation
-      motsunabe:
-        repo: https://github.com/justinwoo/purescript-motsunabe.git
-        version: v2.0.0
-        dependencies:
-          - lists
-          - strings
-      nano-id:
-        repo: https://github.com/eikooc/nano-id.git
-        version: v1.1.0
-        dependencies:
-          - aff
-          - effect
-          - lists
-          - maybe
-          - prelude
-          - random
-          - spec
-          - strings
-          - stringutils
-      naturals:
-        repo: https://github.com/LiamGoodacre/purescript-naturals.git
-        version: v3.0.0
-        dependencies:
-          - enums
-          - maybe
-          - prelude
-      nested-functor:
-        repo: https://github.com/acple/purescript-nested-functor.git
-        version: v0.2.1
-        dependencies:
-          - prelude
-          - type-equality
-      newtype:
-        repo: https://github.com/purescript/purescript-newtype.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-          - safe-coerce
-      node-buffer:
-        repo: https://github.com/purescript-node/purescript-node-buffer.git
-        version: v8.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - maybe
-          - st
-          - unsafe-coerce
-      node-buffer-blob:
-        repo: https://github.com/purescript-node/purescript-node-buffer-blob.git
-        version: v1.0.0
-        dependencies:
-          - aff-promise
-          - arraybuffer-types
-          - arrays
-          - console
-          - effect
-          - maybe
-          - media-types
-          - newtype
-          - node-buffer
-          - nullable
-          - prelude
-          - web-streams
-      node-child-process:
-        repo: https://github.com/purescript-node/purescript-node-child-process.git
-        version: v9.0.0
-        dependencies:
-          - exceptions
-          - foreign
-          - foreign-object
-          - functions
-          - node-fs
-          - node-streams
-          - nullable
-          - posix-types
-          - unsafe-coerce
-      node-fs:
-        repo: https://github.com/purescript-node/purescript-node-fs.git
-        version: v8.0.0
-        dependencies:
-          - datetime
-          - effect
-          - either
-          - enums
-          - exceptions
-          - functions
-          - integers
-          - js-date
-          - maybe
-          - node-buffer
-          - node-path
-          - node-streams
-          - nullable
-          - partial
-          - prelude
-          - strings
-          - unsafe-coerce
-      node-fs-aff:
-        repo: https://github.com/purescript-node/purescript-node-fs-aff.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - either
-          - node-fs
-          - node-path
-      node-http:
-        repo: https://github.com/purescript-node/purescript-node-http.git
-        version: v8.0.0
-        dependencies:
-          - arraybuffer-types
-          - contravariant
-          - effect
-          - foreign
-          - foreign-object
-          - maybe
-          - node-buffer
-          - node-net
-          - node-streams
-          - node-url
-          - nullable
-          - options
-          - prelude
-          - unsafe-coerce
-      node-net:
-        repo: https://github.com/purescript-node/purescript-node-net.git
-        version: v4.0.0
-        dependencies:
-          - effect
-          - either
-          - exceptions
-          - foreign
-          - maybe
-          - node-buffer
-          - node-fs
-          - nullable
-          - options
-          - prelude
-          - transformers
-      node-path:
-        repo: https://github.com/purescript-node/purescript-node-path.git
-        version: v5.0.0
-        dependencies:
-          - effect
-      node-process:
-        repo: https://github.com/purescript-node/purescript-node-process.git
-        version: v10.0.0
-        dependencies:
-          - effect
-          - foreign-object
-          - maybe
-          - node-streams
-          - posix-types
-          - prelude
-          - unsafe-coerce
-      node-readline:
-        repo: https://github.com/purescript-node/purescript-node-readline.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - foreign
-          - node-process
-          - node-streams
-          - options
-          - prelude
-      node-streams:
-        repo: https://github.com/purescript-node/purescript-node-streams.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - either
-          - exceptions
-          - node-buffer
-          - nullable
-          - prelude
-      node-streams-aff:
-        repo: https://github.com/jamesdbrock/purescript-node-streams-aff.git
-        version: v2.0.0
-        dependencies:
-          - aff
-          - arrays
-          - effect
-          - either
-          - exceptions
-          - maybe
-          - node-buffer
-          - node-streams
-          - prelude
-          - st
-          - tuples
-      node-url:
-        repo: https://github.com/purescript-node/purescript-node-url.git
-        version: v6.0.0
-        dependencies:
-          - nullable
-      nonempty:
-        repo: https://github.com/purescript/purescript-nonempty.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - maybe
-          - prelude
-          - tuples
-          - unfoldable
-      now:
-        repo: https://github.com/purescript-contrib/purescript-now.git
-        version: v6.0.0
-        dependencies:
-          - datetime
-          - effect
-      npm-package-json:
-        repo: https://github.com/maxdeviant/purescript-npm-package-json.git
-        version: v2.0.0
-        dependencies:
-          - argonaut
-          - control
-          - either
-          - foreign-object
-          - maybe
-          - ordered-collections
-          - prelude
-      nullable:
-        repo: https://github.com/purescript-contrib/purescript-nullable.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - functions
-          - maybe
-      numbers:
-        repo: https://github.com/purescript/purescript-numbers.git
-        version: v9.0.0
-        dependencies:
-          - functions
-          - maybe
-      open-folds:
-        repo: https://github.com/purescript-open-community/purescript-open-folds.git
-        version: v6.3.0
-        dependencies:
-          - bifunctors
-          - console
-          - control
-          - distributive
-          - effect
-          - either
-          - foldable-traversable
-          - identity
-          - invariant
-          - maybe
-          - newtype
-          - ordered-collections
-          - prelude
-          - profunctor
-          - psci-support
-          - tuples
-      open-memoize:
-        repo: https://github.com/purescript-open-community/purescript-open-memoize.git
-        version: v6.1.0
-        dependencies:
-          - console
-          - effect
-          - either
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - psci-support
-          - strings
-          - tuples
-      open-pairing:
-        repo: https://github.com/purescript-open-community/purescript-open-pairing.git
-        version: v6.1.0
-        dependencies:
-          - console
-          - control
-          - effect
-          - either
-          - free
-          - functors
-          - identity
-          - newtype
-          - prelude
-          - psci-support
-          - transformers
-          - tuples
-      options:
-        repo: https://github.com/purescript-contrib/purescript-options.git
-        version: v7.0.0
-        dependencies:
-          - contravariant
-          - foreign
-          - foreign-object
-          - maybe
-          - tuples
-      optparse:
-        repo: https://github.com/f-o-a-m/purescript-optparse.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - control
-          - effect
-          - either
-          - enums
-          - exists
-          - exitcodes
-          - foldable-traversable
-          - free
-          - gen
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - newtype
-          - node-buffer
-          - node-process
-          - node-streams
-          - nonempty
-          - numbers
-          - open-memoize
-          - partial
-          - prelude
-          - quickcheck
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-      ordered-collections:
-        repo: https://github.com/purescript/purescript-ordered-collections.git
-        version: v3.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - gen
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - unfoldable
-      ordered-set:
-        repo: https://github.com/flip111/purescript-ordered-set.git
-        version: v0.4.0
-        dependencies:
-          - argonaut-codecs
-          - arrays
-          - partial
-          - prelude
-          - unfoldable
-      orders:
-        repo: https://github.com/purescript/purescript-orders.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      pairs:
-        repo: https://github.com/sharkdp/purescript-pairs.git
-        version: v9.0.0
-        dependencies:
-          - console
-          - distributive
-          - foldable-traversable
-          - quickcheck
-      parallel:
-        repo: https://github.com/purescript/purescript-parallel.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - functors
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - refs
-          - transformers
-      parsing:
-        repo: https://github.com/purescript-contrib/purescript-parsing.git
-        version: v9.1.0
-        dependencies:
-          - arrays
-          - either
-          - foldable-traversable
-          - identity
-          - integers
-          - lists
-          - maybe
-          - nullable
-          - prelude
-          - strings
-          - transformers
-          - unicode
-      parsing-dataview:
-        repo: https://github.com/jamesdbrock/purescript-parsing-dataview.git
-        version: v3.1.0
-        dependencies:
-          - arraybuffer
-          - arraybuffer-types
-          - effect
-          - float32
-          - maybe
-          - parsing
-          - prelude
-          - transformers
-          - tuples
-          - uint
-      partial:
-        repo: https://github.com/purescript/purescript-partial.git
-        version: v4.0.0
-        dependencies: []
-      pathy:
-        repo: https://github.com/purescript-contrib/purescript-pathy.git
-        version: v9.0.0
-        dependencies:
-          - console
-          - exceptions
-          - lists
-          - partial
-          - profunctor
-          - strings
-          - transformers
-          - typelevel-prelude
-          - unsafe-coerce
-      pha:
-        repo: https://github.com/gbagan/purescript-pha.git
-        version: v0.9.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - datetime
-          - effect
-          - foldable-traversable
-          - free
-          - integers
-          - maybe
-          - prelude
-          - profunctor-lenses
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-          - unsafe-reference
-          - web-dom
-          - web-events
-          - web-html
-          - web-pointerevents
-          - web-uievents
-      phaser:
-        repo: https://github.com/lfarroco/purescript-phaser.git
-        version: v0.6.0
-        dependencies:
-          - canvas
-          - console
-          - effect
-          - maybe
-          - nullable
-          - options
-          - prelude
-          - web-html
-      pipes:
-        repo: https://github.com/felixschl/purescript-pipes.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - lists
-          - mmorph
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      point-free:
-        repo: https://github.com/ursi/purescript-point-free.git
-        version: v1.0.0
-        dependencies:
-          - prelude
-      polymorphic-vectors:
-        repo: https://github.com/artemisSystem/purescript-polymorphic-vectors.git
-        version: v4.0.0
-        dependencies:
-          - distributive
-          - foldable-traversable
-          - numbers
-          - prelude
-          - record
-          - safe-coerce
-          - type-equality
-          - typelevel-prelude
-      posix-types:
-        repo: https://github.com/purescript-node/purescript-posix-types.git
-        version: v6.0.0
-        dependencies:
-          - maybe
-          - prelude
-      precise:
-        repo: https://github.com/purescript-contrib/purescript-precise.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - exceptions
-          - gen
-          - integers
-          - lists
-          - numbers
-          - prelude
-          - strings
-      precise-datetime:
-        repo: https://github.com/awakesecurity/purescript-precise-datetime.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - datetime
-          - decimals
-          - either
-          - enums
-          - foldable-traversable
-          - formatters
-          - integers
-          - js-date
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - strings
-          - tuples
-          - unicode
-      prelude:
-        repo: https://github.com/purescript/purescript-prelude.git
-        version: v6.0.0
-        dependencies: []
-      prettier-printer:
-        repo: https://github.com/paulyoung/purescript-prettier-printer.git
-        version: v3.0.0
-        dependencies:
-          - console
-          - lists
-          - prelude
-          - strings
-          - tuples
-      profunctor:
-        repo: https://github.com/purescript/purescript-profunctor.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - distributive
-          - either
-          - exists
-          - invariant
-          - newtype
-          - prelude
-          - tuples
-      profunctor-lenses:
-        repo: https://github.com/purescript-contrib/purescript-profunctor-lenses.git
-        version: v8.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - const
-          - control
-          - distributive
-          - either
-          - foldable-traversable
-          - foreign-object
-          - functors
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - ordered-collections
-          - partial
-          - prelude
-          - profunctor
-          - record
-          - transformers
-          - tuples
-      protobuf:
-        repo: https://github.com/xc-jp/purescript-protobuf.git
-        version: v4.0.0
-        dependencies:
-          - arraybuffer
-          - arraybuffer-builder
-          - arraybuffer-types
-          - arrays
-          - control
-          - effect
-          - either
-          - enums
-          - exceptions
-          - float32
-          - foldable-traversable
-          - functions
-          - int64
-          - maybe
-          - newtype
-          - parsing
-          - parsing-dataview
-          - prelude
-          - record
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-          - uint
-          - web-encoding
-      ps-cst:
-        repo: https://github.com/purescript-codegen/purescript-ps-cst.git
-        version: v1.2.0
-        dependencies:
-          - ansi
-          - console
-          - dodo-printer
-          - effect
-          - node-fs-aff
-          - node-path
-          - psci-support
-          - record
-          - strings
-      psa-utils:
-        repo: https://github.com/natefaubion/purescript-psa-utils.git
-        version: v8.0.0
-        dependencies:
-          - ansi
-          - argonaut-codecs
-          - argonaut-core
-          - arrays
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - maybe
-          - node-path
-          - ordered-collections
-          - prelude
-          - strings
-          - tuples
-          - unsafe-coerce
-      psc-ide:
-        repo: https://github.com/kRITZCREEK/purescript-psc-ide.git
-        version: v19.0.0
-        dependencies:
-          - aff
-          - argonaut
-          - arrays
-          - console
-          - maybe
-          - node-child-process
-          - node-fs
-          - parallel
-          - random
-      psci-support:
-        repo: https://github.com/purescript/purescript-psci-support.git
-        version: v6.0.0
-        dependencies:
-          - console
-          - effect
-          - prelude
-      qualified-do:
-        repo: https://github.com/artemisSystem/purescript-qualified-do.git
-        version: v2.2.0
-        dependencies:
-          - arrays
-          - control
-          - foldable-traversable
-          - parallel
-          - prelude
-          - unfoldable
-      quantities:
-        repo: https://github.com/sharkdp/purescript-quantities.git
-        version: v12.0.1
-        dependencies:
-          - decimals
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - newtype
-          - nonempty
-          - numbers
-          - pairs
-          - prelude
-          - tuples
-      quickcheck:
-        repo: https://github.com/purescript/purescript-quickcheck.git
-        version: v8.0.1
-        dependencies:
-          - arrays
-          - console
-          - control
-          - effect
-          - either
-          - enums
-          - exceptions
-          - foldable-traversable
-          - gen
-          - identity
-          - integers
-          - lazy
-          - lcg
-          - lists
-          - maybe
-          - newtype
-          - nonempty
-          - numbers
-          - partial
-          - prelude
-          - record
-          - st
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-          - unfoldable
-      quickcheck-combinators:
-        repo: https://github.com/athanclark/purescript-quickcheck-combinators.git
-        version: v0.1.3
-        dependencies:
-          - quickcheck
-          - typelevel
-      quickcheck-laws:
-        repo: https://github.com/purescript-contrib/purescript-quickcheck-laws.git
-        version: v7.0.0
-        dependencies:
-          - enums
-          - quickcheck
-      quickcheck-utf8:
-        repo: https://github.com/openchronology/purescript-quickcheck-utf8.git
-        version: v0.0.0
-        dependencies:
-          - quickcheck
-      quotient:
-        repo: https://github.com/rightfold/purescript-quotient.git
-        version: v3.0.0
-        dependencies:
-          - prelude
-          - quickcheck
-      random:
-        repo: https://github.com/purescript/purescript-random.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - integers
-      rationals:
-        repo: https://github.com/anttih/purescript-rationals.git
-        version: v5.0.0
-        dependencies:
-          - integers
-          - prelude
-      react:
-        repo: https://github.com/purescript-contrib/purescript-react.git
-        version: v10.0.1
-        dependencies:
-          - effect
-          - exceptions
-          - maybe
-          - nullable
-          - prelude
-          - typelevel-prelude
-          - unsafe-coerce
-      react-basic:
-        repo: https://github.com/lumihq/purescript-react-basic.git
-        version: v17.0.0
-        dependencies:
-          - effect
-          - prelude
-          - record
-      react-basic-dom:
-        repo: https://github.com/lumihq/purescript-react-basic-dom.git
-        version: v5.0.0
-        dependencies:
-          - effect
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - nullable
-          - prelude
-          - react-basic
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-file
-          - web-html
-      react-basic-hooks:
-        repo: https://github.com/megamaddu/purescript-react-basic-hooks.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - aff-promise
-          - bifunctors
-          - console
-          - control
-          - datetime
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - functions
-          - indexed-monad
-          - integers
-          - maybe
-          - newtype
-          - now
-          - nullable
-          - ordered-collections
-          - prelude
-          - react-basic
-          - refs
-          - tuples
-          - type-equality
-          - unsafe-coerce
-          - unsafe-reference
-          - web-html
-      react-dom:
-        repo: https://github.com/purescript-contrib/purescript-react-dom.git
-        version: v8.0.0
-        dependencies:
-          - effect
-          - react
-          - web-dom
-      read:
-        repo: https://github.com/truqu/purescript-read.git
-        version: v1.0.1
-        dependencies:
-          - maybe
-          - prelude
-          - strings
-      record:
-        repo: https://github.com/purescript/purescript-record.git
-        version: v4.0.0
-        dependencies:
-          - functions
-          - prelude
-          - unsafe-coerce
-      refined:
-        repo: https://github.com/danieljharvey/purescript-refined.git
-        version: v1.0.0
-        dependencies:
-          - argonaut
-          - effect
-          - prelude
-          - quickcheck
-          - typelevel
-      refs:
-        repo: https://github.com/purescript/purescript-refs.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - prelude
-      remotedata:
-        repo: https://github.com/krisajenkins/purescript-remotedata.git
-        version: v5.0.0
-        dependencies:
-          - bifunctors
-          - either
-          - profunctor-lenses
-      resource:
-        repo: https://github.com/joneshf/purescript-resource.git
-        version: v2.0.1
-        dependencies:
-          - aff
-          - console
-          - control
-          - effect
-          - newtype
-          - prelude
-          - psci-support
-          - refs
-      resourcet:
-        repo: https://github.com/robertdp/purescript-resourcet.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - effect
-          - foldable-traversable
-          - maybe
-          - ordered-collections
-          - parallel
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-      result:
-        repo: https://github.com/ad-si/purescript-result.git
-        version: v1.0.3
-        dependencies:
-          - either
-          - foldable-traversable
-          - prelude
-      return:
-        repo: https://github.com/ursi/purescript-return.git
-        version: v0.2.0
-        dependencies:
-          - foldable-traversable
-          - point-free
-          - prelude
-      ring-modules:
-        repo: https://github.com/f-o-a-m/purescript-ring-modules.git
-        version: v5.0.1
-        dependencies:
-          - prelude
-      routing:
-        repo: https://github.com/purescript-contrib/purescript-routing.git
-        version: v11.0.0
-        dependencies:
-          - aff
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - integers
-          - js-uri
-          - lists
-          - maybe
-          - numbers
-          - partial
-          - prelude
-          - semirings
-          - tuples
-          - validation
-          - web-html
-      routing-duplex:
-        repo: https://github.com/natefaubion/purescript-routing-duplex.git
-        version: v0.6.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - js-uri
-          - lazy
-          - numbers
-          - prelude
-          - profunctor
-          - record
-          - strings
-          - typelevel-prelude
-      run:
-        repo: https://github.com/natefaubion/purescript-run.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - free
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - tailrec
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - variant
-      safe-coerce:
-        repo: https://github.com/purescript/purescript-safe-coerce.git
-        version: v2.0.0
-        dependencies:
-          - unsafe-coerce
-      safely:
-        repo: https://github.com/paf31/purescript-safely.git
-        version: v4.0.1
-        dependencies:
-          - freet
-          - lists
-      selection-foldable:
-        repo: https://github.com/jamieyung/purescript-selection-foldable.git
-        version: v0.2.0
-        dependencies:
-          - filterable
-          - foldable-traversable
-          - maybe
-          - prelude
-      semirings:
-        repo: https://github.com/purescript/purescript-semirings.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - lists
-          - newtype
-          - prelude
-      signal:
-        repo: https://github.com/bodil/purescript-signal.git
-        version: v13.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - foldable-traversable
-          - maybe
-          - prelude
-      simple-emitter:
-        repo: https://github.com/oreshinya/purescript-simple-emitter.git
-        version: v2.0.0
-        dependencies:
-          - ordered-collections
-          - refs
-      sized-matrices:
-        repo: https://github.com/csicar/purescript-sized-matrices.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - distributive
-          - foldable-traversable
-          - maybe
-          - prelude
-          - sized-vectors
-          - strings
-          - typelevel
-          - unfoldable
-          - vectorfield
-      sized-vectors:
-        repo: https://github.com/bodil/purescript-sized-vectors.git
-        version: v5.0.2
-        dependencies:
-          - argonaut
-          - arrays
-          - distributive
-          - foldable-traversable
-          - maybe
-          - prelude
-          - quickcheck
-          - typelevel
-          - unfoldable
-      slug:
-        repo: https://github.com/thomashoneyman/purescript-slug.git
-        version: v3.0.1
-        dependencies:
-          - argonaut-codecs
-          - maybe
-          - prelude
-          - strings
-          - unicode
-      soundfonts:
-        repo: https://github.com/newlandsvalley/purescript-soundfonts.git
-        version: v4.1.0
-        dependencies:
-          - aff
-          - affjax
-          - affjax-web
-          - argonaut-core
-          - arraybuffer-types
-          - arrays
-          - b64
-          - bifunctors
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign-object
-          - http-methods
-          - integers
-          - lists
-          - maybe
-          - midi
-          - ordered-collections
-          - parallel
-          - partial
-          - prelude
-          - strings
-          - transformers
-          - tuples
-      sparse-matrices:
-        repo: https://github.com/Ebmtranceboy/purescript-sparse-matrices.git
-        version: v1.2.1
-        dependencies:
-          - console
-          - effect
-          - prelude
-          - sparse-polynomials
-      sparse-polynomials:
-        repo: https://github.com/Ebmtranceboy/purescript-sparse-polynomials.git
-        version: v1.0.5
-        dependencies:
-          - cartesian
-          - console
-          - effect
-          - ordered-collections
-          - prelude
-          - rationals
-          - tuples
-      spec:
-        repo: https://github.com/purescript-spec/purescript-spec.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - ansi
-          - avar
-          - console
-          - exceptions
-          - foldable-traversable
-          - fork
-          - now
-          - pipes
-          - prelude
-          - strings
-          - transformers
-      spec-discovery:
-        repo: https://github.com/purescript-spec/purescript-spec-discovery.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - aff-promise
-          - arrays
-          - console
-          - effect
-          - foldable-traversable
-          - node-fs
-          - prelude
-          - spec
-      spec-quickcheck:
-        repo: https://github.com/purescript-spec/purescript-spec-quickcheck.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - prelude
-          - quickcheck
-          - random
-          - spec
-      ssrs:
-        repo: https://github.com/PureFunctor/purescript-ssrs.git
-        version: v1.0.0
-        dependencies:
-          - dissect
-          - either
-          - fixed-points
-          - free
-          - lists
-          - prelude
-          - safe-coerce
-          - tailrec
-          - tuples
-          - variant
-      st:
-        repo: https://github.com/purescript/purescript-st.git
-        version: v6.0.0
-        dependencies:
-          - partial
-          - prelude
-          - tailrec
-          - unsafe-coerce
-      strictlypositiveint:
-        repo: https://github.com/jamieyung/purescript-strictlypositiveint.git
-        version: v1.0.1
-        dependencies:
-          - prelude
-      string-parsers:
-        repo: https://github.com/purescript-contrib/purescript-string-parsers.git
-        version: v8.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - prelude
-          - strings
-          - tailrec
-      strings:
-        repo: https://github.com/purescript/purescript-strings.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - enums
-          - foldable-traversable
-          - gen
-          - integers
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-          - unsafe-coerce
-      strings-extra:
-        repo: https://github.com/purescript-contrib/purescript-strings-extra.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - maybe
-          - prelude
-          - strings
-          - unicode
-      stringutils:
-        repo: https://github.com/menelaos/purescript-stringutils.git
-        version: v0.0.12
-        dependencies:
-          - arrays
-          - integers
-          - maybe
-          - partial
-          - prelude
-          - strings
-      substitute:
-        repo: https://github.com/ursi/purescript-substitute.git
-        version: v0.2.3
-        dependencies:
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - prelude
-          - return
-          - strings
-      supply:
-        repo: https://github.com/ajnsit/purescript-supply.git
-        version: v0.2.0
-        dependencies:
-          - console
-          - control
-          - effect
-          - lazy
-          - prelude
-          - refs
-          - tuples
-      tailrec:
-        repo: https://github.com/purescript/purescript-tailrec.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - effect
-          - either
-          - identity
-          - maybe
-          - partial
-          - prelude
-          - refs
-      test-unit:
-        repo: https://github.com/bodil/purescript-test-unit.git
-        version: v17.0.0
-        dependencies:
-          - aff
-          - avar
-          - effect
-          - either
-          - free
-          - js-timers
-          - lists
-          - prelude
-          - quickcheck
-          - strings
-      thermite:
-        repo: https://github.com/paf31/purescript-thermite.git
-        version: v6.3.1
-        dependencies:
-          - aff
-          - coroutines
-          - freet
-          - profunctor-lenses
-          - react
-      thermite-dom:
-        repo: https://github.com/athanclark/purescript-thermite-dom.git
-        version: v0.3.1
-        dependencies:
-          - react
-          - react-dom
-          - thermite
-          - web-html
-      these:
-        repo: https://github.com/purescript-contrib/purescript-these.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - gen
-          - lists
-          - quickcheck
-          - quickcheck-laws
-          - tuples
-      transformers:
-        repo: https://github.com/purescript/purescript-transformers.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - distributive
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - identity
-          - lazy
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      tree-rose:
-        repo: https://github.com/jordanmartinez/purescript-tree-rose.git
-        version: v4.0.2
-        dependencies:
-          - control
-          - foldable-traversable
-          - free
-          - lists
-          - maybe
-          - prelude
-          - tailrec
-      tuples:
-        repo: https://github.com/purescript/purescript-tuples.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - invariant
-          - prelude
-      two-or-more:
-        repo: https://github.com/i-am-the-slime/purescript-two-or-more.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - foldable-traversable
-          - maybe
-          - partial
-          - prelude
-          - psci-support
-          - tuples
-      type-equality:
-        repo: https://github.com/purescript/purescript-type-equality.git
-        version: v4.0.1
-        dependencies: []
-      typelevel:
-        repo: https://github.com/bodil/purescript-typelevel.git
-        version: v6.0.0
-        dependencies:
-          - partial
-          - prelude
-          - tuples
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-lists:
-        repo: https://github.com/PureFunctor/purescript-typelevel-lists.git
-        version: v2.1.0
-        dependencies:
-          - prelude
-          - tuples
-          - typelevel-peano
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-peano:
-        repo: https://github.com/csicar/purescript-typelevel-peano.git
-        version: v1.0.1
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - prelude
-          - psci-support
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-prelude:
-        repo: https://github.com/purescript/purescript-typelevel-prelude.git
-        version: v7.0.0
-        dependencies:
-          - prelude
-          - type-equality
-      typelevel-rows:
-        repo: https://github.com/jordanmartinez/purescript-typelevel-rows.git
-        version: v0.1.0
-        dependencies:
-          - prelude
-      uint:
-        repo: https://github.com/purescript-contrib/purescript-uint.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - enums
-          - gen
-          - maybe
-          - numbers
-          - prelude
-      uncurried-transformers:
-        repo: https://github.com/PureFunctor/purescript-uncurried-transformers.git
-        version: v1.1.0
-        dependencies:
-          - control
-          - effect
-          - either
-          - functions
-          - identity
-          - prelude
-          - safe-coerce
-          - tailrec
-          - transformers
-          - tuples
-      undefined-is-not-a-problem:
-        repo: https://github.com/paluh/purescript-undefined-is-not-a-problem.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - assert
-          - effect
-          - either
-          - foreign
-          - maybe
-          - newtype
-          - prelude
-          - random
-          - tuples
-          - type-equality
-          - unsafe-coerce
-      unfoldable:
-        repo: https://github.com/purescript/purescript-unfoldable.git
-        version: v6.0.0
-        dependencies:
-          - foldable-traversable
-          - maybe
-          - partial
-          - prelude
-          - tuples
-      unicode:
-        repo: https://github.com/purescript-contrib/purescript-unicode.git
-        version: v6.0.0
-        dependencies:
-          - foldable-traversable
-          - maybe
-          - strings
-      unlift:
-        repo: https://github.com/tweag/purescript-unlift.git
-        version: v1.0.1
-        dependencies:
-          - aff
-          - effect
-          - either
-          - freet
-          - identity
-          - lists
-          - maybe
-          - monad-control
-          - prelude
-          - st
-          - transformers
-          - tuples
-      unsafe-coerce:
-        repo: https://github.com/purescript/purescript-unsafe-coerce.git
-        version: v6.0.0
-        dependencies: []
-      unsafe-reference:
-        repo: https://github.com/purescript-contrib/purescript-unsafe-reference.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-      uri:
-        repo: https://github.com/purescript-contrib/purescript-uri.git
-        version: v9.0.0
-        dependencies:
-          - arrays
-          - integers
-          - js-uri
-          - numbers
-          - parsing
-          - prelude
-          - profunctor-lenses
-          - these
-          - transformers
-          - unfoldable
-      validation:
-        repo: https://github.com/purescript/purescript-validation.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - newtype
-          - prelude
-      variant:
-        repo: https://github.com/natefaubion/purescript-variant.git
-        version: v8.0.0
-        dependencies:
-          - enums
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - record
-          - tuples
-          - unsafe-coerce
-      vectorfield:
-        repo: https://github.com/csicar/purescript-vectorfield.git
-        version: v1.0.1
-        dependencies:
-          - console
-          - effect
-          - group
-          - prelude
-          - psci-support
-      versions:
-        repo: https://github.com/hdgarrood/purescript-versions.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - either
-          - foldable-traversable
-          - functions
-          - integers
-          - lists
-          - maybe
-          - orders
-          - parsing
-          - partial
-          - strings
-      web-clipboard:
-        repo: https://github.com/purescript-web/purescript-web-clipboard.git
-        version: v4.0.0
-        dependencies:
-          - web-html
-      web-cssom:
-        repo: https://github.com/purescript-web/purescript-web-cssom.git
-        version: v2.0.0
-        dependencies:
-          - web-dom
-          - web-html
-          - web-uievents
-      web-dom:
-        repo: https://github.com/purescript-web/purescript-web-dom.git
-        version: v6.0.0
-        dependencies:
-          - web-events
-      web-dom-parser:
-        repo: https://github.com/purescript-web/purescript-web-dom-parser.git
-        version: v8.0.0
-        dependencies:
-          - effect
-          - partial
-          - prelude
-          - web-dom
-      web-dom-xpath:
-        repo: https://github.com/purescript-web/purescript-web-dom-xpath.git
-        version: v3.0.0
-        dependencies:
-          - web-dom
-      web-encoding:
-        repo: https://github.com/purescript-web/purescript-web-encoding.git
-        version: v3.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - newtype
-          - prelude
-      web-events:
-        repo: https://github.com/purescript-web/purescript-web-events.git
-        version: v4.0.0
-        dependencies:
-          - datetime
-          - enums
-          - foreign
-          - nullable
-      web-fetch:
-        repo: https://github.com/purescript-web/purescript-web-fetch.git
-        version: v3.0.0
-        dependencies:
-          - effect
-          - foreign-object
-          - http-methods
-          - prelude
-          - record
-          - typelevel-prelude
-          - web-file
-          - web-promise
-          - web-streams
-      web-file:
-        repo: https://github.com/purescript-web/purescript-web-file.git
-        version: v4.0.0
-        dependencies:
-          - foreign
-          - media-types
-          - web-dom
-      web-html:
-        repo: https://github.com/purescript-web/purescript-web-html.git
-        version: v4.0.0
-        dependencies:
-          - js-date
-          - web-dom
-          - web-file
-          - web-storage
-      web-page-visibility:
-        repo: https://git.sr.ht/~toastal/purescript-web-page-visibility
-        version: v2.0.0
-        dependencies:
-          - effect
-          - enums
-          - exceptions
-          - maybe
-          - prelude
-          - strings
-          - web-events
-          - web-html
-      web-pointerevents:
-        repo: https://github.com/purescript-web/purescript-web-pointerevents.git
-        version: v1.0.0
-        dependencies:
-          - effect
-          - maybe
-          - prelude
-          - web-dom
-          - web-uievents
-      web-promise:
-        repo: https://github.com/purescript-web/purescript-web-promise.git
-        version: v3.0.0
-        dependencies:
-          - effect
-          - exceptions
-          - foldable-traversable
-          - functions
-          - maybe
-          - prelude
-      web-socket:
-        repo: https://github.com/purescript-web/purescript-web-socket.git
-        version: v4.0.0
-        dependencies:
-          - arraybuffer-types
-          - web-file
-      web-storage:
-        repo: https://github.com/purescript-web/purescript-web-storage.git
-        version: v5.0.0
-        dependencies:
-          - nullable
-          - web-events
-      web-streams:
-        repo: https://github.com/purescript-web/purescript-web-streams.git
-        version: v3.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - exceptions
-          - nullable
-          - prelude
-          - tuples
-          - web-promise
-      web-touchevents:
-        repo: https://github.com/purescript-web/purescript-web-touchevents.git
-        version: v4.0.0
-        dependencies:
-          - web-uievents
-      web-uievents:
-        repo: https://github.com/purescript-web/purescript-web-uievents.git
-        version: v4.0.0
-        dependencies:
-          - web-html
-      web-workers:
-        repo: https://github.com/gbagan/purescript-web-workers.git
-        version: v1.1.0
-        dependencies:
-          - effect
-          - foreign
-          - maybe
-          - prelude
-          - unsafe-coerce
-          - web-events
-      web-xhr:
-        repo: https://github.com/purescript-web/purescript-web-xhr.git
-        version: v5.0.0
-        dependencies:
-          - arraybuffer-types
-          - datetime
-          - http-methods
-          - web-dom
-          - web-file
-          - web-html
-      yoga-fetch:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-fetch.git
-        version: v1.0.1
-        dependencies:
-          - aff
-          - aff-promise
-          - arraybuffer-types
-          - effect
-          - foreign
-          - foreign-object
-          - newtype
-          - prelude
-          - typelevel-prelude
-          - unsafe-coerce
-      yoga-json:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-json.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - identity
-          - lists
-          - maybe
-          - nullable
-          - partial
-          - prelude
-          - record
-          - transformers
-          - typelevel-prelude
-          - variant
-      yoga-postgres:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-postgres.git
-        version: v6.0.0
-        dependencies:
-          - aff
-          - arrays
-          - datetime
-          - effect
-          - either
-          - enums
-          - foldable-traversable
-          - foreign
-          - integers
-          - maybe
-          - nullable
-          - prelude
-          - transformers
-          - unsafe-coerce
+      abc-parser: 2.0.0
+      ace: 9.0.0
+      aff: 7.1.0
+      aff-bus: 6.0.0
+      aff-coroutines: 9.0.0
+      aff-promise: 4.0.0
+      aff-retry: 2.0.0
+      affjax: 13.0.0
+      affjax-node: 1.0.0
+      affjax-web: 1.0.0
+      ansi: 7.0.0
+      argonaut: 9.0.0
+      argonaut-aeson-generic: 0.4.1
+      argonaut-codecs: 9.1.0
+      argonaut-core: 7.0.0
+      argonaut-generic: 8.0.0
+      argonaut-traversals: 10.0.0
+      argparse-basic: 2.0.0
+      array-builder: 0.1.2
+      arraybuffer: 13.1.1
+      arraybuffer-builder: 3.1.0
+      arraybuffer-types: 3.0.2
+      arrays: 7.1.0
+      arrays-zipper: 2.0.1
+      ask: 1.0.0
+      assert: 6.0.0
+      avar: 5.0.0
+      b64: 0.0.8
+      barbies: 1.0.1
+      barlow-lens: 0.9.0
+      basic-auth: 3.0.1
+      bifunctors: 6.0.0
+      bigints: 7.0.1
+      bolson: 0.3.1
+      bower-json: 3.0.0
+      bucketchain: 1.0.1
+      bucketchain-basic-auth: 1.0.1
+      bucketchain-conditional: 1.0.1
+      bucketchain-cors: 1.0.1
+      bucketchain-csrf: 1.0.1
+      bucketchain-header-utils: 1.0.1
+      bucketchain-health: 1.0.1
+      bucketchain-history-api-fallback: 1.0.1
+      bucketchain-logger: 1.0.1
+      bucketchain-secure: 1.0.1
+      bucketchain-simple-api: 5.0.1
+      bucketchain-sslify: 1.0.1
+      bucketchain-static: 1.0.1
+      call-by-name: 4.0.1
+      canvas: 6.0.0
+      canvas-action: 9.0.0
+      cartesian: 1.0.6
+      catenable-lists: 7.0.0
+      channel: 1.0.0
+      checked-exceptions: 3.1.1
+      classless: 0.1.1
+      classless-arbitrary: 0.1.1
+      classless-decode-json: 0.1.1
+      classless-encode-json: 0.1.3
+      classnames: 2.0.0
+      codec: 6.0.0
+      codec-argonaut: 10.0.0
+      colors: 7.0.1
+      concur-core: 0.5.0
+      concur-react: 0.5.0
+      concurrent-queues: 3.0.0
+      console: 6.0.0
+      const: 6.0.0
+      contravariant: 6.0.0
+      control: 6.0.0
+      convertable-options: 1.0.0
+      coroutines: 7.0.0
+      crypto: 5.0.1
+      css: 6.0.0
+      datetime: 6.1.0
+      datetime-parsing: 0.2.0
+      debug: 6.0.2
+      decimals: 7.1.0
+      default-values: 1.0.1
+      deku: 0.9.9
+      deno: 0.0.5
+      dissect: 1.0.0
+      distributive: 6.0.0
+      dodo-printer: 2.2.1
+      dom-filereader: 7.0.0
+      dom-indexed: 11.0.0
+      dotenv: 3.0.0
+      droplet: 0.5.0
+      dynamic-buffer: 3.0.1
+      echarts-simple: 0.0.1
+      effect: 4.0.0
+      either: 6.1.0
+      elmish: 0.8.3
+      elmish-enzyme: 0.1.1
+      elmish-hooks: 0.9.1
+      elmish-html: 0.7.2
+      elmish-testing-library: 0.3.1
+      email-validate: 7.0.0
+      encoding: 0.0.8
+      enums: 6.0.1
+      error: 2.0.0
+      exceptions: 6.0.0
+      exists: 6.0.0
+      exitcodes: 4.0.0
+      expect-inferred: 3.0.0
+      fahrtwind: 2.0.0
+      fallback: 0.1.0
+      fast-vect: 1.1.0
+      fetch: 1.1.4
+      fetch-argonaut: 1.0.0
+      fetch-core: 4.0.4
+      fetch-yoga-json: 1.1.0
+      filterable: 5.0.0
+      fixed-points: 7.0.0
+      fixed-precision: 5.0.0
+      flame: 1.2.0
+      float32: 2.0.0
+      foldable-traversable: 6.0.0
+      foreign: 7.0.0
+      foreign-object: 4.1.0
+      foreign-readwrite: 3.4.0
+      fork: 6.0.0
+      form-urlencoded: 7.0.0
+      formatters: 7.0.0
+      framer-motion: 1.0.1
+      free: 7.0.0
+      freeap: 7.0.0
+      freer-free: 0.0.1
+      freet: 7.0.0
+      functions: 6.0.0
+      functor1: 3.0.0
+      functors: 5.0.0
+      fuzzy: 0.4.0
+      gen: 4.0.0
+      generate-values: 1.0.1
+      generic-router: 0.0.1
+      geometry-plane: 1.0.3
+      github-actions-toolkit: 0.5.0
+      grain: 3.0.0
+      grain-router: 3.0.0
+      grain-virtualized: 3.0.0
+      graphql-client: 9.3.2
+      graphs: 8.1.0
+      group: 4.1.1
+      halogen: 7.0.0
+      halogen-bootstrap5: 2.1.0
+      halogen-css: 10.0.0
+      halogen-echarts-simple: 0.0.4
+      halogen-formless: 4.0.2
+      halogen-hooks: 0.6.3
+      halogen-hooks-extra: 0.9.0
+      halogen-store: 0.5.4
+      halogen-storybook: 2.0.0
+      halogen-subscriptions: 2.0.0
+      halogen-svg-elems: 7.0.0
+      halogen-vdom: 8.0.0
+      halogen-vdom-string-renderer: 0.5.0
+      heckin: 2.0.1
+      heterogeneous: 0.6.0
+      homogeneous: 0.4.0
+      http-methods: 6.0.0
+      httpure: 0.16.0
+      httpurple: 3.0.1
+      httpurple-argonaut: 1.0.1
+      httpurple-yoga-json: 1.0.0
+      humdrum: 0.0.1
+      hyrule: 2.3.5
+      identity: 6.0.0
+      identy: 4.0.1
+      indexed-monad: 2.1.0
+      int64: 3.0.0
+      integers: 6.0.0
+      interpolate: 5.0.2
+      invariant: 6.0.0
+      jarilo: 1.0.1
+      jelly: 0.9.1
+      jelly-hooks: 0.3.1
+      jelly-router: 0.2.2
+      jelly-signal: 0.3.0
+      jest: 1.0.0
+      js-bigints: 1.2.0
+      js-date: 8.0.0
+      js-fileio: 3.0.0
+      js-promise: 1.0.0
+      js-promise-aff: 1.0.0
+      js-timers: 6.1.0
+      js-uri: 3.1.0
+      justifill: 0.5.0
+      jwt: 0.0.9
+      language-cst-parser: 0.12.1
+      lazy: 6.0.0
+      lazy-joe: 1.0.0
+      lcg: 4.0.0
+      leibniz: 5.0.0
+      linalg: 5.1.0
+      lists: 7.0.0
+      literals: 1.0.2
+      logging: 3.0.0
+      logging-journald: 0.4.0
+      machines: 7.0.0
+      marionette: 1.0.0
+      marionette-commander: 0.1.1
+      marionette-react-basic-hooks: 0.1.1
+      matrices: 5.0.1
+      matryoshka: 1.0.0
+      maybe: 6.0.0
+      mdast-util-from-markdown: 0.2.1
+      media-types: 6.0.0
+      midi: 4.0.0
+      milkis: 9.0.0
+      minibench: 4.0.1
+      mmorph: 7.0.0
+      monad-control: 5.0.0
+      monad-logger: 1.3.1
+      monad-loops: 0.5.0
+      monad-unlift: 1.0.1
+      monoid-extras: 0.0.1
+      monoidal: 0.16.0
+      morello: 0.4.0
+      mote: 3.0.0
+      motsunabe: 2.0.0
+      mysql: 6.0.1
+      n3: 0.1.0
+      nano-id: 1.1.0
+      naturals: 3.0.0
+      nested-functor: 0.2.1
+      newtype: 5.0.0
+      nextui: 0.1.0
+      node-buffer: 8.0.0
+      node-buffer-blob: 1.0.0
+      node-child-process: 9.0.0
+      node-fs: 8.1.1
+      node-fs-aff: 9.1.0
+      node-http: 8.0.0
+      node-net: 4.0.0
+      node-path: 5.0.0
+      node-process: 10.0.0
+      node-readline: 7.0.0
+      node-sqlite3: 8.0.0
+      node-streams: 7.0.0
+      node-streams-aff: 4.0.1
+      node-url: 6.0.0
+      nodemailer: 4.0.1
+      nonempty: 7.0.0
+      now: 6.0.0
+      npm-package-json: 2.0.0
+      nullable: 6.0.0
+      numbers: 9.0.0
+      object-maps: 0.1.1
+      ocarina: 1.5.2
+      open-folds: 6.3.0
+      open-memoize: 6.1.0
+      open-pairing: 6.1.0
+      options: 7.0.0
+      optparse: 5.0.0
+      ordered-collections: 3.0.0
+      ordered-set: 0.4.0
+      orders: 6.0.0
+      pairs: 9.0.0
+      parallel: 6.0.0
+      parsing: 10.2.0
+      parsing-dataview: 3.2.4
+      partial: 4.0.0
+      pathy: 9.0.0
+      pha: 0.9.0
+      phaser: 0.6.0
+      pipes: 8.0.0
+      pirates-charm: 0.0.1
+      point-free: 1.0.0
+      pointed-list: 0.5.1
+      polymorphic-vectors: 4.0.0
+      posix-types: 6.0.0
+      precise: 6.0.0
+      precise-datetime: 7.0.0
+      prelude: 6.0.1
+      prettier-printer: 3.0.0
+      profunctor: 6.0.0
+      profunctor-lenses: 8.0.0
+      protobuf: 4.2.0
+      ps-cst: 1.2.0
+      psa-utils: 8.0.0
+      psc-ide: 19.0.0
+      psci-support: 6.0.0
+      qualified-do: 2.2.0
+      quantities: 12.1.0
+      quickcheck: 8.0.1
+      quickcheck-combinators: 0.1.3
+      quickcheck-laws: 7.0.0
+      quickcheck-utf8: 0.0.0
+      random: 6.0.0
+      rationals: 5.0.1
+      rdf: 0.1.0
+      react: 10.0.1
+      react-aria: 0.2.0
+      react-basic: 17.0.0
+      react-basic-classic: 3.0.0
+      react-basic-dnd: 10.1.0
+      react-basic-dom: 6.0.0
+      react-basic-emotion: 7.1.0
+      react-basic-hooks: 8.1.2
+      react-basic-storybook: 2.0.0
+      react-dom: 8.0.0
+      react-halo: 3.0.0
+      react-icons: 1.0.8
+      react-testing-library: 4.0.1
+      react-virtuoso: 1.0.0
+      read: 1.0.1
+      record: 4.0.0
+      record-extra: 5.0.1
+      record-studio: 1.0.4
+      refs: 6.0.0
+      remotedata: 5.0.0
+      resource: 2.0.1
+      resourcet: 1.0.0
+      result: 1.0.3
+      return: 0.2.0
+      ring-modules: 5.0.1
+      rito: 0.3.2
+      routing: 11.0.0
+      routing-duplex: 0.7.0
+      run: 5.0.0
+      safe-coerce: 2.0.0
+      safely: 4.0.1
+      school-of-music: 1.3.0
+      selection-foldable: 0.2.0
+      semirings: 7.0.0
+      signal: 13.0.0
+      simple-emitter: 3.0.1
+      simple-i18n: 2.0.1
+      simple-json: 9.0.0
+      simple-jwt: 4.0.1
+      simple-ulid: 3.0.0
+      sized-matrices: 1.0.0
+      sized-vectors: 5.0.2
+      slug: 3.0.8
+      small-ffi: 4.0.1
+      soundfonts: 4.1.0
+      sparse-matrices: 1.2.1
+      sparse-polynomials: 1.0.5
+      spec: 7.2.0
+      spec-discovery: 8.0.1
+      spec-quickcheck: 5.0.0
+      splitmix: 2.1.0
+      ssrs: 1.0.0
+      st: 6.2.0
+      strictlypositiveint: 1.0.1
+      string-parsers: 8.0.0
+      strings: 6.0.1
+      strings-extra: 4.0.0
+      stringutils: 0.0.12
+      substitute: 0.2.3
+      sunde: 3.0.0
+      supply: 0.2.0
+      svg-parser: 3.0.0
+      systemd-journald: 0.3.0
+      tagged: 4.0.2
+      tailrec: 6.1.0
+      tecton: 0.1.6
+      tecton-halogen: 0.1.3
+      test-unit: 17.0.0
+      thermite: 6.3.1
+      thermite-dom: 0.3.1
+      these: 6.0.0
+      toppokki: 4.0.0
+      transformers: 6.0.0
+      tree-rose: 4.0.2
+      tuples: 7.0.0
+      two-or-more: 1.0.0
+      type-equality: 4.0.1
+      typelevel: 6.0.0
+      typelevel-lists: 2.1.0
+      typelevel-peano: 1.0.1
+      typelevel-prelude: 7.0.0
+      typelevel-rows: 0.1.0
+      uint: 7.0.0
+      ulid: 3.0.1
+      uncurried-transformers: 1.1.0
+      undefined: 2.0.0
+      undefined-is-not-a-problem: 1.1.0
+      unfoldable: 6.0.0
+      unicode: 6.0.0
+      unlift: 1.0.1
+      unordered-collections: 3.0.1
+      unsafe-coerce: 6.0.0
+      unsafe-reference: 5.0.0
+      untagged-to-tagged: 0.1.4
+      untagged-union: 1.0.0
+      uri: 9.0.0
+      uuid: 9.0.0
+      uuidv4: 1.0.0
+      validation: 6.0.0
+      variant: 8.0.0
+      vectorfield: 1.0.1
+      vectors: 2.1.0
+      versions: 7.0.0
+      visx: 0.0.2
+      web-clipboard: 5.0.0
+      web-cssom: 2.0.0
+      web-dom: 6.0.0
+      web-dom-parser: 8.0.0
+      web-dom-xpath: 3.0.0
+      web-encoding: 3.0.0
+      web-events: 4.0.0
+      web-fetch: 3.0.0
+      web-file: 4.0.0
+      web-html: 4.1.0
+      web-pointerevents: 1.0.0
+      web-proletarian: 1.0.0
+      web-promise: 3.1.0
+      web-resize-observer: 2.0.0
+      web-router: 1.0.0
+      web-socket: 4.0.0
+      web-storage: 5.0.0
+      web-streams: 3.0.0
+      web-touchevents: 4.0.0
+      web-uievents: 4.0.0
+      web-url: 2.0.0
+      web-workers: 1.1.0
+      web-xhr: 5.0.0
+      which: 2.0.0
+      yoga-fetch: 1.0.1
+      yoga-json: 4.0.1
+      yoga-om: 0.1.0
+      yoga-postgres: 6.0.0
+      yoga-tree: 1.0.0
   extra_packages: {}
 packages:
   aff:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-aff.git
-    rev: 2d44d9f9d0d6a416a4103fba2fb39e5160f80e36
+    type: registry
+    version: 7.1.0
+    integrity: sha256-7hOC6uQO9XBAI5FD8F33ChLjFAiZVfd4BJMqlMh7TNU=
     dependencies:
+      - arrays
+      - bifunctors
+      - control
       - datetime
       - effect
+      - either
       - exceptions
+      - foldable-traversable
       - functions
+      - maybe
+      - newtype
       - parallel
+      - prelude
+      - refs
+      - tailrec
       - transformers
       - unsafe-coerce
   arrays:
-    type: git
-    url: https://github.com/purescript/purescript-arrays.git
-    rev: d20bae2f76db6cf29b7b75e26e82b8a54c32295e
+    type: registry
+    version: 7.1.0
+    integrity: sha256-Rvb3AVLal0ZLpmpABgOPIUeYHa4M+c5GwcUP5rQ2trA=
     dependencies:
       - bifunctors
       - control
@@ -3523,15 +533,16 @@ packages:
       - nonempty
       - partial
       - prelude
+      - safe-coerce
       - st
       - tailrec
       - tuples
       - unfoldable
       - unsafe-coerce
   avar:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-avar.git
-    rev: d00f5784d9cc8f079babd62740f5c52b87e5caa5
+    type: registry
+    version: 5.0.0
+    integrity: sha256-e7hf0x4hEpcygXP0LtvfvAQ49Bbj2aWtZT3gqM///0A=
     dependencies:
       - aff
       - effect
@@ -3540,9 +551,9 @@ packages:
       - functions
       - maybe
   bifunctors:
-    type: git
-    url: https://github.com/purescript/purescript-bifunctors.git
-    rev: 16ba2fb6dd7f05528ebd9e2f9ca3a068b325e5b3
+    type: registry
+    version: 6.0.0
+    integrity: sha256-/gZwC9YhNxZNQpnHa5BIYerCGM2jeX9ukZiEvYxm5Nw=
     dependencies:
       - const
       - either
@@ -3550,9 +561,9 @@ packages:
       - prelude
       - tuples
   catenable-lists:
-    type: git
-    url: https://github.com/purescript/purescript-catenable-lists.git
-    rev: 09abe1f4888bc00841ad2b59e56a9e7ce7ebd4ab
+    type: registry
+    version: 7.0.0
+    integrity: sha256-76vYENhwF4BWTBsjeLuErCH2jqVT4M3R1HX+4RwSftA=
     dependencies:
       - control
       - foldable-traversable
@@ -3562,24 +573,24 @@ packages:
       - tuples
       - unfoldable
   console:
-    type: git
-    url: https://github.com/purescript/purescript-console.git
-    rev: 3b83d7b792d03872afeea5e62b4f686ab0f09842
+    type: registry
+    version: 6.0.0
+    integrity: sha256-gJpJ53fCDAL8BiCiJXH0HNAJ9K3gJtLo8GDaCK6hA5U=
     dependencies:
       - effect
       - prelude
   const:
-    type: git
-    url: https://github.com/purescript/purescript-const.git
-    rev: ab9570cf2b6e67f7e441178211db1231cfd75c37
+    type: registry
+    version: 6.0.0
+    integrity: sha256-tNrxDW8D8H4jdHE2HiPzpLy08zkzJMmGHdRqt5BQuTc=
     dependencies:
       - invariant
       - newtype
       - prelude
   contravariant:
-    type: git
-    url: https://github.com/purescript/purescript-contravariant.git
-    rev: 9ad3e105b8855bcc25f4e0893c784789d05a58de
+    type: registry
+    version: 6.0.0
+    integrity: sha256-TP+ooAp3vvmdjfQsQJSichF5B4BPDHp3wAJoWchip6c=
     dependencies:
       - const
       - either
@@ -3587,16 +598,16 @@ packages:
       - prelude
       - tuples
   control:
-    type: git
-    url: https://github.com/purescript/purescript-control.git
-    rev: a6033808790879a17b2729e73747a9ed3fb2264e
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sH7Pg9E96JCPF9PIA6oQ8+BjTyO/BH1ZuE/bOcyj4Jk=
     dependencies:
       - newtype
       - prelude
   datetime:
-    type: git
-    url: https://github.com/purescript/purescript-datetime.git
-    rev: a6a0cf1b0324964ad1854bc3377ed8766ba90e6f
+    type: registry
+    version: 6.1.0
+    integrity: sha256-g/5X5BBegQWLpI9IWD+sY6mcaYpzzlW5lz5NBzaMtyI=
     dependencies:
       - bifunctors
       - control
@@ -3615,9 +626,9 @@ packages:
       - prelude
       - tuples
   distributive:
-    type: git
-    url: https://github.com/purescript/purescript-distributive.git
-    rev: 6005e513642e855ebf6f884d24a35c2803ca252a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-HTDdmEnzigMl+02SJB88j+gAXDx9VKsbvR4MJGDPbOQ=
     dependencies:
       - identity
       - newtype
@@ -3625,24 +636,24 @@ packages:
       - tuples
       - type-equality
   effect:
-    type: git
-    url: https://github.com/purescript/purescript-effect.git
-    rev: a192ddb923027d426d6ea3d8deb030c9aa7c7dda
+    type: registry
+    version: 4.0.0
+    integrity: sha256-eBtZu+HZcMa5HilvI6kaDyVX3ji8p0W9MGKy2K4T6+M=
     dependencies:
       - prelude
   either:
-    type: git
-    url: https://github.com/purescript/purescript-either.git
-    rev: af655a04ed2fd694b6688af39ee20d7907ad0763
+    type: registry
+    version: 6.1.0
+    integrity: sha256-6hgTPisnMWVwQivOu2PKYcH8uqjEOOqDyaDQVUchTpY=
     dependencies:
       - control
       - invariant
       - maybe
       - prelude
   enums:
-    type: git
-    url: https://github.com/purescript/purescript-enums.git
-    rev: bae47961d401f9acf88da38f32e87403e5f0cf2f
+    type: registry
+    version: 6.0.1
+    integrity: sha256-HWaD73JFLorc4A6trKIRUeDMdzE+GpkJaEOM1nTNkC8=
     dependencies:
       - control
       - either
@@ -3655,24 +666,24 @@ packages:
       - tuples
       - unfoldable
   exceptions:
-    type: git
-    url: https://github.com/purescript/purescript-exceptions.git
-    rev: afab3c07c820bb49b6c5be50049db46a964a6161
+    type: registry
+    version: 6.0.0
+    integrity: sha256-y/xTAEIZIARCE+50/u1di0ncebJ+CIwNOLswyOWzMTw=
     dependencies:
       - effect
       - either
       - maybe
       - prelude
   exists:
-    type: git
-    url: https://github.com/purescript/purescript-exists.git
-    rev: f765b4ace7869c27b9c05949e18c843881f9173b
+    type: registry
+    version: 6.0.0
+    integrity: sha256-A0JQHpTfo1dNOj9U5/Fd3xndlRSE0g2IQWOGor2yXn8=
     dependencies:
       - unsafe-coerce
   foldable-traversable:
-    type: git
-    url: https://github.com/purescript/purescript-foldable-traversable.git
-    rev: b3926f870532d287ea59e2d5cd3873b81ef2a93a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-fLeqRYM4jUrZD5H4WqcwUgzU7XfYkzO4zhgtNc3jcWM=
     dependencies:
       - bifunctors
       - const
@@ -3686,9 +697,9 @@ packages:
       - prelude
       - tuples
   free:
-    type: git
-    url: https://github.com/purescript/purescript-free.git
-    rev: e2d8fa8023a864363857834e11393483bced5e38
+    type: registry
+    version: 7.0.0
+    integrity: sha256-72auTIZAG6fhz4F94rxyDwgfnHwp+/89rujZpZWrV0w=
     dependencies:
       - catenable-lists
       - control
@@ -3705,15 +716,15 @@ packages:
       - tuples
       - unsafe-coerce
   functions:
-    type: git
-    url: https://github.com/purescript/purescript-functions.git
-    rev: f626f20580483977c5b27a01aac6471e28aff367
+    type: registry
+    version: 6.0.0
+    integrity: sha256-adMyJNEnhGde2unHHAP79gPtlNjNqzgLB8arEOn9hLI=
     dependencies:
       - prelude
   functors:
-    type: git
-    url: https://github.com/purescript/purescript-functors.git
-    rev: 022ffd7a2a7ec12080314f3d217b400674a247b4
+    type: registry
+    version: 5.0.0
+    integrity: sha256-zfPWWYisbD84MqwpJSZFlvM6v86McM68ob8p9s27ywU=
     dependencies:
       - bifunctors
       - const
@@ -3729,9 +740,9 @@ packages:
       - tuples
       - unsafe-coerce
   gen:
-    type: git
-    url: https://github.com/purescript/purescript-gen.git
-    rev: 9fbcc2a1261c32e30d79c5418edef4d96fe76931
+    type: registry
+    version: 4.0.0
+    integrity: sha256-f7yzAXWwr+xnaqEOcvyO3ezKdoes8+WXWdXIHDBCAPI=
     dependencies:
       - either
       - foldable-traversable
@@ -3744,48 +755,48 @@ packages:
       - tuples
       - unfoldable
   identity:
-    type: git
-    url: https://github.com/purescript/purescript-identity.git
-    rev: ef6768f8a52ab0bc943a85f5761ba07c257f639f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-4wY0XZbAksjY6UAg99WkuKyJlQlWAfTi2ssadH0wVMY=
     dependencies:
       - control
       - invariant
       - newtype
       - prelude
   integers:
-    type: git
-    url: https://github.com/purescript/purescript-integers.git
-    rev: 54d712b25c594833083d15dc9ff2418eb9c52822
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sf+sK26R1hzwl3NhXR7WAu9zCDjQnfoXwcyGoseX158=
     dependencies:
       - maybe
       - numbers
       - prelude
   invariant:
-    type: git
-    url: https://github.com/purescript/purescript-invariant.git
-    rev: 1d2a196d51e90623adb88496c2cfd759c6736894
+    type: registry
+    version: 6.0.0
+    integrity: sha256-RGWWyYrz0Hs1KjPDA+87Kia67ZFBhfJ5lMGOMCEFoLo=
     dependencies:
       - control
       - prelude
   js-timers:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-js-timers.git
-    rev: 7cb728b3e6dc29f355143617e6e9ac770ecd9273
+    type: registry
+    version: 6.1.0
+    integrity: sha256-znHWLSSOYw15P5DTcsAdal2lf7nGA2yayLdOZ2t5r7o=
     dependencies:
       - effect
   lazy:
-    type: git
-    url: https://github.com/purescript/purescript-lazy.git
-    rev: 48347841226b27af5205a1a8ec71e27a93ce86fd
+    type: registry
+    version: 6.0.0
+    integrity: sha256-lMsfFOnlqfe4KzRRiW8ot5ge6HtcU3Eyh2XkXcP5IgU=
     dependencies:
       - control
       - foldable-traversable
       - invariant
       - prelude
   lcg:
-    type: git
-    url: https://github.com/purescript/purescript-lcg.git
-    rev: 67c6c6483a563a59ae036d9dca0f1be2835326a5
+    type: registry
+    version: 4.0.0
+    integrity: sha256-h7ME5cthLfbgJOJdsZcSfFpwXsx4rf8YmhebU+3iSYg=
     dependencies:
       - effect
       - integers
@@ -3794,9 +805,9 @@ packages:
       - prelude
       - random
   lists:
-    type: git
-    url: https://github.com/purescript/purescript-lists.git
-    rev: b113451e5b41cad87d669a3165f955c71cd863e2
+    type: registry
+    version: 7.0.0
+    integrity: sha256-EKF15qYqucuXP2lT/xPxhqy58f0FFT6KHdIB/yBOayI=
     dependencies:
       - bifunctors
       - control
@@ -3811,25 +822,25 @@ packages:
       - tuples
       - unfoldable
   maybe:
-    type: git
-    url: https://github.com/purescript/purescript-maybe.git
-    rev: c6f98ac1088766287106c5d9c8e30e7648d36786
+    type: registry
+    version: 6.0.0
+    integrity: sha256-5cCIb0wPwbat2PRkQhUeZO0jcAmf8jCt2qE0wbC3v2Q=
     dependencies:
       - control
       - invariant
       - newtype
       - prelude
   newtype:
-    type: git
-    url: https://github.com/purescript/purescript-newtype.git
-    rev: 29d8e6dd77aec2c975c948364ec3faf26e14ee7b
+    type: registry
+    version: 5.0.0
+    integrity: sha256-gdrQu8oGe9eZE6L3wOI8ql/igOg+zEGB5ITh2g+uttw=
     dependencies:
       - prelude
       - safe-coerce
   nonempty:
-    type: git
-    url: https://github.com/purescript/purescript-nonempty.git
-    rev: 28150ecc7419238b187abd609a92a645273348bb
+    type: registry
+    version: 7.0.0
+    integrity: sha256-54ablJZUHGvvlTJzi3oXyPCuvY6zsrWJuH/dMJ/MFLs=
     dependencies:
       - control
       - foldable-traversable
@@ -3838,16 +849,16 @@ packages:
       - tuples
       - unfoldable
   numbers:
-    type: git
-    url: https://github.com/purescript/purescript-numbers.git
-    rev: 2a53528f18f9415334bae28e7bb3cf3be86342c2
+    type: registry
+    version: 9.0.0
+    integrity: sha256-fDKXExFxMRFgy+v+kbjVbGBIOOQkWGnmm0vtnE3zWRE=
     dependencies:
       - functions
       - maybe
   ordered-collections:
-    type: git
-    url: https://github.com/purescript/purescript-ordered-collections.git
-    rev: 9826b7632d0d0a691173bde308a634195f42a419
+    type: registry
+    version: 3.0.0
+    integrity: sha256-R9WddNBRPkY37gw8XkDCLX2vJ5eI9qdaWDdCp61r2+M=
     dependencies:
       - arrays
       - foldable-traversable
@@ -3861,16 +872,16 @@ packages:
       - tuples
       - unfoldable
   orders:
-    type: git
-    url: https://github.com/purescript/purescript-orders.git
-    rev: f86db621ec5eef1274145f8b1fd8ebbfe0ed4a2c
+    type: registry
+    version: 6.0.0
+    integrity: sha256-nBA0g3/ai0euH8q9pSbGqk53W2q6agm/dECZTHcoink=
     dependencies:
       - newtype
       - prelude
   parallel:
-    type: git
-    url: https://github.com/purescript/purescript-parallel.git
-    rev: 85290dca837771ac4870071008c933d315ef678f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-VJbkGD0rAKX+NUEeBJbYJ78bEKaZbgow+QwQEfPB6ko=
     dependencies:
       - control
       - effect
@@ -3884,19 +895,19 @@ packages:
       - refs
       - transformers
   partial:
-    type: git
-    url: https://github.com/purescript/purescript-partial.git
-    rev: 0fa0646f5ea1ec5f0c46dcbd770c705a6c9ad3ec
+    type: registry
+    version: 4.0.0
+    integrity: sha256-fwXerld6Xw1VkReh8yeQsdtLVrjfGiVuC5bA1Wyo/J4=
     dependencies: []
   prelude:
-    type: git
-    url: https://github.com/purescript/purescript-prelude.git
-    rev: 32787f4399c92459c41602131a5858559eb868c5
+    type: registry
+    version: 6.0.1
+    integrity: sha256-o8p6SLYmVPqzXZhQFd2hGAWEwBoXl1swxLG/scpJ0V0=
     dependencies: []
   profunctor:
-    type: git
-    url: https://github.com/purescript/purescript-profunctor.git
-    rev: 0a966a14e7b0c827d44657dc1710cdc712d2e034
+    type: registry
+    version: 6.0.0
+    integrity: sha256-99NzxFgTr4CGlCSRYG1kShL+JhYbihhHtbOk1/0R5zI=
     dependencies:
       - control
       - distributive
@@ -3907,9 +918,9 @@ packages:
       - prelude
       - tuples
   quickcheck:
-    type: git
-    url: https://github.com/purescript/purescript-quickcheck.git
-    rev: bf5029f97e6c0d7552d3a08d2ab793a19e2c5e3d
+    type: registry
+    version: 8.0.1
+    integrity: sha256-ZvpccKQCvgslTXZCNmpYW4bUsFzhZd/kQUr2WmxFTGY=
     dependencies:
       - arrays
       - console
@@ -3939,46 +950,46 @@ packages:
       - tuples
       - unfoldable
   random:
-    type: git
-    url: https://github.com/purescript/purescript-random.git
-    rev: 9540bc965a9596da02fefd9949418bb19c92533a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-CJ611a35MPCE7XQMp0rdC6MCn76znlhisiCRgboAG+Q=
     dependencies:
       - effect
       - integers
   record:
-    type: git
-    url: https://github.com/purescript/purescript-record.git
-    rev: c89cd1ada6b636692571fc374196b1c39c4c9f70
+    type: registry
+    version: 4.0.0
+    integrity: sha256-Za5U85bTRJEfGK5Sk4hM41oXy84YQI0I8TL3WUn1Qzg=
     dependencies:
       - functions
       - prelude
       - unsafe-coerce
   refs:
-    type: git
-    url: https://github.com/purescript/purescript-refs.git
-    rev: f8e6216da4cb9309fde1f20cd6f69ac3a3b7f9e8
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Vgwne7jIbD3ZMoLNNETLT8Litw6lIYo3MfYNdtYWj9s=
     dependencies:
       - effect
       - prelude
   safe-coerce:
-    type: git
-    url: https://github.com/purescript/purescript-safe-coerce.git
-    rev: 7fa799ae80a38b8d948efcb52608e58e198b3da7
+    type: registry
+    version: 2.0.0
+    integrity: sha256-a1ibQkiUcbODbLE/WAq7Ttbbh9ex+x33VCQ7GngKudU=
     dependencies:
       - unsafe-coerce
   st:
-    type: git
-    url: https://github.com/purescript/purescript-st.git
-    rev: 2cc7ae1c3318a303378c4a9f3fa0f10ee7cc3589
+    type: registry
+    version: 6.2.0
+    integrity: sha256-z9X0WsOUlPwNx9GlCC+YccCyz8MejC8Wb0C4+9fiBRY=
     dependencies:
       - partial
       - prelude
       - tailrec
       - unsafe-coerce
   strings:
-    type: git
-    url: https://github.com/purescript/purescript-strings.git
-    rev: 4bc6954448d056f8aa7a659695a6ad60ad4fdf19
+    type: registry
+    version: 6.0.1
+    integrity: sha256-WssD3DbX4OPzxSdjvRMX0yvc9+pS7n5gyPv5I2Trb7k=
     dependencies:
       - arrays
       - control
@@ -3997,9 +1008,9 @@ packages:
       - unfoldable
       - unsafe-coerce
   tailrec:
-    type: git
-    url: https://github.com/purescript/purescript-tailrec.git
-    rev: 5e2104aa734b31a17074cc805bf087d72b65afd1
+    type: registry
+    version: 6.1.0
+    integrity: sha256-Xx19ECVDRrDWpz9D2GxQHHV89vd61dnXxQm0IcYQHGk=
     dependencies:
       - bifunctors
       - effect
@@ -4010,9 +1021,9 @@ packages:
       - prelude
       - refs
   test-unit:
-    type: git
-    url: https://github.com/bodil/purescript-test-unit.git
-    rev: 3112d7ebe06d467238058a6384dc75ffd960d335
+    type: registry
+    version: 17.0.0
+    integrity: sha256-aITJ2KngFFjASmG0JjnjybaKWl9dn7Hf2B3Wk4engNs=
     dependencies:
       - aff
       - avar
@@ -4025,9 +1036,9 @@ packages:
       - quickcheck
       - strings
   transformers:
-    type: git
-    url: https://github.com/purescript/purescript-transformers.git
-    rev: be72ab52357d9a665cbf93d73ba1c07c4b0957ee
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Pzw40HjthX77tdPAYzjx43LK3X5Bb7ZspYAp27wksFA=
     dependencies:
       - control
       - distributive
@@ -4044,22 +1055,22 @@ packages:
       - tuples
       - unfoldable
   tuples:
-    type: git
-    url: https://github.com/purescript/purescript-tuples.git
-    rev: 4f52da2729b448c8564369378f1232d8d2dc1d8b
+    type: registry
+    version: 7.0.0
+    integrity: sha256-1rXgTomes9105BjgXqIw0FL6Fz1lqqUTLWOumhWec1M=
     dependencies:
       - control
       - invariant
       - prelude
   type-equality:
-    type: git
-    url: https://github.com/purescript/purescript-type-equality.git
-    rev: 0525b7d39e0fbd81b4209518139fb8ab02695774
+    type: registry
+    version: 4.0.1
+    integrity: sha256-Hs9D6Y71zFi/b+qu5NSbuadUQXe5iv5iWx0226vOHUw=
     dependencies: []
   unfoldable:
-    type: git
-    url: https://github.com/purescript/purescript-unfoldable.git
-    rev: 493dfe04ed590e20d8f69079df2f58486882748d
+    type: registry
+    version: 6.0.0
+    integrity: sha256-JtikvJdktRap7vr/K4ITlxUX1QexpnqBq0G/InLr6eg=
     dependencies:
       - foldable-traversable
       - maybe
@@ -4067,7 +1078,7 @@ packages:
       - prelude
       - tuples
   unsafe-coerce:
-    type: git
-    url: https://github.com/purescript/purescript-unsafe-coerce.git
-    rev: ab956f82e66e633f647fb3098e8ddd3ec58d689f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-IqIYW4Vkevn8sI+6aUwRGvd87tVL36BBeOr0cGAE7t0=
     dependencies: []

--- a/exercises/chapter4/spago.yaml
+++ b/exercises/chapter4/spago.yaml
@@ -1,0 +1,17 @@
+package:
+  dependencies:
+    - arrays
+    - console
+    - effect
+    - foldable-traversable
+    - integers
+    - maybe
+    - numbers
+    - partial
+    - prelude
+    - test-unit
+  name: my-project
+workspace:
+  extraPackages: {}
+  packageSet:
+    url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json

--- a/exercises/chapter4/spago.yaml
+++ b/exercises/chapter4/spago.yaml
@@ -14,4 +14,4 @@ package:
 workspace:
   extraPackages: {}
   packageSet:
-    url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
+    registry: 10.0.0

--- a/exercises/chapter5/spago.lock
+++ b/exercises/chapter5/spago.lock
@@ -1,0 +1,4074 @@
+workspace:
+  packages:
+    my-project:
+      path: ./
+      dependencies:
+        - arrays
+        - console
+        - control
+        - effect
+        - foldable-traversable
+        - integers
+        - maybe
+        - prelude
+        - strings
+        - test-unit
+        - tuples
+      test_dependencies: []
+      build_plan:
+        - aff
+        - arrays
+        - avar
+        - bifunctors
+        - catenable-lists
+        - console
+        - const
+        - contravariant
+        - control
+        - datetime
+        - distributive
+        - effect
+        - either
+        - enums
+        - exceptions
+        - exists
+        - foldable-traversable
+        - free
+        - functions
+        - functors
+        - gen
+        - identity
+        - integers
+        - invariant
+        - js-timers
+        - lazy
+        - lcg
+        - lists
+        - maybe
+        - newtype
+        - nonempty
+        - numbers
+        - ordered-collections
+        - orders
+        - parallel
+        - partial
+        - prelude
+        - profunctor
+        - quickcheck
+        - random
+        - record
+        - refs
+        - safe-coerce
+        - st
+        - strings
+        - tailrec
+        - test-unit
+        - transformers
+        - tuples
+        - type-equality
+        - unfoldable
+        - unsafe-coerce
+  package_set:
+    address:
+      url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
+    compiler: ">=0.15.0 <0.16.0"
+    content:
+      ace:
+        repo: https://github.com/purescript-contrib/purescript-ace.git
+        version: v9.0.0
+        dependencies:
+          - arrays
+          - effect
+          - foreign
+          - nullable
+          - prelude
+          - web-html
+          - web-uievents
+      aff:
+        repo: https://github.com/purescript-contrib/purescript-aff.git
+        version: v7.0.0
+        dependencies:
+          - datetime
+          - effect
+          - exceptions
+          - functions
+          - parallel
+          - transformers
+          - unsafe-coerce
+      aff-bus:
+        repo: https://github.com/purescript-contrib/purescript-aff-bus.git
+        version: v6.0.0
+        dependencies:
+          - aff
+          - avar
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - lists
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+      aff-coroutines:
+        repo: https://github.com/purescript-contrib/purescript-aff-coroutines.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - avar
+          - coroutines
+          - effect
+      aff-promise:
+        repo: https://github.com/nwolverson/purescript-aff-promise.git
+        version: v4.0.0
+        dependencies:
+          - aff
+          - foreign
+      aff-retry:
+        repo: https://github.com/Unisay/purescript-aff-retry.git
+        version: v2.0.0
+        dependencies:
+          - aff
+          - arrays
+          - datetime
+          - effect
+          - either
+          - exceptions
+          - integers
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - random
+          - transformers
+      affjax:
+        repo: https://github.com/purescript-contrib/purescript-affjax.git
+        version: v13.0.0
+        dependencies:
+          - aff
+          - argonaut-core
+          - arraybuffer-types
+          - foreign
+          - form-urlencoded
+          - http-methods
+          - integers
+          - media-types
+          - nullable
+          - refs
+          - unsafe-coerce
+          - web-xhr
+      affjax-node:
+        repo: https://github.com/purescript-contrib/purescript-affjax-node.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - affjax
+          - either
+          - maybe
+          - prelude
+      affjax-web:
+        repo: https://github.com/purescript-contrib/purescript-affjax-web.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - affjax
+          - either
+          - maybe
+          - prelude
+      ansi:
+        repo: https://github.com/hdgarrood/purescript-ansi.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - lists
+          - strings
+      argonaut:
+        repo: https://github.com/purescript-contrib/purescript-argonaut.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - argonaut-traversals
+      argonaut-codecs:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-codecs.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-core
+          - arrays
+          - effect
+          - foreign-object
+          - identity
+          - integers
+          - maybe
+          - nonempty
+          - ordered-collections
+          - prelude
+          - record
+      argonaut-core:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-core.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - foreign-object
+          - functions
+          - gen
+          - maybe
+          - nonempty
+          - prelude
+          - strings
+          - tailrec
+      argonaut-generic:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-generic.git
+        version: v8.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - prelude
+          - record
+      argonaut-traversals:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-traversals.git
+        version: v10.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - profunctor-lenses
+      argparse-basic:
+        repo: https://github.com/natefaubion/purescript-argparse-basic.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - record
+          - strings
+          - tuples
+          - unfoldable
+      arraybuffer:
+        repo: https://github.com/purescript-contrib/purescript-arraybuffer.git
+        version: v13.0.0
+        dependencies:
+          - arraybuffer-types
+          - arrays
+          - effect
+          - float32
+          - functions
+          - gen
+          - maybe
+          - nullable
+          - prelude
+          - tailrec
+          - uint
+          - unfoldable
+      arraybuffer-builder:
+        repo: https://github.com/jamesdbrock/purescript-arraybuffer-builder.git
+        version: v3.0.1
+        dependencies:
+          - arraybuffer
+          - arraybuffer-types
+          - effect
+          - float32
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - transformers
+          - uint
+      arraybuffer-types:
+        repo: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
+        version: v3.0.2
+        dependencies: []
+      arrays:
+        repo: https://github.com/purescript/purescript-arrays.git
+        version: v7.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - foldable-traversable
+          - maybe
+          - nonempty
+          - partial
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - unfoldable
+          - unsafe-coerce
+      arrays-zipper:
+        repo: https://github.com/JordanMartinez/purescript-arrays-zipper.git
+        version: v2.0.1
+        dependencies:
+          - arrays
+          - control
+          - quickcheck
+      ask:
+        repo: https://github.com/Mateiadrielrafael/purescript-ask.git
+        version: v1.0.0
+        dependencies:
+          - unsafe-coerce
+      assert:
+        repo: https://github.com/purescript/purescript-assert.git
+        version: v6.0.0
+        dependencies:
+          - console
+          - effect
+          - prelude
+      avar:
+        repo: https://github.com/purescript-contrib/purescript-avar.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - exceptions
+          - functions
+          - maybe
+      b64:
+        repo: https://github.com/menelaos/purescript-b64.git
+        version: v0.0.8
+        dependencies:
+          - arraybuffer-types
+          - either
+          - encoding
+          - enums
+          - exceptions
+          - functions
+          - partial
+          - prelude
+          - strings
+      barlow-lens:
+        repo: https://github.com/sigma-andex/purescript-barlow-lens.git
+        version: v0.9.0
+        dependencies:
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - profunctor-lenses
+          - tuples
+          - typelevel-prelude
+      bifunctors:
+        repo: https://github.com/purescript/purescript-bifunctors.git
+        version: v6.0.0
+        dependencies:
+          - const
+          - either
+          - newtype
+          - prelude
+          - tuples
+      bigints:
+        repo: https://github.com/sharkdp/purescript-bigints.git
+        version: v7.0.1
+        dependencies:
+          - integers
+          - maybe
+          - strings
+      bower-json:
+        repo: https://github.com/klntsky/purescript-bower-json.git
+        version: v3.0.0
+        dependencies:
+          - argonaut-codecs
+          - arrays
+          - either
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - newtype
+          - prelude
+          - tuples
+      call-by-name:
+        repo: https://github.com/natefaubion/purescript-call-by-name.git
+        version: v4.0.1
+        dependencies:
+          - control
+          - either
+          - lazy
+          - maybe
+          - unsafe-coerce
+      canvas:
+        repo: https://github.com/purescript-web/purescript-canvas.git
+        version: v6.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - exceptions
+          - functions
+          - maybe
+      canvas-action:
+        repo: https://github.com/artemisSystem/purescript-canvas-action.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - arrays
+          - canvas
+          - colors
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - maybe
+          - numbers
+          - polymorphic-vectors
+          - prelude
+          - refs
+          - run
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-html
+      cartesian:
+        repo: https://github.com/Ebmtranceboy/purescript-cartesian.git
+        version: v1.0.6
+        dependencies:
+          - console
+          - effect
+          - integers
+          - psci-support
+      catenable-lists:
+        repo: https://github.com/purescript/purescript-catenable-lists.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - lists
+          - maybe
+          - prelude
+          - tuples
+          - unfoldable
+      channel:
+        repo: https://github.com/ConnorDillon/purescript-channel.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - assert
+          - avar
+          - console
+          - contravariant
+          - control
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - lazy
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      checked-exceptions:
+        repo: https://github.com/natefaubion/purescript-checked-exceptions.git
+        version: v3.1.1
+        dependencies:
+          - prelude
+          - transformers
+          - variant
+      codec:
+        repo: https://github.com/garyb/purescript-codec.git
+        version: v5.0.0
+        dependencies:
+          - profunctor
+          - transformers
+      codec-argonaut:
+        repo: https://github.com/garyb/purescript-codec-argonaut.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-core
+          - codec
+          - ordered-collections
+          - type-equality
+          - variant
+      colors:
+        repo: https://github.com/purescript-contrib/purescript-colors.git
+        version: v7.0.1
+        dependencies:
+          - arrays
+          - integers
+          - lists
+          - numbers
+          - partial
+          - strings
+      concurrent-queues:
+        repo: https://github.com/purescript-contrib/purescript-concurrent-queues.git
+        version: v3.0.0
+        dependencies:
+          - aff
+          - avar
+          - effect
+      console:
+        repo: https://github.com/purescript/purescript-console.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - prelude
+      const:
+        repo: https://github.com/purescript/purescript-const.git
+        version: v6.0.0
+        dependencies:
+          - invariant
+          - newtype
+          - prelude
+      contravariant:
+        repo: https://github.com/purescript/purescript-contravariant.git
+        version: v6.0.0
+        dependencies:
+          - const
+          - either
+          - newtype
+          - prelude
+          - tuples
+      control:
+        repo: https://github.com/purescript/purescript-control.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      convertable-options:
+        repo: https://github.com/natefaubion/purescript-convertable-options.git
+        version: v1.0.0
+        dependencies:
+          - console
+          - effect
+          - maybe
+          - record
+      coroutines:
+        repo: https://github.com/purescript-contrib/purescript-coroutines.git
+        version: v7.0.0
+        dependencies:
+          - freet
+          - parallel
+          - profunctor
+      css:
+        repo: https://github.com/purescript-contrib/purescript-css.git
+        version: v6.0.0
+        dependencies:
+          - colors
+          - console
+          - effect
+          - nonempty
+          - profunctor
+          - strings
+          - these
+          - transformers
+      datetime:
+        repo: https://github.com/purescript/purescript-datetime.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - either
+          - enums
+          - foldable-traversable
+          - functions
+          - gen
+          - integers
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - ordered-collections
+          - partial
+          - prelude
+          - tuples
+      datetime-parsing:
+        repo: https://github.com/flounders/purescript-datetime-parsing.git
+        version: v0.2.0
+        dependencies:
+          - arrays
+          - datetime
+          - either
+          - enums
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - numbers
+          - parsing
+          - prelude
+          - strings
+          - unicode
+      debug:
+        repo: https://github.com/garyb/purescript-debug.git
+        version: v6.0.0
+        dependencies:
+          - functions
+          - prelude
+      decimals:
+        repo: https://github.com/sharkdp/purescript-decimals.git
+        version: v7.0.0
+        dependencies:
+          - maybe
+      dissect:
+        repo: https://github.com/PureFunctor/purescript-dissect.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - foreign-object
+          - functors
+          - newtype
+          - partial
+          - prelude
+          - tailrec
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - variant
+      distributive:
+        repo: https://github.com/purescript/purescript-distributive.git
+        version: v6.0.0
+        dependencies:
+          - identity
+          - newtype
+          - prelude
+          - tuples
+          - type-equality
+      dodo-printer:
+        repo: https://github.com/natefaubion/purescript-dodo-printer.git
+        version: v2.2.0
+        dependencies:
+          - aff
+          - ansi
+          - avar
+          - console
+          - effect
+          - foldable-traversable
+          - lists
+          - maybe
+          - minibench
+          - node-child-process
+          - node-fs-aff
+          - node-process
+          - psci-support
+          - strings
+      dom-indexed:
+        repo: https://github.com/purescript-halogen/purescript-dom-indexed.git
+        version: v11.0.0
+        dependencies:
+          - media-types
+          - prelude
+          - web-clipboard
+          - web-pointerevents
+          - web-touchevents
+      droplet:
+        repo: https://github.com/easafe/purescript-droplet.git
+        version: v0.4.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - bigints
+          - datetime
+          - debug
+          - effect
+          - either
+          - enums
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - integers
+          - maybe
+          - newtype
+          - nullable
+          - ordered-collections
+          - partial
+          - prelude
+          - profunctor
+          - record
+          - spec
+          - strings
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+      dynamic-buffer:
+        repo: https://github.com/kritzcreek/purescript-dynamic-buffer.git
+        version: v3.0.1
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - refs
+      effect:
+        repo: https://github.com/purescript/purescript-effect.git
+        version: v4.0.0
+        dependencies:
+          - prelude
+      either:
+        repo: https://github.com/purescript/purescript-either.git
+        version: v6.1.0
+        dependencies:
+          - control
+          - invariant
+          - maybe
+          - prelude
+      elmish:
+        repo: https://github.com/collegevine/purescript-elmish.git
+        version: v0.8.1
+        dependencies:
+          - aff
+          - argonaut-core
+          - arrays
+          - bifunctors
+          - console
+          - debug
+          - effect
+          - either
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - functions
+          - integers
+          - js-date
+          - maybe
+          - nullable
+          - partial
+          - prelude
+          - refs
+          - typelevel-prelude
+          - undefined-is-not-a-problem
+          - unsafe-coerce
+          - web-dom
+          - web-html
+      elmish-enzyme:
+        repo: https://github.com/collegevine/purescript-elmish-enzyme.git
+        version: v0.1.1
+        dependencies:
+          - aff
+          - aff-promise
+          - arrays
+          - console
+          - debug
+          - effect
+          - elmish
+          - foldable-traversable
+          - foreign
+          - functions
+          - prelude
+          - transformers
+          - unsafe-coerce
+      elmish-hooks:
+        repo: https://github.com/collegevine/purescript-elmish-hooks.git
+        version: v0.8.2
+        dependencies:
+          - aff
+          - debug
+          - elmish
+          - maybe
+          - prelude
+          - tuples
+          - undefined-is-not-a-problem
+      elmish-html:
+        repo: https://github.com/collegevine/purescript-elmish-html.git
+        version: v0.7.1
+        dependencies:
+          - effect
+          - elmish
+          - foreign
+          - foreign-object
+          - prelude
+          - record
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-html
+      email-validate:
+        repo: https://github.com/cdepillabout/purescript-email-validate.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - string-parsers
+          - transformers
+      encoding:
+        repo: https://github.com/menelaos/purescript-encoding.git
+        version: v0.0.8
+        dependencies:
+          - arraybuffer-types
+          - either
+          - exceptions
+          - functions
+          - prelude
+      enums:
+        repo: https://github.com/purescript/purescript-enums.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - either
+          - gen
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tuples
+          - unfoldable
+      exceptions:
+        repo: https://github.com/purescript/purescript-exceptions.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - either
+          - maybe
+          - prelude
+      exists:
+        repo: https://github.com/purescript/purescript-exists.git
+        version: v6.0.0
+        dependencies:
+          - unsafe-coerce
+      exitcodes:
+        repo: https://github.com/Risto-Stevcev/purescript-exitcodes.git
+        version: v4.0.0
+        dependencies:
+          - enums
+      expect-inferred:
+        repo: https://github.com/justinwoo/purescript-expect-inferred.git
+        version: v3.0.0
+        dependencies:
+          - prelude
+          - typelevel-prelude
+      fast-vect:
+        repo: https://github.com/sigma-andex/purescript-fast-vect.git
+        version: v0.7.0
+        dependencies:
+          - arrays
+          - filterable
+          - foldable-traversable
+          - lists
+          - maybe
+          - ordered-collections
+          - prelude
+          - profunctor
+          - tuples
+          - unfoldable
+      filterable:
+        repo: https://github.com/purescript/purescript-filterable.git
+        version: v5.0.0
+        dependencies:
+          - arrays
+          - either
+          - foldable-traversable
+          - identity
+          - lists
+          - ordered-collections
+      fixed-points:
+        repo: https://github.com/purescript-contrib/purescript-fixed-points.git
+        version: v7.0.0
+        dependencies:
+          - exists
+          - newtype
+          - prelude
+          - transformers
+      fixed-precision:
+        repo: https://github.com/lumihq/purescript-fixed-precision.git
+        version: v5.0.0
+        dependencies:
+          - arrays
+          - bigints
+          - control
+          - integers
+          - maybe
+          - numbers
+          - partial
+          - prelude
+          - strings
+      flame:
+        repo: https://github.com/easafe/purescript-flame.git
+        version: v1.2.0
+        dependencies:
+          - aff
+          - argonaut-codecs
+          - argonaut-core
+          - argonaut-generic
+          - arrays
+          - bifunctors
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - maybe
+          - newtype
+          - nullable
+          - partial
+          - prelude
+          - random
+          - refs
+          - spec
+          - strings
+          - tuples
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-html
+          - web-uievents
+      float32:
+        repo: https://github.com/purescript-contrib/purescript-float32.git
+        version: v2.0.0
+        dependencies:
+          - gen
+          - maybe
+          - prelude
+      foldable-traversable:
+        repo: https://github.com/purescript/purescript-foldable-traversable.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - const
+          - control
+          - either
+          - functors
+          - identity
+          - maybe
+          - newtype
+          - orders
+          - prelude
+          - tuples
+      foreign:
+        repo: https://github.com/purescript/purescript-foreign.git
+        version: v7.0.0
+        dependencies:
+          - either
+          - functions
+          - identity
+          - integers
+          - lists
+          - maybe
+          - prelude
+          - strings
+          - transformers
+      foreign-object:
+        repo: https://github.com/purescript/purescript-foreign-object.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - functions
+          - gen
+          - lists
+          - maybe
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - typelevel-prelude
+          - unfoldable
+      foreign-readwrite:
+        repo: https://github.com/artemisSystem/purescript-foreign-readwrite.git
+        version: v3.0.0
+        dependencies:
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - record
+          - safe-coerce
+          - transformers
+          - unsafe-coerce
+      fork:
+        repo: https://github.com/purescript-contrib/purescript-fork.git
+        version: v6.0.0
+        dependencies:
+          - aff
+      form-urlencoded:
+        repo: https://github.com/purescript-contrib/purescript-form-urlencoded.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - js-uri
+          - maybe
+          - newtype
+          - prelude
+          - strings
+          - tuples
+      formatters:
+        repo: https://github.com/purescript-contrib/purescript-formatters.git
+        version: v7.0.0
+        dependencies:
+          - datetime
+          - fixed-points
+          - lists
+          - numbers
+          - parsing
+          - prelude
+          - transformers
+      free:
+        repo: https://github.com/purescript/purescript-free.git
+        version: v7.0.0
+        dependencies:
+          - catenable-lists
+          - control
+          - distributive
+          - either
+          - exists
+          - foldable-traversable
+          - invariant
+          - lazy
+          - maybe
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+      freeap:
+        repo: https://github.com/ethul/purescript-freeap.git
+        version: v7.0.0
+        dependencies:
+          - const
+          - exists
+          - gen
+          - lists
+      freet:
+        repo: https://github.com/purescript-contrib/purescript-freet.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - bifunctors
+          - effect
+          - either
+          - exists
+          - free
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      functions:
+        repo: https://github.com/purescript/purescript-functions.git
+        version: v6.0.0
+        dependencies:
+          - prelude
+      functors:
+        repo: https://github.com/purescript/purescript-functors.git
+        version: v5.0.0
+        dependencies:
+          - bifunctors
+          - const
+          - contravariant
+          - control
+          - distributive
+          - either
+          - invariant
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - tuples
+          - unsafe-coerce
+      fuzzy:
+        repo: https://github.com/citizennet/purescript-fuzzy.git
+        version: v0.4.0
+        dependencies:
+          - foldable-traversable
+          - foreign-object
+          - newtype
+          - ordered-collections
+          - prelude
+          - rationals
+          - strings
+          - tuples
+      gen:
+        repo: https://github.com/purescript/purescript-gen.git
+        version: v4.0.0
+        dependencies:
+          - either
+          - foldable-traversable
+          - identity
+          - maybe
+          - newtype
+          - nonempty
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      generate-values:
+        repo: https://github.com/jordanmartinez/purescript-generate-values.git
+        version: v1.0.1
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - enums
+          - foldable-traversable
+          - gen
+          - identity
+          - integers
+          - lcg
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - partial
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      geometry-plane:
+        repo: https://github.com/Ebmtranceboy/purescript-geometry-plane.git
+        version: v1.0.3
+        dependencies:
+          - console
+          - effect
+          - psci-support
+          - sparse-polynomials
+      github-actions-toolkit:
+        repo: https://github.com/purescript-contrib/purescript-github-actions-toolkit.git
+        version: v0.5.0
+        dependencies:
+          - aff
+          - aff-promise
+          - effect
+          - foreign-object
+          - node-buffer
+          - node-path
+          - node-streams
+          - nullable
+          - transformers
+      graphs:
+        repo: https://github.com/purescript/purescript-graphs.git
+        version: v8.0.0
+        dependencies:
+          - catenable-lists
+          - ordered-collections
+      group:
+        repo: https://github.com/morganthomas/purescript-group.git
+        version: v4.1.1
+        dependencies:
+          - lists
+      halogen:
+        repo: https://github.com/purescript-halogen/purescript-halogen.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - avar
+          - console
+          - const
+          - dom-indexed
+          - effect
+          - foreign
+          - fork
+          - free
+          - freeap
+          - halogen-subscriptions
+          - halogen-vdom
+          - media-types
+          - nullable
+          - ordered-collections
+          - parallel
+          - profunctor
+          - transformers
+          - unsafe-coerce
+          - unsafe-reference
+          - web-file
+          - web-uievents
+      halogen-css:
+        repo: https://github.com/purescript-halogen/purescript-halogen-css.git
+        version: v10.0.0
+        dependencies:
+          - css
+          - halogen
+      halogen-formless:
+        repo: https://github.com/thomashoneyman/purescript-halogen-formless.git
+        version: v4.0.0
+        dependencies:
+          - convertable-options
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - halogen
+          - heterogeneous
+          - maybe
+          - prelude
+          - record
+          - safe-coerce
+          - type-equality
+          - unsafe-coerce
+          - unsafe-reference
+          - variant
+          - web-events
+          - web-uievents
+      halogen-hooks:
+        repo: https://github.com/thomashoneyman/purescript-halogen-hooks.git
+        version: v0.6.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - effect
+          - exceptions
+          - foldable-traversable
+          - foreign-object
+          - free
+          - freeap
+          - halogen
+          - halogen-subscriptions
+          - maybe
+          - newtype
+          - ordered-collections
+          - parallel
+          - partial
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+          - unsafe-reference
+          - web-dom
+          - web-html
+      halogen-hooks-extra:
+        repo: https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git
+        version: v0.9.0
+        dependencies:
+          - halogen-hooks
+      halogen-store:
+        repo: https://github.com/thomashoneyman/purescript-halogen-store.git
+        version: v0.5.0
+        dependencies:
+          - aff
+          - distributive
+          - effect
+          - fork
+          - halogen
+          - halogen-hooks
+          - halogen-subscriptions
+          - maybe
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-reference
+      halogen-storybook:
+        repo: https://github.com/rnons/purescript-halogen-storybook.git
+        version: v2.0.0
+        dependencies:
+          - foreign-object
+          - halogen
+          - prelude
+          - routing
+      halogen-subscriptions:
+        repo: https://github.com/purescript-halogen/purescript-halogen-subscriptions.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - effect
+          - foldable-traversable
+          - functors
+          - refs
+          - safe-coerce
+          - unsafe-reference
+      halogen-svg-elems:
+        repo: https://github.com/JordanMartinez/purescript-halogen-svg-elems.git
+        version: v6.0.0
+        dependencies:
+          - halogen
+      halogen-vdom:
+        repo: https://github.com/purescript-halogen/purescript-halogen-vdom.git
+        version: v8.0.0
+        dependencies:
+          - bifunctors
+          - effect
+          - foreign
+          - foreign-object
+          - maybe
+          - prelude
+          - refs
+          - tuples
+          - unsafe-coerce
+          - web-html
+      halogen-vdom-string-renderer:
+        repo: https://github.com/purescript-halogen/purescript-halogen-vdom-string-renderer.git
+        version: v0.5.0
+        dependencies:
+          - foreign
+          - halogen-vdom
+          - ordered-collections
+          - prelude
+      heckin:
+        repo: https://github.com/maxdeviant/purescript-heckin.git
+        version: v2.0.1
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - maybe
+          - prelude
+          - strings
+          - transformers
+          - tuples
+          - unicode
+      heterogeneous:
+        repo: https://github.com/natefaubion/purescript-heterogeneous.git
+        version: v0.6.0
+        dependencies:
+          - either
+          - functors
+          - prelude
+          - record
+          - tuples
+          - variant
+      heterogeneous-extrablatt:
+        repo: https://github.com/sigma-andex/purescript-heterogeneous-extrablatt.git
+        version: v0.2.1
+        dependencies:
+          - heterogeneous
+          - prelude
+          - record
+      http-methods:
+        repo: https://github.com/purescript-contrib/purescript-http-methods.git
+        version: v6.0.0
+        dependencies:
+          - either
+          - prelude
+          - strings
+      httpure:
+        repo: https://github.com/citizennet/purescript-httpure.git
+        version: v0.15.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - js-uri
+          - maybe
+          - newtype
+          - node-buffer
+          - node-fs
+          - node-http
+          - node-streams
+          - options
+          - ordered-collections
+          - prelude
+          - refs
+          - strings
+          - tuples
+          - type-equality
+      httpurple:
+        repo: https://github.com/sigma-andex/purescript-httpurple.git
+        version: v1.3.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - js-uri
+          - justifill
+          - maybe
+          - newtype
+          - node-buffer
+          - node-fs
+          - node-http
+          - node-net
+          - node-process
+          - node-streams
+          - options
+          - ordered-collections
+          - posix-types
+          - prelude
+          - profunctor
+          - record
+          - refs
+          - routing-duplex
+          - strings
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+      httpurple-argonaut:
+        repo: https://github.com/sigma-andex/purescript-httpurple-argonaut.git
+        version: v1.0.1
+        dependencies:
+          - argonaut
+          - console
+          - effect
+          - either
+          - httpurple
+          - prelude
+      httpurple-yoga-json:
+        repo: https://github.com/sigma-andex/purescript-httpurple-yoga-json.git
+        version: v1.0.0
+        dependencies:
+          - console
+          - effect
+          - either
+          - foreign
+          - httpurple
+          - lists
+          - prelude
+          - yoga-json
+      identity:
+        repo: https://github.com/purescript/purescript-identity.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - invariant
+          - newtype
+          - prelude
+      indexed-monad:
+        repo: https://github.com/garyb/purescript-indexed-monad.git
+        version: v2.1.0
+        dependencies:
+          - control
+          - newtype
+      int64:
+        repo: https://github.com/purescript-contrib/purescript-int64.git
+        version: v2.0.0
+        dependencies:
+          - effect
+          - foreign
+          - functions
+          - integers
+          - maybe
+          - nullable
+          - prelude
+          - quickcheck
+      integers:
+        repo: https://github.com/purescript/purescript-integers.git
+        version: v6.0.0
+        dependencies:
+          - maybe
+          - numbers
+          - prelude
+      interpolate:
+        repo: https://github.com/jordanmartinez/purescript-interpolate.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+      invariant:
+        repo: https://github.com/purescript/purescript-invariant.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - prelude
+      js-date:
+        repo: https://github.com/purescript-contrib/purescript-js-date.git
+        version: v8.0.0
+        dependencies:
+          - datetime
+          - effect
+          - exceptions
+          - foreign
+          - integers
+          - now
+      js-fileio:
+        repo: https://github.com/newlandsvalley/purescript-js-fileio.git
+        version: v3.0.0
+        dependencies:
+          - aff
+          - effect
+          - prelude
+      js-timers:
+        repo: https://github.com/purescript-contrib/purescript-js-timers.git
+        version: v6.1.0
+        dependencies:
+          - effect
+      js-uri:
+        repo: https://github.com/purescript-contrib/purescript-js-uri.git
+        version: v3.0.0
+        dependencies:
+          - functions
+          - maybe
+      justifill:
+        repo: https://github.com/i-am-the-slime/purescript-justifill.git
+        version: v0.5.0
+        dependencies:
+          - maybe
+          - prelude
+          - record
+          - typelevel-prelude
+      jwt:
+        repo: https://github.com/menelaos/purescript-jwt.git
+        version: v0.0.9
+        dependencies:
+          - argonaut-core
+          - arrays
+          - b64
+          - either
+          - exceptions
+          - prelude
+          - profunctor-lenses
+          - strings
+      language-cst-parser:
+        repo: https://github.com/natefaubion/purescript-language-cst-parser.git
+        version: v0.12.0
+        dependencies:
+          - arrays
+          - const
+          - control
+          - either
+          - foldable-traversable
+          - free
+          - functions
+          - functors
+          - identity
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - ordered-collections
+          - partial
+          - prelude
+          - st
+          - strings
+          - transformers
+          - tuples
+          - typelevel-prelude
+          - unfoldable
+          - unsafe-coerce
+      lazy:
+        repo: https://github.com/purescript/purescript-lazy.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - invariant
+          - prelude
+      lcg:
+        repo: https://github.com/purescript/purescript-lcg.git
+        version: v4.0.0
+        dependencies:
+          - effect
+          - integers
+          - maybe
+          - partial
+          - prelude
+          - random
+      leibniz:
+        repo: https://github.com/paf31/purescript-leibniz.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+          - unsafe-coerce
+      linalg:
+        repo: https://github.com/gbagan/purescript-linalg.git
+        version: v5.1.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - functions
+          - maybe
+          - prelude
+          - tuples
+      lists:
+        repo: https://github.com/purescript/purescript-lists.git
+        version: v7.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - foldable-traversable
+          - lazy
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      logging:
+        repo: https://github.com/rightfold/purescript-logging.git
+        version: v3.0.0
+        dependencies:
+          - console
+          - contravariant
+          - effect
+          - either
+          - prelude
+          - transformers
+          - tuples
+      machines:
+        repo: https://github.com/purescript-contrib/purescript-machines.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - lists
+          - maybe
+          - prelude
+          - profunctor
+          - tuples
+          - unfoldable
+      matrices:
+        repo: https://github.com/kRITZCREEK/purescript-matrices.git
+        version: v5.0.1
+        dependencies:
+          - arrays
+          - strings
+      matryoshka:
+        repo: https://github.com/purescript-contrib/purescript-matryoshka.git
+        version: v1.0.0
+        dependencies:
+          - fixed-points
+          - free
+          - prelude
+          - profunctor
+          - transformers
+      maybe:
+        repo: https://github.com/purescript/purescript-maybe.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - invariant
+          - newtype
+          - prelude
+      media-types:
+        repo: https://github.com/purescript-contrib/purescript-media-types.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      metadata:
+        repo: https://github.com/purescript/purescript-metadata.git
+        version: v0.15.0
+        dependencies: []
+      midi:
+        repo: https://github.com/newlandsvalley/purescript-midi.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - ordered-collections
+          - prelude
+          - signal
+          - string-parsers
+          - strings
+          - tuples
+          - unfoldable
+      minibench:
+        repo: https://github.com/purescript/purescript-minibench.git
+        version: v4.0.0
+        dependencies:
+          - console
+          - effect
+          - integers
+          - numbers
+          - partial
+          - prelude
+          - refs
+      mmorph:
+        repo: https://github.com/Thimoteus/purescript-mmorph.git
+        version: v7.0.0
+        dependencies:
+          - free
+          - functors
+          - transformers
+      monad-control:
+        repo: https://github.com/athanclark/purescript-monad-control.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - freet
+          - identity
+          - lists
+      monad-logger:
+        repo: https://github.com/cprussin/purescript-monad-logger.git
+        version: v1.3.1
+        dependencies:
+          - aff
+          - ansi
+          - argonaut
+          - arrays
+          - console
+          - control
+          - effect
+          - foldable-traversable
+          - foreign-object
+          - integers
+          - js-date
+          - maybe
+          - newtype
+          - ordered-collections
+          - prelude
+          - strings
+          - transformers
+          - tuples
+      monad-loops:
+        repo: https://github.com/mlang/purescript-monad-loops.git
+        version: v0.5.0
+        dependencies:
+          - lists
+          - maybe
+          - prelude
+          - tailrec
+          - tuples
+      monad-unlift:
+        repo: https://github.com/athanclark/purescript-monad-unlift.git
+        version: v1.0.1
+        dependencies:
+          - monad-control
+      monoidal:
+        repo: https://github.com/mcneissue/purescript-monoidal.git
+        version: v0.16.0
+        dependencies:
+          - either
+          - profunctor
+          - these
+          - tuples
+      morello:
+        repo: https://github.com/sigma-andex/purescript-morello.git
+        version: v0.3.2
+        dependencies:
+          - arrays
+          - barlow-lens
+          - foldable-traversable
+          - heterogeneous
+          - heterogeneous-extrablatt
+          - newtype
+          - prelude
+          - profunctor
+          - profunctor-lenses
+          - record
+          - tuples
+          - typelevel-prelude
+          - validation
+      motsunabe:
+        repo: https://github.com/justinwoo/purescript-motsunabe.git
+        version: v2.0.0
+        dependencies:
+          - lists
+          - strings
+      nano-id:
+        repo: https://github.com/eikooc/nano-id.git
+        version: v1.1.0
+        dependencies:
+          - aff
+          - effect
+          - lists
+          - maybe
+          - prelude
+          - random
+          - spec
+          - strings
+          - stringutils
+      naturals:
+        repo: https://github.com/LiamGoodacre/purescript-naturals.git
+        version: v3.0.0
+        dependencies:
+          - enums
+          - maybe
+          - prelude
+      nested-functor:
+        repo: https://github.com/acple/purescript-nested-functor.git
+        version: v0.2.1
+        dependencies:
+          - prelude
+          - type-equality
+      newtype:
+        repo: https://github.com/purescript/purescript-newtype.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+          - safe-coerce
+      node-buffer:
+        repo: https://github.com/purescript-node/purescript-node-buffer.git
+        version: v8.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - maybe
+          - st
+          - unsafe-coerce
+      node-buffer-blob:
+        repo: https://github.com/purescript-node/purescript-node-buffer-blob.git
+        version: v1.0.0
+        dependencies:
+          - aff-promise
+          - arraybuffer-types
+          - arrays
+          - console
+          - effect
+          - maybe
+          - media-types
+          - newtype
+          - node-buffer
+          - nullable
+          - prelude
+          - web-streams
+      node-child-process:
+        repo: https://github.com/purescript-node/purescript-node-child-process.git
+        version: v9.0.0
+        dependencies:
+          - exceptions
+          - foreign
+          - foreign-object
+          - functions
+          - node-fs
+          - node-streams
+          - nullable
+          - posix-types
+          - unsafe-coerce
+      node-fs:
+        repo: https://github.com/purescript-node/purescript-node-fs.git
+        version: v8.0.0
+        dependencies:
+          - datetime
+          - effect
+          - either
+          - enums
+          - exceptions
+          - functions
+          - integers
+          - js-date
+          - maybe
+          - node-buffer
+          - node-path
+          - node-streams
+          - nullable
+          - partial
+          - prelude
+          - strings
+          - unsafe-coerce
+      node-fs-aff:
+        repo: https://github.com/purescript-node/purescript-node-fs-aff.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - either
+          - node-fs
+          - node-path
+      node-http:
+        repo: https://github.com/purescript-node/purescript-node-http.git
+        version: v8.0.0
+        dependencies:
+          - arraybuffer-types
+          - contravariant
+          - effect
+          - foreign
+          - foreign-object
+          - maybe
+          - node-buffer
+          - node-net
+          - node-streams
+          - node-url
+          - nullable
+          - options
+          - prelude
+          - unsafe-coerce
+      node-net:
+        repo: https://github.com/purescript-node/purescript-node-net.git
+        version: v4.0.0
+        dependencies:
+          - effect
+          - either
+          - exceptions
+          - foreign
+          - maybe
+          - node-buffer
+          - node-fs
+          - nullable
+          - options
+          - prelude
+          - transformers
+      node-path:
+        repo: https://github.com/purescript-node/purescript-node-path.git
+        version: v5.0.0
+        dependencies:
+          - effect
+      node-process:
+        repo: https://github.com/purescript-node/purescript-node-process.git
+        version: v10.0.0
+        dependencies:
+          - effect
+          - foreign-object
+          - maybe
+          - node-streams
+          - posix-types
+          - prelude
+          - unsafe-coerce
+      node-readline:
+        repo: https://github.com/purescript-node/purescript-node-readline.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - foreign
+          - node-process
+          - node-streams
+          - options
+          - prelude
+      node-streams:
+        repo: https://github.com/purescript-node/purescript-node-streams.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - either
+          - exceptions
+          - node-buffer
+          - nullable
+          - prelude
+      node-streams-aff:
+        repo: https://github.com/jamesdbrock/purescript-node-streams-aff.git
+        version: v2.0.0
+        dependencies:
+          - aff
+          - arrays
+          - effect
+          - either
+          - exceptions
+          - maybe
+          - node-buffer
+          - node-streams
+          - prelude
+          - st
+          - tuples
+      node-url:
+        repo: https://github.com/purescript-node/purescript-node-url.git
+        version: v6.0.0
+        dependencies:
+          - nullable
+      nonempty:
+        repo: https://github.com/purescript/purescript-nonempty.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - maybe
+          - prelude
+          - tuples
+          - unfoldable
+      now:
+        repo: https://github.com/purescript-contrib/purescript-now.git
+        version: v6.0.0
+        dependencies:
+          - datetime
+          - effect
+      npm-package-json:
+        repo: https://github.com/maxdeviant/purescript-npm-package-json.git
+        version: v2.0.0
+        dependencies:
+          - argonaut
+          - control
+          - either
+          - foreign-object
+          - maybe
+          - ordered-collections
+          - prelude
+      nullable:
+        repo: https://github.com/purescript-contrib/purescript-nullable.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - functions
+          - maybe
+      numbers:
+        repo: https://github.com/purescript/purescript-numbers.git
+        version: v9.0.0
+        dependencies:
+          - functions
+          - maybe
+      open-folds:
+        repo: https://github.com/purescript-open-community/purescript-open-folds.git
+        version: v6.3.0
+        dependencies:
+          - bifunctors
+          - console
+          - control
+          - distributive
+          - effect
+          - either
+          - foldable-traversable
+          - identity
+          - invariant
+          - maybe
+          - newtype
+          - ordered-collections
+          - prelude
+          - profunctor
+          - psci-support
+          - tuples
+      open-memoize:
+        repo: https://github.com/purescript-open-community/purescript-open-memoize.git
+        version: v6.1.0
+        dependencies:
+          - console
+          - effect
+          - either
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - psci-support
+          - strings
+          - tuples
+      open-pairing:
+        repo: https://github.com/purescript-open-community/purescript-open-pairing.git
+        version: v6.1.0
+        dependencies:
+          - console
+          - control
+          - effect
+          - either
+          - free
+          - functors
+          - identity
+          - newtype
+          - prelude
+          - psci-support
+          - transformers
+          - tuples
+      options:
+        repo: https://github.com/purescript-contrib/purescript-options.git
+        version: v7.0.0
+        dependencies:
+          - contravariant
+          - foreign
+          - foreign-object
+          - maybe
+          - tuples
+      optparse:
+        repo: https://github.com/f-o-a-m/purescript-optparse.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - control
+          - effect
+          - either
+          - enums
+          - exists
+          - exitcodes
+          - foldable-traversable
+          - free
+          - gen
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - newtype
+          - node-buffer
+          - node-process
+          - node-streams
+          - nonempty
+          - numbers
+          - open-memoize
+          - partial
+          - prelude
+          - quickcheck
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+      ordered-collections:
+        repo: https://github.com/purescript/purescript-ordered-collections.git
+        version: v3.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - gen
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - unfoldable
+      ordered-set:
+        repo: https://github.com/flip111/purescript-ordered-set.git
+        version: v0.4.0
+        dependencies:
+          - argonaut-codecs
+          - arrays
+          - partial
+          - prelude
+          - unfoldable
+      orders:
+        repo: https://github.com/purescript/purescript-orders.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      pairs:
+        repo: https://github.com/sharkdp/purescript-pairs.git
+        version: v9.0.0
+        dependencies:
+          - console
+          - distributive
+          - foldable-traversable
+          - quickcheck
+      parallel:
+        repo: https://github.com/purescript/purescript-parallel.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - functors
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - refs
+          - transformers
+      parsing:
+        repo: https://github.com/purescript-contrib/purescript-parsing.git
+        version: v9.1.0
+        dependencies:
+          - arrays
+          - either
+          - foldable-traversable
+          - identity
+          - integers
+          - lists
+          - maybe
+          - nullable
+          - prelude
+          - strings
+          - transformers
+          - unicode
+      parsing-dataview:
+        repo: https://github.com/jamesdbrock/purescript-parsing-dataview.git
+        version: v3.1.0
+        dependencies:
+          - arraybuffer
+          - arraybuffer-types
+          - effect
+          - float32
+          - maybe
+          - parsing
+          - prelude
+          - transformers
+          - tuples
+          - uint
+      partial:
+        repo: https://github.com/purescript/purescript-partial.git
+        version: v4.0.0
+        dependencies: []
+      pathy:
+        repo: https://github.com/purescript-contrib/purescript-pathy.git
+        version: v9.0.0
+        dependencies:
+          - console
+          - exceptions
+          - lists
+          - partial
+          - profunctor
+          - strings
+          - transformers
+          - typelevel-prelude
+          - unsafe-coerce
+      pha:
+        repo: https://github.com/gbagan/purescript-pha.git
+        version: v0.9.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - datetime
+          - effect
+          - foldable-traversable
+          - free
+          - integers
+          - maybe
+          - prelude
+          - profunctor-lenses
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+          - unsafe-reference
+          - web-dom
+          - web-events
+          - web-html
+          - web-pointerevents
+          - web-uievents
+      phaser:
+        repo: https://github.com/lfarroco/purescript-phaser.git
+        version: v0.6.0
+        dependencies:
+          - canvas
+          - console
+          - effect
+          - maybe
+          - nullable
+          - options
+          - prelude
+          - web-html
+      pipes:
+        repo: https://github.com/felixschl/purescript-pipes.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - lists
+          - mmorph
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      point-free:
+        repo: https://github.com/ursi/purescript-point-free.git
+        version: v1.0.0
+        dependencies:
+          - prelude
+      polymorphic-vectors:
+        repo: https://github.com/artemisSystem/purescript-polymorphic-vectors.git
+        version: v4.0.0
+        dependencies:
+          - distributive
+          - foldable-traversable
+          - numbers
+          - prelude
+          - record
+          - safe-coerce
+          - type-equality
+          - typelevel-prelude
+      posix-types:
+        repo: https://github.com/purescript-node/purescript-posix-types.git
+        version: v6.0.0
+        dependencies:
+          - maybe
+          - prelude
+      precise:
+        repo: https://github.com/purescript-contrib/purescript-precise.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - exceptions
+          - gen
+          - integers
+          - lists
+          - numbers
+          - prelude
+          - strings
+      precise-datetime:
+        repo: https://github.com/awakesecurity/purescript-precise-datetime.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - datetime
+          - decimals
+          - either
+          - enums
+          - foldable-traversable
+          - formatters
+          - integers
+          - js-date
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - strings
+          - tuples
+          - unicode
+      prelude:
+        repo: https://github.com/purescript/purescript-prelude.git
+        version: v6.0.0
+        dependencies: []
+      prettier-printer:
+        repo: https://github.com/paulyoung/purescript-prettier-printer.git
+        version: v3.0.0
+        dependencies:
+          - console
+          - lists
+          - prelude
+          - strings
+          - tuples
+      profunctor:
+        repo: https://github.com/purescript/purescript-profunctor.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - distributive
+          - either
+          - exists
+          - invariant
+          - newtype
+          - prelude
+          - tuples
+      profunctor-lenses:
+        repo: https://github.com/purescript-contrib/purescript-profunctor-lenses.git
+        version: v8.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - const
+          - control
+          - distributive
+          - either
+          - foldable-traversable
+          - foreign-object
+          - functors
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - ordered-collections
+          - partial
+          - prelude
+          - profunctor
+          - record
+          - transformers
+          - tuples
+      protobuf:
+        repo: https://github.com/xc-jp/purescript-protobuf.git
+        version: v4.0.0
+        dependencies:
+          - arraybuffer
+          - arraybuffer-builder
+          - arraybuffer-types
+          - arrays
+          - control
+          - effect
+          - either
+          - enums
+          - exceptions
+          - float32
+          - foldable-traversable
+          - functions
+          - int64
+          - maybe
+          - newtype
+          - parsing
+          - parsing-dataview
+          - prelude
+          - record
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+          - uint
+          - web-encoding
+      ps-cst:
+        repo: https://github.com/purescript-codegen/purescript-ps-cst.git
+        version: v1.2.0
+        dependencies:
+          - ansi
+          - console
+          - dodo-printer
+          - effect
+          - node-fs-aff
+          - node-path
+          - psci-support
+          - record
+          - strings
+      psa-utils:
+        repo: https://github.com/natefaubion/purescript-psa-utils.git
+        version: v8.0.0
+        dependencies:
+          - ansi
+          - argonaut-codecs
+          - argonaut-core
+          - arrays
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - maybe
+          - node-path
+          - ordered-collections
+          - prelude
+          - strings
+          - tuples
+          - unsafe-coerce
+      psc-ide:
+        repo: https://github.com/kRITZCREEK/purescript-psc-ide.git
+        version: v19.0.0
+        dependencies:
+          - aff
+          - argonaut
+          - arrays
+          - console
+          - maybe
+          - node-child-process
+          - node-fs
+          - parallel
+          - random
+      psci-support:
+        repo: https://github.com/purescript/purescript-psci-support.git
+        version: v6.0.0
+        dependencies:
+          - console
+          - effect
+          - prelude
+      qualified-do:
+        repo: https://github.com/artemisSystem/purescript-qualified-do.git
+        version: v2.2.0
+        dependencies:
+          - arrays
+          - control
+          - foldable-traversable
+          - parallel
+          - prelude
+          - unfoldable
+      quantities:
+        repo: https://github.com/sharkdp/purescript-quantities.git
+        version: v12.0.1
+        dependencies:
+          - decimals
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - newtype
+          - nonempty
+          - numbers
+          - pairs
+          - prelude
+          - tuples
+      quickcheck:
+        repo: https://github.com/purescript/purescript-quickcheck.git
+        version: v8.0.1
+        dependencies:
+          - arrays
+          - console
+          - control
+          - effect
+          - either
+          - enums
+          - exceptions
+          - foldable-traversable
+          - gen
+          - identity
+          - integers
+          - lazy
+          - lcg
+          - lists
+          - maybe
+          - newtype
+          - nonempty
+          - numbers
+          - partial
+          - prelude
+          - record
+          - st
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+          - unfoldable
+      quickcheck-combinators:
+        repo: https://github.com/athanclark/purescript-quickcheck-combinators.git
+        version: v0.1.3
+        dependencies:
+          - quickcheck
+          - typelevel
+      quickcheck-laws:
+        repo: https://github.com/purescript-contrib/purescript-quickcheck-laws.git
+        version: v7.0.0
+        dependencies:
+          - enums
+          - quickcheck
+      quickcheck-utf8:
+        repo: https://github.com/openchronology/purescript-quickcheck-utf8.git
+        version: v0.0.0
+        dependencies:
+          - quickcheck
+      quotient:
+        repo: https://github.com/rightfold/purescript-quotient.git
+        version: v3.0.0
+        dependencies:
+          - prelude
+          - quickcheck
+      random:
+        repo: https://github.com/purescript/purescript-random.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - integers
+      rationals:
+        repo: https://github.com/anttih/purescript-rationals.git
+        version: v5.0.0
+        dependencies:
+          - integers
+          - prelude
+      react:
+        repo: https://github.com/purescript-contrib/purescript-react.git
+        version: v10.0.1
+        dependencies:
+          - effect
+          - exceptions
+          - maybe
+          - nullable
+          - prelude
+          - typelevel-prelude
+          - unsafe-coerce
+      react-basic:
+        repo: https://github.com/lumihq/purescript-react-basic.git
+        version: v17.0.0
+        dependencies:
+          - effect
+          - prelude
+          - record
+      react-basic-dom:
+        repo: https://github.com/lumihq/purescript-react-basic-dom.git
+        version: v5.0.0
+        dependencies:
+          - effect
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - nullable
+          - prelude
+          - react-basic
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-file
+          - web-html
+      react-basic-hooks:
+        repo: https://github.com/megamaddu/purescript-react-basic-hooks.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - aff-promise
+          - bifunctors
+          - console
+          - control
+          - datetime
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - functions
+          - indexed-monad
+          - integers
+          - maybe
+          - newtype
+          - now
+          - nullable
+          - ordered-collections
+          - prelude
+          - react-basic
+          - refs
+          - tuples
+          - type-equality
+          - unsafe-coerce
+          - unsafe-reference
+          - web-html
+      react-dom:
+        repo: https://github.com/purescript-contrib/purescript-react-dom.git
+        version: v8.0.0
+        dependencies:
+          - effect
+          - react
+          - web-dom
+      read:
+        repo: https://github.com/truqu/purescript-read.git
+        version: v1.0.1
+        dependencies:
+          - maybe
+          - prelude
+          - strings
+      record:
+        repo: https://github.com/purescript/purescript-record.git
+        version: v4.0.0
+        dependencies:
+          - functions
+          - prelude
+          - unsafe-coerce
+      refined:
+        repo: https://github.com/danieljharvey/purescript-refined.git
+        version: v1.0.0
+        dependencies:
+          - argonaut
+          - effect
+          - prelude
+          - quickcheck
+          - typelevel
+      refs:
+        repo: https://github.com/purescript/purescript-refs.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - prelude
+      remotedata:
+        repo: https://github.com/krisajenkins/purescript-remotedata.git
+        version: v5.0.0
+        dependencies:
+          - bifunctors
+          - either
+          - profunctor-lenses
+      resource:
+        repo: https://github.com/joneshf/purescript-resource.git
+        version: v2.0.1
+        dependencies:
+          - aff
+          - console
+          - control
+          - effect
+          - newtype
+          - prelude
+          - psci-support
+          - refs
+      resourcet:
+        repo: https://github.com/robertdp/purescript-resourcet.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - effect
+          - foldable-traversable
+          - maybe
+          - ordered-collections
+          - parallel
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+      result:
+        repo: https://github.com/ad-si/purescript-result.git
+        version: v1.0.3
+        dependencies:
+          - either
+          - foldable-traversable
+          - prelude
+      return:
+        repo: https://github.com/ursi/purescript-return.git
+        version: v0.2.0
+        dependencies:
+          - foldable-traversable
+          - point-free
+          - prelude
+      ring-modules:
+        repo: https://github.com/f-o-a-m/purescript-ring-modules.git
+        version: v5.0.1
+        dependencies:
+          - prelude
+      routing:
+        repo: https://github.com/purescript-contrib/purescript-routing.git
+        version: v11.0.0
+        dependencies:
+          - aff
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - integers
+          - js-uri
+          - lists
+          - maybe
+          - numbers
+          - partial
+          - prelude
+          - semirings
+          - tuples
+          - validation
+          - web-html
+      routing-duplex:
+        repo: https://github.com/natefaubion/purescript-routing-duplex.git
+        version: v0.6.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - js-uri
+          - lazy
+          - numbers
+          - prelude
+          - profunctor
+          - record
+          - strings
+          - typelevel-prelude
+      run:
+        repo: https://github.com/natefaubion/purescript-run.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - free
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - tailrec
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - variant
+      safe-coerce:
+        repo: https://github.com/purescript/purescript-safe-coerce.git
+        version: v2.0.0
+        dependencies:
+          - unsafe-coerce
+      safely:
+        repo: https://github.com/paf31/purescript-safely.git
+        version: v4.0.1
+        dependencies:
+          - freet
+          - lists
+      selection-foldable:
+        repo: https://github.com/jamieyung/purescript-selection-foldable.git
+        version: v0.2.0
+        dependencies:
+          - filterable
+          - foldable-traversable
+          - maybe
+          - prelude
+      semirings:
+        repo: https://github.com/purescript/purescript-semirings.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - lists
+          - newtype
+          - prelude
+      signal:
+        repo: https://github.com/bodil/purescript-signal.git
+        version: v13.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - foldable-traversable
+          - maybe
+          - prelude
+      simple-emitter:
+        repo: https://github.com/oreshinya/purescript-simple-emitter.git
+        version: v2.0.0
+        dependencies:
+          - ordered-collections
+          - refs
+      sized-matrices:
+        repo: https://github.com/csicar/purescript-sized-matrices.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - distributive
+          - foldable-traversable
+          - maybe
+          - prelude
+          - sized-vectors
+          - strings
+          - typelevel
+          - unfoldable
+          - vectorfield
+      sized-vectors:
+        repo: https://github.com/bodil/purescript-sized-vectors.git
+        version: v5.0.2
+        dependencies:
+          - argonaut
+          - arrays
+          - distributive
+          - foldable-traversable
+          - maybe
+          - prelude
+          - quickcheck
+          - typelevel
+          - unfoldable
+      slug:
+        repo: https://github.com/thomashoneyman/purescript-slug.git
+        version: v3.0.1
+        dependencies:
+          - argonaut-codecs
+          - maybe
+          - prelude
+          - strings
+          - unicode
+      soundfonts:
+        repo: https://github.com/newlandsvalley/purescript-soundfonts.git
+        version: v4.1.0
+        dependencies:
+          - aff
+          - affjax
+          - affjax-web
+          - argonaut-core
+          - arraybuffer-types
+          - arrays
+          - b64
+          - bifunctors
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign-object
+          - http-methods
+          - integers
+          - lists
+          - maybe
+          - midi
+          - ordered-collections
+          - parallel
+          - partial
+          - prelude
+          - strings
+          - transformers
+          - tuples
+      sparse-matrices:
+        repo: https://github.com/Ebmtranceboy/purescript-sparse-matrices.git
+        version: v1.2.1
+        dependencies:
+          - console
+          - effect
+          - prelude
+          - sparse-polynomials
+      sparse-polynomials:
+        repo: https://github.com/Ebmtranceboy/purescript-sparse-polynomials.git
+        version: v1.0.5
+        dependencies:
+          - cartesian
+          - console
+          - effect
+          - ordered-collections
+          - prelude
+          - rationals
+          - tuples
+      spec:
+        repo: https://github.com/purescript-spec/purescript-spec.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - ansi
+          - avar
+          - console
+          - exceptions
+          - foldable-traversable
+          - fork
+          - now
+          - pipes
+          - prelude
+          - strings
+          - transformers
+      spec-discovery:
+        repo: https://github.com/purescript-spec/purescript-spec-discovery.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - aff-promise
+          - arrays
+          - console
+          - effect
+          - foldable-traversable
+          - node-fs
+          - prelude
+          - spec
+      spec-quickcheck:
+        repo: https://github.com/purescript-spec/purescript-spec-quickcheck.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - prelude
+          - quickcheck
+          - random
+          - spec
+      ssrs:
+        repo: https://github.com/PureFunctor/purescript-ssrs.git
+        version: v1.0.0
+        dependencies:
+          - dissect
+          - either
+          - fixed-points
+          - free
+          - lists
+          - prelude
+          - safe-coerce
+          - tailrec
+          - tuples
+          - variant
+      st:
+        repo: https://github.com/purescript/purescript-st.git
+        version: v6.0.0
+        dependencies:
+          - partial
+          - prelude
+          - tailrec
+          - unsafe-coerce
+      strictlypositiveint:
+        repo: https://github.com/jamieyung/purescript-strictlypositiveint.git
+        version: v1.0.1
+        dependencies:
+          - prelude
+      string-parsers:
+        repo: https://github.com/purescript-contrib/purescript-string-parsers.git
+        version: v8.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - prelude
+          - strings
+          - tailrec
+      strings:
+        repo: https://github.com/purescript/purescript-strings.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - enums
+          - foldable-traversable
+          - gen
+          - integers
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+          - unsafe-coerce
+      strings-extra:
+        repo: https://github.com/purescript-contrib/purescript-strings-extra.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - maybe
+          - prelude
+          - strings
+          - unicode
+      stringutils:
+        repo: https://github.com/menelaos/purescript-stringutils.git
+        version: v0.0.12
+        dependencies:
+          - arrays
+          - integers
+          - maybe
+          - partial
+          - prelude
+          - strings
+      substitute:
+        repo: https://github.com/ursi/purescript-substitute.git
+        version: v0.2.3
+        dependencies:
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - prelude
+          - return
+          - strings
+      supply:
+        repo: https://github.com/ajnsit/purescript-supply.git
+        version: v0.2.0
+        dependencies:
+          - console
+          - control
+          - effect
+          - lazy
+          - prelude
+          - refs
+          - tuples
+      tailrec:
+        repo: https://github.com/purescript/purescript-tailrec.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - effect
+          - either
+          - identity
+          - maybe
+          - partial
+          - prelude
+          - refs
+      test-unit:
+        repo: https://github.com/bodil/purescript-test-unit.git
+        version: v17.0.0
+        dependencies:
+          - aff
+          - avar
+          - effect
+          - either
+          - free
+          - js-timers
+          - lists
+          - prelude
+          - quickcheck
+          - strings
+      thermite:
+        repo: https://github.com/paf31/purescript-thermite.git
+        version: v6.3.1
+        dependencies:
+          - aff
+          - coroutines
+          - freet
+          - profunctor-lenses
+          - react
+      thermite-dom:
+        repo: https://github.com/athanclark/purescript-thermite-dom.git
+        version: v0.3.1
+        dependencies:
+          - react
+          - react-dom
+          - thermite
+          - web-html
+      these:
+        repo: https://github.com/purescript-contrib/purescript-these.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - gen
+          - lists
+          - quickcheck
+          - quickcheck-laws
+          - tuples
+      transformers:
+        repo: https://github.com/purescript/purescript-transformers.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - distributive
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - identity
+          - lazy
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      tree-rose:
+        repo: https://github.com/jordanmartinez/purescript-tree-rose.git
+        version: v4.0.2
+        dependencies:
+          - control
+          - foldable-traversable
+          - free
+          - lists
+          - maybe
+          - prelude
+          - tailrec
+      tuples:
+        repo: https://github.com/purescript/purescript-tuples.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - invariant
+          - prelude
+      two-or-more:
+        repo: https://github.com/i-am-the-slime/purescript-two-or-more.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - foldable-traversable
+          - maybe
+          - partial
+          - prelude
+          - psci-support
+          - tuples
+      type-equality:
+        repo: https://github.com/purescript/purescript-type-equality.git
+        version: v4.0.1
+        dependencies: []
+      typelevel:
+        repo: https://github.com/bodil/purescript-typelevel.git
+        version: v6.0.0
+        dependencies:
+          - partial
+          - prelude
+          - tuples
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-lists:
+        repo: https://github.com/PureFunctor/purescript-typelevel-lists.git
+        version: v2.1.0
+        dependencies:
+          - prelude
+          - tuples
+          - typelevel-peano
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-peano:
+        repo: https://github.com/csicar/purescript-typelevel-peano.git
+        version: v1.0.1
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - prelude
+          - psci-support
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-prelude:
+        repo: https://github.com/purescript/purescript-typelevel-prelude.git
+        version: v7.0.0
+        dependencies:
+          - prelude
+          - type-equality
+      typelevel-rows:
+        repo: https://github.com/jordanmartinez/purescript-typelevel-rows.git
+        version: v0.1.0
+        dependencies:
+          - prelude
+      uint:
+        repo: https://github.com/purescript-contrib/purescript-uint.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - enums
+          - gen
+          - maybe
+          - numbers
+          - prelude
+      uncurried-transformers:
+        repo: https://github.com/PureFunctor/purescript-uncurried-transformers.git
+        version: v1.1.0
+        dependencies:
+          - control
+          - effect
+          - either
+          - functions
+          - identity
+          - prelude
+          - safe-coerce
+          - tailrec
+          - transformers
+          - tuples
+      undefined-is-not-a-problem:
+        repo: https://github.com/paluh/purescript-undefined-is-not-a-problem.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - assert
+          - effect
+          - either
+          - foreign
+          - maybe
+          - newtype
+          - prelude
+          - random
+          - tuples
+          - type-equality
+          - unsafe-coerce
+      unfoldable:
+        repo: https://github.com/purescript/purescript-unfoldable.git
+        version: v6.0.0
+        dependencies:
+          - foldable-traversable
+          - maybe
+          - partial
+          - prelude
+          - tuples
+      unicode:
+        repo: https://github.com/purescript-contrib/purescript-unicode.git
+        version: v6.0.0
+        dependencies:
+          - foldable-traversable
+          - maybe
+          - strings
+      unlift:
+        repo: https://github.com/tweag/purescript-unlift.git
+        version: v1.0.1
+        dependencies:
+          - aff
+          - effect
+          - either
+          - freet
+          - identity
+          - lists
+          - maybe
+          - monad-control
+          - prelude
+          - st
+          - transformers
+          - tuples
+      unsafe-coerce:
+        repo: https://github.com/purescript/purescript-unsafe-coerce.git
+        version: v6.0.0
+        dependencies: []
+      unsafe-reference:
+        repo: https://github.com/purescript-contrib/purescript-unsafe-reference.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+      uri:
+        repo: https://github.com/purescript-contrib/purescript-uri.git
+        version: v9.0.0
+        dependencies:
+          - arrays
+          - integers
+          - js-uri
+          - numbers
+          - parsing
+          - prelude
+          - profunctor-lenses
+          - these
+          - transformers
+          - unfoldable
+      validation:
+        repo: https://github.com/purescript/purescript-validation.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - newtype
+          - prelude
+      variant:
+        repo: https://github.com/natefaubion/purescript-variant.git
+        version: v8.0.0
+        dependencies:
+          - enums
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - record
+          - tuples
+          - unsafe-coerce
+      vectorfield:
+        repo: https://github.com/csicar/purescript-vectorfield.git
+        version: v1.0.1
+        dependencies:
+          - console
+          - effect
+          - group
+          - prelude
+          - psci-support
+      versions:
+        repo: https://github.com/hdgarrood/purescript-versions.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - either
+          - foldable-traversable
+          - functions
+          - integers
+          - lists
+          - maybe
+          - orders
+          - parsing
+          - partial
+          - strings
+      web-clipboard:
+        repo: https://github.com/purescript-web/purescript-web-clipboard.git
+        version: v4.0.0
+        dependencies:
+          - web-html
+      web-cssom:
+        repo: https://github.com/purescript-web/purescript-web-cssom.git
+        version: v2.0.0
+        dependencies:
+          - web-dom
+          - web-html
+          - web-uievents
+      web-dom:
+        repo: https://github.com/purescript-web/purescript-web-dom.git
+        version: v6.0.0
+        dependencies:
+          - web-events
+      web-dom-parser:
+        repo: https://github.com/purescript-web/purescript-web-dom-parser.git
+        version: v8.0.0
+        dependencies:
+          - effect
+          - partial
+          - prelude
+          - web-dom
+      web-dom-xpath:
+        repo: https://github.com/purescript-web/purescript-web-dom-xpath.git
+        version: v3.0.0
+        dependencies:
+          - web-dom
+      web-encoding:
+        repo: https://github.com/purescript-web/purescript-web-encoding.git
+        version: v3.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - newtype
+          - prelude
+      web-events:
+        repo: https://github.com/purescript-web/purescript-web-events.git
+        version: v4.0.0
+        dependencies:
+          - datetime
+          - enums
+          - foreign
+          - nullable
+      web-fetch:
+        repo: https://github.com/purescript-web/purescript-web-fetch.git
+        version: v3.0.0
+        dependencies:
+          - effect
+          - foreign-object
+          - http-methods
+          - prelude
+          - record
+          - typelevel-prelude
+          - web-file
+          - web-promise
+          - web-streams
+      web-file:
+        repo: https://github.com/purescript-web/purescript-web-file.git
+        version: v4.0.0
+        dependencies:
+          - foreign
+          - media-types
+          - web-dom
+      web-html:
+        repo: https://github.com/purescript-web/purescript-web-html.git
+        version: v4.0.0
+        dependencies:
+          - js-date
+          - web-dom
+          - web-file
+          - web-storage
+      web-page-visibility:
+        repo: https://git.sr.ht/~toastal/purescript-web-page-visibility
+        version: v2.0.0
+        dependencies:
+          - effect
+          - enums
+          - exceptions
+          - maybe
+          - prelude
+          - strings
+          - web-events
+          - web-html
+      web-pointerevents:
+        repo: https://github.com/purescript-web/purescript-web-pointerevents.git
+        version: v1.0.0
+        dependencies:
+          - effect
+          - maybe
+          - prelude
+          - web-dom
+          - web-uievents
+      web-promise:
+        repo: https://github.com/purescript-web/purescript-web-promise.git
+        version: v3.0.0
+        dependencies:
+          - effect
+          - exceptions
+          - foldable-traversable
+          - functions
+          - maybe
+          - prelude
+      web-socket:
+        repo: https://github.com/purescript-web/purescript-web-socket.git
+        version: v4.0.0
+        dependencies:
+          - arraybuffer-types
+          - web-file
+      web-storage:
+        repo: https://github.com/purescript-web/purescript-web-storage.git
+        version: v5.0.0
+        dependencies:
+          - nullable
+          - web-events
+      web-streams:
+        repo: https://github.com/purescript-web/purescript-web-streams.git
+        version: v3.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - exceptions
+          - nullable
+          - prelude
+          - tuples
+          - web-promise
+      web-touchevents:
+        repo: https://github.com/purescript-web/purescript-web-touchevents.git
+        version: v4.0.0
+        dependencies:
+          - web-uievents
+      web-uievents:
+        repo: https://github.com/purescript-web/purescript-web-uievents.git
+        version: v4.0.0
+        dependencies:
+          - web-html
+      web-workers:
+        repo: https://github.com/gbagan/purescript-web-workers.git
+        version: v1.1.0
+        dependencies:
+          - effect
+          - foreign
+          - maybe
+          - prelude
+          - unsafe-coerce
+          - web-events
+      web-xhr:
+        repo: https://github.com/purescript-web/purescript-web-xhr.git
+        version: v5.0.0
+        dependencies:
+          - arraybuffer-types
+          - datetime
+          - http-methods
+          - web-dom
+          - web-file
+          - web-html
+      yoga-fetch:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-fetch.git
+        version: v1.0.1
+        dependencies:
+          - aff
+          - aff-promise
+          - arraybuffer-types
+          - effect
+          - foreign
+          - foreign-object
+          - newtype
+          - prelude
+          - typelevel-prelude
+          - unsafe-coerce
+      yoga-json:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-json.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - identity
+          - lists
+          - maybe
+          - nullable
+          - partial
+          - prelude
+          - record
+          - transformers
+          - typelevel-prelude
+          - variant
+      yoga-postgres:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-postgres.git
+        version: v6.0.0
+        dependencies:
+          - aff
+          - arrays
+          - datetime
+          - effect
+          - either
+          - enums
+          - foldable-traversable
+          - foreign
+          - integers
+          - maybe
+          - nullable
+          - prelude
+          - transformers
+          - unsafe-coerce
+  extra_packages: {}
+packages:
+  aff:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-aff.git
+    rev: 2d44d9f9d0d6a416a4103fba2fb39e5160f80e36
+    dependencies:
+      - datetime
+      - effect
+      - exceptions
+      - functions
+      - parallel
+      - transformers
+      - unsafe-coerce
+  arrays:
+    type: git
+    url: https://github.com/purescript/purescript-arrays.git
+    rev: d20bae2f76db6cf29b7b75e26e82b8a54c32295e
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - maybe
+      - nonempty
+      - partial
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  avar:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-avar.git
+    rev: d00f5784d9cc8f079babd62740f5c52b87e5caa5
+    dependencies:
+      - aff
+      - effect
+      - either
+      - exceptions
+      - functions
+      - maybe
+  bifunctors:
+    type: git
+    url: https://github.com/purescript/purescript-bifunctors.git
+    rev: 16ba2fb6dd7f05528ebd9e2f9ca3a068b325e5b3
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  catenable-lists:
+    type: git
+    url: https://github.com/purescript/purescript-catenable-lists.git
+    rev: 09abe1f4888bc00841ad2b59e56a9e7ce7ebd4ab
+    dependencies:
+      - control
+      - foldable-traversable
+      - lists
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  console:
+    type: git
+    url: https://github.com/purescript/purescript-console.git
+    rev: 3b83d7b792d03872afeea5e62b4f686ab0f09842
+    dependencies:
+      - effect
+      - prelude
+  const:
+    type: git
+    url: https://github.com/purescript/purescript-const.git
+    rev: ab9570cf2b6e67f7e441178211db1231cfd75c37
+    dependencies:
+      - invariant
+      - newtype
+      - prelude
+  contravariant:
+    type: git
+    url: https://github.com/purescript/purescript-contravariant.git
+    rev: 9ad3e105b8855bcc25f4e0893c784789d05a58de
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  control:
+    type: git
+    url: https://github.com/purescript/purescript-control.git
+    rev: a6033808790879a17b2729e73747a9ed3fb2264e
+    dependencies:
+      - newtype
+      - prelude
+  datetime:
+    type: git
+    url: https://github.com/purescript/purescript-datetime.git
+    rev: a6a0cf1b0324964ad1854bc3377ed8766ba90e6f
+    dependencies:
+      - bifunctors
+      - control
+      - either
+      - enums
+      - foldable-traversable
+      - functions
+      - gen
+      - integers
+      - lists
+      - maybe
+      - newtype
+      - numbers
+      - ordered-collections
+      - partial
+      - prelude
+      - tuples
+  distributive:
+    type: git
+    url: https://github.com/purescript/purescript-distributive.git
+    rev: 6005e513642e855ebf6f884d24a35c2803ca252a
+    dependencies:
+      - identity
+      - newtype
+      - prelude
+      - tuples
+      - type-equality
+  effect:
+    type: git
+    url: https://github.com/purescript/purescript-effect.git
+    rev: a192ddb923027d426d6ea3d8deb030c9aa7c7dda
+    dependencies:
+      - prelude
+  either:
+    type: git
+    url: https://github.com/purescript/purescript-either.git
+    rev: af655a04ed2fd694b6688af39ee20d7907ad0763
+    dependencies:
+      - control
+      - invariant
+      - maybe
+      - prelude
+  enums:
+    type: git
+    url: https://github.com/purescript/purescript-enums.git
+    rev: bae47961d401f9acf88da38f32e87403e5f0cf2f
+    dependencies:
+      - control
+      - either
+      - gen
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tuples
+      - unfoldable
+  exceptions:
+    type: git
+    url: https://github.com/purescript/purescript-exceptions.git
+    rev: afab3c07c820bb49b6c5be50049db46a964a6161
+    dependencies:
+      - effect
+      - either
+      - maybe
+      - prelude
+  exists:
+    type: git
+    url: https://github.com/purescript/purescript-exists.git
+    rev: f765b4ace7869c27b9c05949e18c843881f9173b
+    dependencies:
+      - unsafe-coerce
+  foldable-traversable:
+    type: git
+    url: https://github.com/purescript/purescript-foldable-traversable.git
+    rev: b3926f870532d287ea59e2d5cd3873b81ef2a93a
+    dependencies:
+      - bifunctors
+      - const
+      - control
+      - either
+      - functors
+      - identity
+      - maybe
+      - newtype
+      - orders
+      - prelude
+      - tuples
+  free:
+    type: git
+    url: https://github.com/purescript/purescript-free.git
+    rev: e2d8fa8023a864363857834e11393483bced5e38
+    dependencies:
+      - catenable-lists
+      - control
+      - distributive
+      - either
+      - exists
+      - foldable-traversable
+      - invariant
+      - lazy
+      - maybe
+      - prelude
+      - tailrec
+      - transformers
+      - tuples
+      - unsafe-coerce
+  functions:
+    type: git
+    url: https://github.com/purescript/purescript-functions.git
+    rev: f626f20580483977c5b27a01aac6471e28aff367
+    dependencies:
+      - prelude
+  functors:
+    type: git
+    url: https://github.com/purescript/purescript-functors.git
+    rev: 022ffd7a2a7ec12080314f3d217b400674a247b4
+    dependencies:
+      - bifunctors
+      - const
+      - contravariant
+      - control
+      - distributive
+      - either
+      - invariant
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - tuples
+      - unsafe-coerce
+  gen:
+    type: git
+    url: https://github.com/purescript/purescript-gen.git
+    rev: 9fbcc2a1261c32e30d79c5418edef4d96fe76931
+    dependencies:
+      - either
+      - foldable-traversable
+      - identity
+      - maybe
+      - newtype
+      - nonempty
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  identity:
+    type: git
+    url: https://github.com/purescript/purescript-identity.git
+    rev: ef6768f8a52ab0bc943a85f5761ba07c257f639f
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  integers:
+    type: git
+    url: https://github.com/purescript/purescript-integers.git
+    rev: 54d712b25c594833083d15dc9ff2418eb9c52822
+    dependencies:
+      - maybe
+      - numbers
+      - prelude
+  invariant:
+    type: git
+    url: https://github.com/purescript/purescript-invariant.git
+    rev: 1d2a196d51e90623adb88496c2cfd759c6736894
+    dependencies:
+      - control
+      - prelude
+  js-timers:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-js-timers.git
+    rev: 7cb728b3e6dc29f355143617e6e9ac770ecd9273
+    dependencies:
+      - effect
+  lazy:
+    type: git
+    url: https://github.com/purescript/purescript-lazy.git
+    rev: 48347841226b27af5205a1a8ec71e27a93ce86fd
+    dependencies:
+      - control
+      - foldable-traversable
+      - invariant
+      - prelude
+  lcg:
+    type: git
+    url: https://github.com/purescript/purescript-lcg.git
+    rev: 67c6c6483a563a59ae036d9dca0f1be2835326a5
+    dependencies:
+      - effect
+      - integers
+      - maybe
+      - partial
+      - prelude
+      - random
+  lists:
+    type: git
+    url: https://github.com/purescript/purescript-lists.git
+    rev: b113451e5b41cad87d669a3165f955c71cd863e2
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - lazy
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  maybe:
+    type: git
+    url: https://github.com/purescript/purescript-maybe.git
+    rev: c6f98ac1088766287106c5d9c8e30e7648d36786
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  newtype:
+    type: git
+    url: https://github.com/purescript/purescript-newtype.git
+    rev: 29d8e6dd77aec2c975c948364ec3faf26e14ee7b
+    dependencies:
+      - prelude
+      - safe-coerce
+  nonempty:
+    type: git
+    url: https://github.com/purescript/purescript-nonempty.git
+    rev: 28150ecc7419238b187abd609a92a645273348bb
+    dependencies:
+      - control
+      - foldable-traversable
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  numbers:
+    type: git
+    url: https://github.com/purescript/purescript-numbers.git
+    rev: 2a53528f18f9415334bae28e7bb3cf3be86342c2
+    dependencies:
+      - functions
+      - maybe
+  ordered-collections:
+    type: git
+    url: https://github.com/purescript/purescript-ordered-collections.git
+    rev: 9826b7632d0d0a691173bde308a634195f42a419
+    dependencies:
+      - arrays
+      - foldable-traversable
+      - gen
+      - lists
+      - maybe
+      - partial
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+  orders:
+    type: git
+    url: https://github.com/purescript/purescript-orders.git
+    rev: f86db621ec5eef1274145f8b1fd8ebbfe0ed4a2c
+    dependencies:
+      - newtype
+      - prelude
+  parallel:
+    type: git
+    url: https://github.com/purescript/purescript-parallel.git
+    rev: 85290dca837771ac4870071008c933d315ef678f
+    dependencies:
+      - control
+      - effect
+      - either
+      - foldable-traversable
+      - functors
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - refs
+      - transformers
+  partial:
+    type: git
+    url: https://github.com/purescript/purescript-partial.git
+    rev: 0fa0646f5ea1ec5f0c46dcbd770c705a6c9ad3ec
+    dependencies: []
+  prelude:
+    type: git
+    url: https://github.com/purescript/purescript-prelude.git
+    rev: 32787f4399c92459c41602131a5858559eb868c5
+    dependencies: []
+  profunctor:
+    type: git
+    url: https://github.com/purescript/purescript-profunctor.git
+    rev: 0a966a14e7b0c827d44657dc1710cdc712d2e034
+    dependencies:
+      - control
+      - distributive
+      - either
+      - exists
+      - invariant
+      - newtype
+      - prelude
+      - tuples
+  quickcheck:
+    type: git
+    url: https://github.com/purescript/purescript-quickcheck.git
+    rev: bf5029f97e6c0d7552d3a08d2ab793a19e2c5e3d
+    dependencies:
+      - arrays
+      - console
+      - control
+      - effect
+      - either
+      - enums
+      - exceptions
+      - foldable-traversable
+      - gen
+      - identity
+      - integers
+      - lazy
+      - lcg
+      - lists
+      - maybe
+      - newtype
+      - nonempty
+      - numbers
+      - partial
+      - prelude
+      - record
+      - st
+      - strings
+      - tailrec
+      - transformers
+      - tuples
+      - unfoldable
+  random:
+    type: git
+    url: https://github.com/purescript/purescript-random.git
+    rev: 9540bc965a9596da02fefd9949418bb19c92533a
+    dependencies:
+      - effect
+      - integers
+  record:
+    type: git
+    url: https://github.com/purescript/purescript-record.git
+    rev: c89cd1ada6b636692571fc374196b1c39c4c9f70
+    dependencies:
+      - functions
+      - prelude
+      - unsafe-coerce
+  refs:
+    type: git
+    url: https://github.com/purescript/purescript-refs.git
+    rev: f8e6216da4cb9309fde1f20cd6f69ac3a3b7f9e8
+    dependencies:
+      - effect
+      - prelude
+  safe-coerce:
+    type: git
+    url: https://github.com/purescript/purescript-safe-coerce.git
+    rev: 7fa799ae80a38b8d948efcb52608e58e198b3da7
+    dependencies:
+      - unsafe-coerce
+  st:
+    type: git
+    url: https://github.com/purescript/purescript-st.git
+    rev: 2cc7ae1c3318a303378c4a9f3fa0f10ee7cc3589
+    dependencies:
+      - partial
+      - prelude
+      - tailrec
+      - unsafe-coerce
+  strings:
+    type: git
+    url: https://github.com/purescript/purescript-strings.git
+    rev: 4bc6954448d056f8aa7a659695a6ad60ad4fdf19
+    dependencies:
+      - arrays
+      - control
+      - either
+      - enums
+      - foldable-traversable
+      - gen
+      - integers
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  tailrec:
+    type: git
+    url: https://github.com/purescript/purescript-tailrec.git
+    rev: 5e2104aa734b31a17074cc805bf087d72b65afd1
+    dependencies:
+      - bifunctors
+      - effect
+      - either
+      - identity
+      - maybe
+      - partial
+      - prelude
+      - refs
+  test-unit:
+    type: git
+    url: https://github.com/bodil/purescript-test-unit.git
+    rev: 3112d7ebe06d467238058a6384dc75ffd960d335
+    dependencies:
+      - aff
+      - avar
+      - effect
+      - either
+      - free
+      - js-timers
+      - lists
+      - prelude
+      - quickcheck
+      - strings
+  transformers:
+    type: git
+    url: https://github.com/purescript/purescript-transformers.git
+    rev: be72ab52357d9a665cbf93d73ba1c07c4b0957ee
+    dependencies:
+      - control
+      - distributive
+      - effect
+      - either
+      - exceptions
+      - foldable-traversable
+      - identity
+      - lazy
+      - maybe
+      - newtype
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  tuples:
+    type: git
+    url: https://github.com/purescript/purescript-tuples.git
+    rev: 4f52da2729b448c8564369378f1232d8d2dc1d8b
+    dependencies:
+      - control
+      - invariant
+      - prelude
+  type-equality:
+    type: git
+    url: https://github.com/purescript/purescript-type-equality.git
+    rev: 0525b7d39e0fbd81b4209518139fb8ab02695774
+    dependencies: []
+  unfoldable:
+    type: git
+    url: https://github.com/purescript/purescript-unfoldable.git
+    rev: 493dfe04ed590e20d8f69079df2f58486882748d
+    dependencies:
+      - foldable-traversable
+      - maybe
+      - partial
+      - prelude
+      - tuples
+  unsafe-coerce:
+    type: git
+    url: https://github.com/purescript/purescript-unsafe-coerce.git
+    rev: ab956f82e66e633f647fb3098e8ddd3ec58d689f
+    dependencies: []

--- a/exercises/chapter5/spago.lock
+++ b/exercises/chapter5/spago.lock
@@ -70,3452 +70,462 @@ workspace:
         - unsafe-coerce
   package_set:
     address:
-      url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
-    compiler: ">=0.15.0 <0.16.0"
+      registry: 10.0.0
+    compiler: ">=0.15.4 <0.16.0"
     content:
-      ace:
-        repo: https://github.com/purescript-contrib/purescript-ace.git
-        version: v9.0.0
-        dependencies:
-          - arrays
-          - effect
-          - foreign
-          - nullable
-          - prelude
-          - web-html
-          - web-uievents
-      aff:
-        repo: https://github.com/purescript-contrib/purescript-aff.git
-        version: v7.0.0
-        dependencies:
-          - datetime
-          - effect
-          - exceptions
-          - functions
-          - parallel
-          - transformers
-          - unsafe-coerce
-      aff-bus:
-        repo: https://github.com/purescript-contrib/purescript-aff-bus.git
-        version: v6.0.0
-        dependencies:
-          - aff
-          - avar
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - lists
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-      aff-coroutines:
-        repo: https://github.com/purescript-contrib/purescript-aff-coroutines.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - avar
-          - coroutines
-          - effect
-      aff-promise:
-        repo: https://github.com/nwolverson/purescript-aff-promise.git
-        version: v4.0.0
-        dependencies:
-          - aff
-          - foreign
-      aff-retry:
-        repo: https://github.com/Unisay/purescript-aff-retry.git
-        version: v2.0.0
-        dependencies:
-          - aff
-          - arrays
-          - datetime
-          - effect
-          - either
-          - exceptions
-          - integers
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - random
-          - transformers
-      affjax:
-        repo: https://github.com/purescript-contrib/purescript-affjax.git
-        version: v13.0.0
-        dependencies:
-          - aff
-          - argonaut-core
-          - arraybuffer-types
-          - foreign
-          - form-urlencoded
-          - http-methods
-          - integers
-          - media-types
-          - nullable
-          - refs
-          - unsafe-coerce
-          - web-xhr
-      affjax-node:
-        repo: https://github.com/purescript-contrib/purescript-affjax-node.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - affjax
-          - either
-          - maybe
-          - prelude
-      affjax-web:
-        repo: https://github.com/purescript-contrib/purescript-affjax-web.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - affjax
-          - either
-          - maybe
-          - prelude
-      ansi:
-        repo: https://github.com/hdgarrood/purescript-ansi.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - lists
-          - strings
-      argonaut:
-        repo: https://github.com/purescript-contrib/purescript-argonaut.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - argonaut-traversals
-      argonaut-codecs:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-codecs.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-core
-          - arrays
-          - effect
-          - foreign-object
-          - identity
-          - integers
-          - maybe
-          - nonempty
-          - ordered-collections
-          - prelude
-          - record
-      argonaut-core:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-core.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - foreign-object
-          - functions
-          - gen
-          - maybe
-          - nonempty
-          - prelude
-          - strings
-          - tailrec
-      argonaut-generic:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-generic.git
-        version: v8.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - prelude
-          - record
-      argonaut-traversals:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-traversals.git
-        version: v10.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - profunctor-lenses
-      argparse-basic:
-        repo: https://github.com/natefaubion/purescript-argparse-basic.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - record
-          - strings
-          - tuples
-          - unfoldable
-      arraybuffer:
-        repo: https://github.com/purescript-contrib/purescript-arraybuffer.git
-        version: v13.0.0
-        dependencies:
-          - arraybuffer-types
-          - arrays
-          - effect
-          - float32
-          - functions
-          - gen
-          - maybe
-          - nullable
-          - prelude
-          - tailrec
-          - uint
-          - unfoldable
-      arraybuffer-builder:
-        repo: https://github.com/jamesdbrock/purescript-arraybuffer-builder.git
-        version: v3.0.1
-        dependencies:
-          - arraybuffer
-          - arraybuffer-types
-          - effect
-          - float32
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - transformers
-          - uint
-      arraybuffer-types:
-        repo: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
-        version: v3.0.2
-        dependencies: []
-      arrays:
-        repo: https://github.com/purescript/purescript-arrays.git
-        version: v7.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - foldable-traversable
-          - maybe
-          - nonempty
-          - partial
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - unfoldable
-          - unsafe-coerce
-      arrays-zipper:
-        repo: https://github.com/JordanMartinez/purescript-arrays-zipper.git
-        version: v2.0.1
-        dependencies:
-          - arrays
-          - control
-          - quickcheck
-      ask:
-        repo: https://github.com/Mateiadrielrafael/purescript-ask.git
-        version: v1.0.0
-        dependencies:
-          - unsafe-coerce
-      assert:
-        repo: https://github.com/purescript/purescript-assert.git
-        version: v6.0.0
-        dependencies:
-          - console
-          - effect
-          - prelude
-      avar:
-        repo: https://github.com/purescript-contrib/purescript-avar.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - exceptions
-          - functions
-          - maybe
-      b64:
-        repo: https://github.com/menelaos/purescript-b64.git
-        version: v0.0.8
-        dependencies:
-          - arraybuffer-types
-          - either
-          - encoding
-          - enums
-          - exceptions
-          - functions
-          - partial
-          - prelude
-          - strings
-      barlow-lens:
-        repo: https://github.com/sigma-andex/purescript-barlow-lens.git
-        version: v0.9.0
-        dependencies:
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - profunctor-lenses
-          - tuples
-          - typelevel-prelude
-      bifunctors:
-        repo: https://github.com/purescript/purescript-bifunctors.git
-        version: v6.0.0
-        dependencies:
-          - const
-          - either
-          - newtype
-          - prelude
-          - tuples
-      bigints:
-        repo: https://github.com/sharkdp/purescript-bigints.git
-        version: v7.0.1
-        dependencies:
-          - integers
-          - maybe
-          - strings
-      bower-json:
-        repo: https://github.com/klntsky/purescript-bower-json.git
-        version: v3.0.0
-        dependencies:
-          - argonaut-codecs
-          - arrays
-          - either
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - newtype
-          - prelude
-          - tuples
-      call-by-name:
-        repo: https://github.com/natefaubion/purescript-call-by-name.git
-        version: v4.0.1
-        dependencies:
-          - control
-          - either
-          - lazy
-          - maybe
-          - unsafe-coerce
-      canvas:
-        repo: https://github.com/purescript-web/purescript-canvas.git
-        version: v6.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - exceptions
-          - functions
-          - maybe
-      canvas-action:
-        repo: https://github.com/artemisSystem/purescript-canvas-action.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - arrays
-          - canvas
-          - colors
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - maybe
-          - numbers
-          - polymorphic-vectors
-          - prelude
-          - refs
-          - run
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-html
-      cartesian:
-        repo: https://github.com/Ebmtranceboy/purescript-cartesian.git
-        version: v1.0.6
-        dependencies:
-          - console
-          - effect
-          - integers
-          - psci-support
-      catenable-lists:
-        repo: https://github.com/purescript/purescript-catenable-lists.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - lists
-          - maybe
-          - prelude
-          - tuples
-          - unfoldable
-      channel:
-        repo: https://github.com/ConnorDillon/purescript-channel.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - assert
-          - avar
-          - console
-          - contravariant
-          - control
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - lazy
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      checked-exceptions:
-        repo: https://github.com/natefaubion/purescript-checked-exceptions.git
-        version: v3.1.1
-        dependencies:
-          - prelude
-          - transformers
-          - variant
-      codec:
-        repo: https://github.com/garyb/purescript-codec.git
-        version: v5.0.0
-        dependencies:
-          - profunctor
-          - transformers
-      codec-argonaut:
-        repo: https://github.com/garyb/purescript-codec-argonaut.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-core
-          - codec
-          - ordered-collections
-          - type-equality
-          - variant
-      colors:
-        repo: https://github.com/purescript-contrib/purescript-colors.git
-        version: v7.0.1
-        dependencies:
-          - arrays
-          - integers
-          - lists
-          - numbers
-          - partial
-          - strings
-      concurrent-queues:
-        repo: https://github.com/purescript-contrib/purescript-concurrent-queues.git
-        version: v3.0.0
-        dependencies:
-          - aff
-          - avar
-          - effect
-      console:
-        repo: https://github.com/purescript/purescript-console.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - prelude
-      const:
-        repo: https://github.com/purescript/purescript-const.git
-        version: v6.0.0
-        dependencies:
-          - invariant
-          - newtype
-          - prelude
-      contravariant:
-        repo: https://github.com/purescript/purescript-contravariant.git
-        version: v6.0.0
-        dependencies:
-          - const
-          - either
-          - newtype
-          - prelude
-          - tuples
-      control:
-        repo: https://github.com/purescript/purescript-control.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      convertable-options:
-        repo: https://github.com/natefaubion/purescript-convertable-options.git
-        version: v1.0.0
-        dependencies:
-          - console
-          - effect
-          - maybe
-          - record
-      coroutines:
-        repo: https://github.com/purescript-contrib/purescript-coroutines.git
-        version: v7.0.0
-        dependencies:
-          - freet
-          - parallel
-          - profunctor
-      css:
-        repo: https://github.com/purescript-contrib/purescript-css.git
-        version: v6.0.0
-        dependencies:
-          - colors
-          - console
-          - effect
-          - nonempty
-          - profunctor
-          - strings
-          - these
-          - transformers
-      datetime:
-        repo: https://github.com/purescript/purescript-datetime.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - either
-          - enums
-          - foldable-traversable
-          - functions
-          - gen
-          - integers
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - ordered-collections
-          - partial
-          - prelude
-          - tuples
-      datetime-parsing:
-        repo: https://github.com/flounders/purescript-datetime-parsing.git
-        version: v0.2.0
-        dependencies:
-          - arrays
-          - datetime
-          - either
-          - enums
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - numbers
-          - parsing
-          - prelude
-          - strings
-          - unicode
-      debug:
-        repo: https://github.com/garyb/purescript-debug.git
-        version: v6.0.0
-        dependencies:
-          - functions
-          - prelude
-      decimals:
-        repo: https://github.com/sharkdp/purescript-decimals.git
-        version: v7.0.0
-        dependencies:
-          - maybe
-      dissect:
-        repo: https://github.com/PureFunctor/purescript-dissect.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - foreign-object
-          - functors
-          - newtype
-          - partial
-          - prelude
-          - tailrec
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - variant
-      distributive:
-        repo: https://github.com/purescript/purescript-distributive.git
-        version: v6.0.0
-        dependencies:
-          - identity
-          - newtype
-          - prelude
-          - tuples
-          - type-equality
-      dodo-printer:
-        repo: https://github.com/natefaubion/purescript-dodo-printer.git
-        version: v2.2.0
-        dependencies:
-          - aff
-          - ansi
-          - avar
-          - console
-          - effect
-          - foldable-traversable
-          - lists
-          - maybe
-          - minibench
-          - node-child-process
-          - node-fs-aff
-          - node-process
-          - psci-support
-          - strings
-      dom-indexed:
-        repo: https://github.com/purescript-halogen/purescript-dom-indexed.git
-        version: v11.0.0
-        dependencies:
-          - media-types
-          - prelude
-          - web-clipboard
-          - web-pointerevents
-          - web-touchevents
-      droplet:
-        repo: https://github.com/easafe/purescript-droplet.git
-        version: v0.4.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - bigints
-          - datetime
-          - debug
-          - effect
-          - either
-          - enums
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - integers
-          - maybe
-          - newtype
-          - nullable
-          - ordered-collections
-          - partial
-          - prelude
-          - profunctor
-          - record
-          - spec
-          - strings
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-      dynamic-buffer:
-        repo: https://github.com/kritzcreek/purescript-dynamic-buffer.git
-        version: v3.0.1
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - refs
-      effect:
-        repo: https://github.com/purescript/purescript-effect.git
-        version: v4.0.0
-        dependencies:
-          - prelude
-      either:
-        repo: https://github.com/purescript/purescript-either.git
-        version: v6.1.0
-        dependencies:
-          - control
-          - invariant
-          - maybe
-          - prelude
-      elmish:
-        repo: https://github.com/collegevine/purescript-elmish.git
-        version: v0.8.1
-        dependencies:
-          - aff
-          - argonaut-core
-          - arrays
-          - bifunctors
-          - console
-          - debug
-          - effect
-          - either
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - functions
-          - integers
-          - js-date
-          - maybe
-          - nullable
-          - partial
-          - prelude
-          - refs
-          - typelevel-prelude
-          - undefined-is-not-a-problem
-          - unsafe-coerce
-          - web-dom
-          - web-html
-      elmish-enzyme:
-        repo: https://github.com/collegevine/purescript-elmish-enzyme.git
-        version: v0.1.1
-        dependencies:
-          - aff
-          - aff-promise
-          - arrays
-          - console
-          - debug
-          - effect
-          - elmish
-          - foldable-traversable
-          - foreign
-          - functions
-          - prelude
-          - transformers
-          - unsafe-coerce
-      elmish-hooks:
-        repo: https://github.com/collegevine/purescript-elmish-hooks.git
-        version: v0.8.2
-        dependencies:
-          - aff
-          - debug
-          - elmish
-          - maybe
-          - prelude
-          - tuples
-          - undefined-is-not-a-problem
-      elmish-html:
-        repo: https://github.com/collegevine/purescript-elmish-html.git
-        version: v0.7.1
-        dependencies:
-          - effect
-          - elmish
-          - foreign
-          - foreign-object
-          - prelude
-          - record
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-html
-      email-validate:
-        repo: https://github.com/cdepillabout/purescript-email-validate.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - string-parsers
-          - transformers
-      encoding:
-        repo: https://github.com/menelaos/purescript-encoding.git
-        version: v0.0.8
-        dependencies:
-          - arraybuffer-types
-          - either
-          - exceptions
-          - functions
-          - prelude
-      enums:
-        repo: https://github.com/purescript/purescript-enums.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - either
-          - gen
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tuples
-          - unfoldable
-      exceptions:
-        repo: https://github.com/purescript/purescript-exceptions.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - either
-          - maybe
-          - prelude
-      exists:
-        repo: https://github.com/purescript/purescript-exists.git
-        version: v6.0.0
-        dependencies:
-          - unsafe-coerce
-      exitcodes:
-        repo: https://github.com/Risto-Stevcev/purescript-exitcodes.git
-        version: v4.0.0
-        dependencies:
-          - enums
-      expect-inferred:
-        repo: https://github.com/justinwoo/purescript-expect-inferred.git
-        version: v3.0.0
-        dependencies:
-          - prelude
-          - typelevel-prelude
-      fast-vect:
-        repo: https://github.com/sigma-andex/purescript-fast-vect.git
-        version: v0.7.0
-        dependencies:
-          - arrays
-          - filterable
-          - foldable-traversable
-          - lists
-          - maybe
-          - ordered-collections
-          - prelude
-          - profunctor
-          - tuples
-          - unfoldable
-      filterable:
-        repo: https://github.com/purescript/purescript-filterable.git
-        version: v5.0.0
-        dependencies:
-          - arrays
-          - either
-          - foldable-traversable
-          - identity
-          - lists
-          - ordered-collections
-      fixed-points:
-        repo: https://github.com/purescript-contrib/purescript-fixed-points.git
-        version: v7.0.0
-        dependencies:
-          - exists
-          - newtype
-          - prelude
-          - transformers
-      fixed-precision:
-        repo: https://github.com/lumihq/purescript-fixed-precision.git
-        version: v5.0.0
-        dependencies:
-          - arrays
-          - bigints
-          - control
-          - integers
-          - maybe
-          - numbers
-          - partial
-          - prelude
-          - strings
-      flame:
-        repo: https://github.com/easafe/purescript-flame.git
-        version: v1.2.0
-        dependencies:
-          - aff
-          - argonaut-codecs
-          - argonaut-core
-          - argonaut-generic
-          - arrays
-          - bifunctors
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - maybe
-          - newtype
-          - nullable
-          - partial
-          - prelude
-          - random
-          - refs
-          - spec
-          - strings
-          - tuples
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-html
-          - web-uievents
-      float32:
-        repo: https://github.com/purescript-contrib/purescript-float32.git
-        version: v2.0.0
-        dependencies:
-          - gen
-          - maybe
-          - prelude
-      foldable-traversable:
-        repo: https://github.com/purescript/purescript-foldable-traversable.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - const
-          - control
-          - either
-          - functors
-          - identity
-          - maybe
-          - newtype
-          - orders
-          - prelude
-          - tuples
-      foreign:
-        repo: https://github.com/purescript/purescript-foreign.git
-        version: v7.0.0
-        dependencies:
-          - either
-          - functions
-          - identity
-          - integers
-          - lists
-          - maybe
-          - prelude
-          - strings
-          - transformers
-      foreign-object:
-        repo: https://github.com/purescript/purescript-foreign-object.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - functions
-          - gen
-          - lists
-          - maybe
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - typelevel-prelude
-          - unfoldable
-      foreign-readwrite:
-        repo: https://github.com/artemisSystem/purescript-foreign-readwrite.git
-        version: v3.0.0
-        dependencies:
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - record
-          - safe-coerce
-          - transformers
-          - unsafe-coerce
-      fork:
-        repo: https://github.com/purescript-contrib/purescript-fork.git
-        version: v6.0.0
-        dependencies:
-          - aff
-      form-urlencoded:
-        repo: https://github.com/purescript-contrib/purescript-form-urlencoded.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - js-uri
-          - maybe
-          - newtype
-          - prelude
-          - strings
-          - tuples
-      formatters:
-        repo: https://github.com/purescript-contrib/purescript-formatters.git
-        version: v7.0.0
-        dependencies:
-          - datetime
-          - fixed-points
-          - lists
-          - numbers
-          - parsing
-          - prelude
-          - transformers
-      free:
-        repo: https://github.com/purescript/purescript-free.git
-        version: v7.0.0
-        dependencies:
-          - catenable-lists
-          - control
-          - distributive
-          - either
-          - exists
-          - foldable-traversable
-          - invariant
-          - lazy
-          - maybe
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-      freeap:
-        repo: https://github.com/ethul/purescript-freeap.git
-        version: v7.0.0
-        dependencies:
-          - const
-          - exists
-          - gen
-          - lists
-      freet:
-        repo: https://github.com/purescript-contrib/purescript-freet.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - bifunctors
-          - effect
-          - either
-          - exists
-          - free
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      functions:
-        repo: https://github.com/purescript/purescript-functions.git
-        version: v6.0.0
-        dependencies:
-          - prelude
-      functors:
-        repo: https://github.com/purescript/purescript-functors.git
-        version: v5.0.0
-        dependencies:
-          - bifunctors
-          - const
-          - contravariant
-          - control
-          - distributive
-          - either
-          - invariant
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - tuples
-          - unsafe-coerce
-      fuzzy:
-        repo: https://github.com/citizennet/purescript-fuzzy.git
-        version: v0.4.0
-        dependencies:
-          - foldable-traversable
-          - foreign-object
-          - newtype
-          - ordered-collections
-          - prelude
-          - rationals
-          - strings
-          - tuples
-      gen:
-        repo: https://github.com/purescript/purescript-gen.git
-        version: v4.0.0
-        dependencies:
-          - either
-          - foldable-traversable
-          - identity
-          - maybe
-          - newtype
-          - nonempty
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      generate-values:
-        repo: https://github.com/jordanmartinez/purescript-generate-values.git
-        version: v1.0.1
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - enums
-          - foldable-traversable
-          - gen
-          - identity
-          - integers
-          - lcg
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - partial
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      geometry-plane:
-        repo: https://github.com/Ebmtranceboy/purescript-geometry-plane.git
-        version: v1.0.3
-        dependencies:
-          - console
-          - effect
-          - psci-support
-          - sparse-polynomials
-      github-actions-toolkit:
-        repo: https://github.com/purescript-contrib/purescript-github-actions-toolkit.git
-        version: v0.5.0
-        dependencies:
-          - aff
-          - aff-promise
-          - effect
-          - foreign-object
-          - node-buffer
-          - node-path
-          - node-streams
-          - nullable
-          - transformers
-      graphs:
-        repo: https://github.com/purescript/purescript-graphs.git
-        version: v8.0.0
-        dependencies:
-          - catenable-lists
-          - ordered-collections
-      group:
-        repo: https://github.com/morganthomas/purescript-group.git
-        version: v4.1.1
-        dependencies:
-          - lists
-      halogen:
-        repo: https://github.com/purescript-halogen/purescript-halogen.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - avar
-          - console
-          - const
-          - dom-indexed
-          - effect
-          - foreign
-          - fork
-          - free
-          - freeap
-          - halogen-subscriptions
-          - halogen-vdom
-          - media-types
-          - nullable
-          - ordered-collections
-          - parallel
-          - profunctor
-          - transformers
-          - unsafe-coerce
-          - unsafe-reference
-          - web-file
-          - web-uievents
-      halogen-css:
-        repo: https://github.com/purescript-halogen/purescript-halogen-css.git
-        version: v10.0.0
-        dependencies:
-          - css
-          - halogen
-      halogen-formless:
-        repo: https://github.com/thomashoneyman/purescript-halogen-formless.git
-        version: v4.0.0
-        dependencies:
-          - convertable-options
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - halogen
-          - heterogeneous
-          - maybe
-          - prelude
-          - record
-          - safe-coerce
-          - type-equality
-          - unsafe-coerce
-          - unsafe-reference
-          - variant
-          - web-events
-          - web-uievents
-      halogen-hooks:
-        repo: https://github.com/thomashoneyman/purescript-halogen-hooks.git
-        version: v0.6.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - effect
-          - exceptions
-          - foldable-traversable
-          - foreign-object
-          - free
-          - freeap
-          - halogen
-          - halogen-subscriptions
-          - maybe
-          - newtype
-          - ordered-collections
-          - parallel
-          - partial
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-          - unsafe-reference
-          - web-dom
-          - web-html
-      halogen-hooks-extra:
-        repo: https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git
-        version: v0.9.0
-        dependencies:
-          - halogen-hooks
-      halogen-store:
-        repo: https://github.com/thomashoneyman/purescript-halogen-store.git
-        version: v0.5.0
-        dependencies:
-          - aff
-          - distributive
-          - effect
-          - fork
-          - halogen
-          - halogen-hooks
-          - halogen-subscriptions
-          - maybe
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-reference
-      halogen-storybook:
-        repo: https://github.com/rnons/purescript-halogen-storybook.git
-        version: v2.0.0
-        dependencies:
-          - foreign-object
-          - halogen
-          - prelude
-          - routing
-      halogen-subscriptions:
-        repo: https://github.com/purescript-halogen/purescript-halogen-subscriptions.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - effect
-          - foldable-traversable
-          - functors
-          - refs
-          - safe-coerce
-          - unsafe-reference
-      halogen-svg-elems:
-        repo: https://github.com/JordanMartinez/purescript-halogen-svg-elems.git
-        version: v6.0.0
-        dependencies:
-          - halogen
-      halogen-vdom:
-        repo: https://github.com/purescript-halogen/purescript-halogen-vdom.git
-        version: v8.0.0
-        dependencies:
-          - bifunctors
-          - effect
-          - foreign
-          - foreign-object
-          - maybe
-          - prelude
-          - refs
-          - tuples
-          - unsafe-coerce
-          - web-html
-      halogen-vdom-string-renderer:
-        repo: https://github.com/purescript-halogen/purescript-halogen-vdom-string-renderer.git
-        version: v0.5.0
-        dependencies:
-          - foreign
-          - halogen-vdom
-          - ordered-collections
-          - prelude
-      heckin:
-        repo: https://github.com/maxdeviant/purescript-heckin.git
-        version: v2.0.1
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - maybe
-          - prelude
-          - strings
-          - transformers
-          - tuples
-          - unicode
-      heterogeneous:
-        repo: https://github.com/natefaubion/purescript-heterogeneous.git
-        version: v0.6.0
-        dependencies:
-          - either
-          - functors
-          - prelude
-          - record
-          - tuples
-          - variant
-      heterogeneous-extrablatt:
-        repo: https://github.com/sigma-andex/purescript-heterogeneous-extrablatt.git
-        version: v0.2.1
-        dependencies:
-          - heterogeneous
-          - prelude
-          - record
-      http-methods:
-        repo: https://github.com/purescript-contrib/purescript-http-methods.git
-        version: v6.0.0
-        dependencies:
-          - either
-          - prelude
-          - strings
-      httpure:
-        repo: https://github.com/citizennet/purescript-httpure.git
-        version: v0.15.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - js-uri
-          - maybe
-          - newtype
-          - node-buffer
-          - node-fs
-          - node-http
-          - node-streams
-          - options
-          - ordered-collections
-          - prelude
-          - refs
-          - strings
-          - tuples
-          - type-equality
-      httpurple:
-        repo: https://github.com/sigma-andex/purescript-httpurple.git
-        version: v1.3.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - js-uri
-          - justifill
-          - maybe
-          - newtype
-          - node-buffer
-          - node-fs
-          - node-http
-          - node-net
-          - node-process
-          - node-streams
-          - options
-          - ordered-collections
-          - posix-types
-          - prelude
-          - profunctor
-          - record
-          - refs
-          - routing-duplex
-          - strings
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-      httpurple-argonaut:
-        repo: https://github.com/sigma-andex/purescript-httpurple-argonaut.git
-        version: v1.0.1
-        dependencies:
-          - argonaut
-          - console
-          - effect
-          - either
-          - httpurple
-          - prelude
-      httpurple-yoga-json:
-        repo: https://github.com/sigma-andex/purescript-httpurple-yoga-json.git
-        version: v1.0.0
-        dependencies:
-          - console
-          - effect
-          - either
-          - foreign
-          - httpurple
-          - lists
-          - prelude
-          - yoga-json
-      identity:
-        repo: https://github.com/purescript/purescript-identity.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - invariant
-          - newtype
-          - prelude
-      indexed-monad:
-        repo: https://github.com/garyb/purescript-indexed-monad.git
-        version: v2.1.0
-        dependencies:
-          - control
-          - newtype
-      int64:
-        repo: https://github.com/purescript-contrib/purescript-int64.git
-        version: v2.0.0
-        dependencies:
-          - effect
-          - foreign
-          - functions
-          - integers
-          - maybe
-          - nullable
-          - prelude
-          - quickcheck
-      integers:
-        repo: https://github.com/purescript/purescript-integers.git
-        version: v6.0.0
-        dependencies:
-          - maybe
-          - numbers
-          - prelude
-      interpolate:
-        repo: https://github.com/jordanmartinez/purescript-interpolate.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-      invariant:
-        repo: https://github.com/purescript/purescript-invariant.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - prelude
-      js-date:
-        repo: https://github.com/purescript-contrib/purescript-js-date.git
-        version: v8.0.0
-        dependencies:
-          - datetime
-          - effect
-          - exceptions
-          - foreign
-          - integers
-          - now
-      js-fileio:
-        repo: https://github.com/newlandsvalley/purescript-js-fileio.git
-        version: v3.0.0
-        dependencies:
-          - aff
-          - effect
-          - prelude
-      js-timers:
-        repo: https://github.com/purescript-contrib/purescript-js-timers.git
-        version: v6.1.0
-        dependencies:
-          - effect
-      js-uri:
-        repo: https://github.com/purescript-contrib/purescript-js-uri.git
-        version: v3.0.0
-        dependencies:
-          - functions
-          - maybe
-      justifill:
-        repo: https://github.com/i-am-the-slime/purescript-justifill.git
-        version: v0.5.0
-        dependencies:
-          - maybe
-          - prelude
-          - record
-          - typelevel-prelude
-      jwt:
-        repo: https://github.com/menelaos/purescript-jwt.git
-        version: v0.0.9
-        dependencies:
-          - argonaut-core
-          - arrays
-          - b64
-          - either
-          - exceptions
-          - prelude
-          - profunctor-lenses
-          - strings
-      language-cst-parser:
-        repo: https://github.com/natefaubion/purescript-language-cst-parser.git
-        version: v0.12.0
-        dependencies:
-          - arrays
-          - const
-          - control
-          - either
-          - foldable-traversable
-          - free
-          - functions
-          - functors
-          - identity
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - ordered-collections
-          - partial
-          - prelude
-          - st
-          - strings
-          - transformers
-          - tuples
-          - typelevel-prelude
-          - unfoldable
-          - unsafe-coerce
-      lazy:
-        repo: https://github.com/purescript/purescript-lazy.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - invariant
-          - prelude
-      lcg:
-        repo: https://github.com/purescript/purescript-lcg.git
-        version: v4.0.0
-        dependencies:
-          - effect
-          - integers
-          - maybe
-          - partial
-          - prelude
-          - random
-      leibniz:
-        repo: https://github.com/paf31/purescript-leibniz.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-          - unsafe-coerce
-      linalg:
-        repo: https://github.com/gbagan/purescript-linalg.git
-        version: v5.1.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - functions
-          - maybe
-          - prelude
-          - tuples
-      lists:
-        repo: https://github.com/purescript/purescript-lists.git
-        version: v7.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - foldable-traversable
-          - lazy
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      logging:
-        repo: https://github.com/rightfold/purescript-logging.git
-        version: v3.0.0
-        dependencies:
-          - console
-          - contravariant
-          - effect
-          - either
-          - prelude
-          - transformers
-          - tuples
-      machines:
-        repo: https://github.com/purescript-contrib/purescript-machines.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - lists
-          - maybe
-          - prelude
-          - profunctor
-          - tuples
-          - unfoldable
-      matrices:
-        repo: https://github.com/kRITZCREEK/purescript-matrices.git
-        version: v5.0.1
-        dependencies:
-          - arrays
-          - strings
-      matryoshka:
-        repo: https://github.com/purescript-contrib/purescript-matryoshka.git
-        version: v1.0.0
-        dependencies:
-          - fixed-points
-          - free
-          - prelude
-          - profunctor
-          - transformers
-      maybe:
-        repo: https://github.com/purescript/purescript-maybe.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - invariant
-          - newtype
-          - prelude
-      media-types:
-        repo: https://github.com/purescript-contrib/purescript-media-types.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      metadata:
-        repo: https://github.com/purescript/purescript-metadata.git
-        version: v0.15.0
-        dependencies: []
-      midi:
-        repo: https://github.com/newlandsvalley/purescript-midi.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - ordered-collections
-          - prelude
-          - signal
-          - string-parsers
-          - strings
-          - tuples
-          - unfoldable
-      minibench:
-        repo: https://github.com/purescript/purescript-minibench.git
-        version: v4.0.0
-        dependencies:
-          - console
-          - effect
-          - integers
-          - numbers
-          - partial
-          - prelude
-          - refs
-      mmorph:
-        repo: https://github.com/Thimoteus/purescript-mmorph.git
-        version: v7.0.0
-        dependencies:
-          - free
-          - functors
-          - transformers
-      monad-control:
-        repo: https://github.com/athanclark/purescript-monad-control.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - freet
-          - identity
-          - lists
-      monad-logger:
-        repo: https://github.com/cprussin/purescript-monad-logger.git
-        version: v1.3.1
-        dependencies:
-          - aff
-          - ansi
-          - argonaut
-          - arrays
-          - console
-          - control
-          - effect
-          - foldable-traversable
-          - foreign-object
-          - integers
-          - js-date
-          - maybe
-          - newtype
-          - ordered-collections
-          - prelude
-          - strings
-          - transformers
-          - tuples
-      monad-loops:
-        repo: https://github.com/mlang/purescript-monad-loops.git
-        version: v0.5.0
-        dependencies:
-          - lists
-          - maybe
-          - prelude
-          - tailrec
-          - tuples
-      monad-unlift:
-        repo: https://github.com/athanclark/purescript-monad-unlift.git
-        version: v1.0.1
-        dependencies:
-          - monad-control
-      monoidal:
-        repo: https://github.com/mcneissue/purescript-monoidal.git
-        version: v0.16.0
-        dependencies:
-          - either
-          - profunctor
-          - these
-          - tuples
-      morello:
-        repo: https://github.com/sigma-andex/purescript-morello.git
-        version: v0.3.2
-        dependencies:
-          - arrays
-          - barlow-lens
-          - foldable-traversable
-          - heterogeneous
-          - heterogeneous-extrablatt
-          - newtype
-          - prelude
-          - profunctor
-          - profunctor-lenses
-          - record
-          - tuples
-          - typelevel-prelude
-          - validation
-      motsunabe:
-        repo: https://github.com/justinwoo/purescript-motsunabe.git
-        version: v2.0.0
-        dependencies:
-          - lists
-          - strings
-      nano-id:
-        repo: https://github.com/eikooc/nano-id.git
-        version: v1.1.0
-        dependencies:
-          - aff
-          - effect
-          - lists
-          - maybe
-          - prelude
-          - random
-          - spec
-          - strings
-          - stringutils
-      naturals:
-        repo: https://github.com/LiamGoodacre/purescript-naturals.git
-        version: v3.0.0
-        dependencies:
-          - enums
-          - maybe
-          - prelude
-      nested-functor:
-        repo: https://github.com/acple/purescript-nested-functor.git
-        version: v0.2.1
-        dependencies:
-          - prelude
-          - type-equality
-      newtype:
-        repo: https://github.com/purescript/purescript-newtype.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-          - safe-coerce
-      node-buffer:
-        repo: https://github.com/purescript-node/purescript-node-buffer.git
-        version: v8.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - maybe
-          - st
-          - unsafe-coerce
-      node-buffer-blob:
-        repo: https://github.com/purescript-node/purescript-node-buffer-blob.git
-        version: v1.0.0
-        dependencies:
-          - aff-promise
-          - arraybuffer-types
-          - arrays
-          - console
-          - effect
-          - maybe
-          - media-types
-          - newtype
-          - node-buffer
-          - nullable
-          - prelude
-          - web-streams
-      node-child-process:
-        repo: https://github.com/purescript-node/purescript-node-child-process.git
-        version: v9.0.0
-        dependencies:
-          - exceptions
-          - foreign
-          - foreign-object
-          - functions
-          - node-fs
-          - node-streams
-          - nullable
-          - posix-types
-          - unsafe-coerce
-      node-fs:
-        repo: https://github.com/purescript-node/purescript-node-fs.git
-        version: v8.0.0
-        dependencies:
-          - datetime
-          - effect
-          - either
-          - enums
-          - exceptions
-          - functions
-          - integers
-          - js-date
-          - maybe
-          - node-buffer
-          - node-path
-          - node-streams
-          - nullable
-          - partial
-          - prelude
-          - strings
-          - unsafe-coerce
-      node-fs-aff:
-        repo: https://github.com/purescript-node/purescript-node-fs-aff.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - either
-          - node-fs
-          - node-path
-      node-http:
-        repo: https://github.com/purescript-node/purescript-node-http.git
-        version: v8.0.0
-        dependencies:
-          - arraybuffer-types
-          - contravariant
-          - effect
-          - foreign
-          - foreign-object
-          - maybe
-          - node-buffer
-          - node-net
-          - node-streams
-          - node-url
-          - nullable
-          - options
-          - prelude
-          - unsafe-coerce
-      node-net:
-        repo: https://github.com/purescript-node/purescript-node-net.git
-        version: v4.0.0
-        dependencies:
-          - effect
-          - either
-          - exceptions
-          - foreign
-          - maybe
-          - node-buffer
-          - node-fs
-          - nullable
-          - options
-          - prelude
-          - transformers
-      node-path:
-        repo: https://github.com/purescript-node/purescript-node-path.git
-        version: v5.0.0
-        dependencies:
-          - effect
-      node-process:
-        repo: https://github.com/purescript-node/purescript-node-process.git
-        version: v10.0.0
-        dependencies:
-          - effect
-          - foreign-object
-          - maybe
-          - node-streams
-          - posix-types
-          - prelude
-          - unsafe-coerce
-      node-readline:
-        repo: https://github.com/purescript-node/purescript-node-readline.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - foreign
-          - node-process
-          - node-streams
-          - options
-          - prelude
-      node-streams:
-        repo: https://github.com/purescript-node/purescript-node-streams.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - either
-          - exceptions
-          - node-buffer
-          - nullable
-          - prelude
-      node-streams-aff:
-        repo: https://github.com/jamesdbrock/purescript-node-streams-aff.git
-        version: v2.0.0
-        dependencies:
-          - aff
-          - arrays
-          - effect
-          - either
-          - exceptions
-          - maybe
-          - node-buffer
-          - node-streams
-          - prelude
-          - st
-          - tuples
-      node-url:
-        repo: https://github.com/purescript-node/purescript-node-url.git
-        version: v6.0.0
-        dependencies:
-          - nullable
-      nonempty:
-        repo: https://github.com/purescript/purescript-nonempty.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - maybe
-          - prelude
-          - tuples
-          - unfoldable
-      now:
-        repo: https://github.com/purescript-contrib/purescript-now.git
-        version: v6.0.0
-        dependencies:
-          - datetime
-          - effect
-      npm-package-json:
-        repo: https://github.com/maxdeviant/purescript-npm-package-json.git
-        version: v2.0.0
-        dependencies:
-          - argonaut
-          - control
-          - either
-          - foreign-object
-          - maybe
-          - ordered-collections
-          - prelude
-      nullable:
-        repo: https://github.com/purescript-contrib/purescript-nullable.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - functions
-          - maybe
-      numbers:
-        repo: https://github.com/purescript/purescript-numbers.git
-        version: v9.0.0
-        dependencies:
-          - functions
-          - maybe
-      open-folds:
-        repo: https://github.com/purescript-open-community/purescript-open-folds.git
-        version: v6.3.0
-        dependencies:
-          - bifunctors
-          - console
-          - control
-          - distributive
-          - effect
-          - either
-          - foldable-traversable
-          - identity
-          - invariant
-          - maybe
-          - newtype
-          - ordered-collections
-          - prelude
-          - profunctor
-          - psci-support
-          - tuples
-      open-memoize:
-        repo: https://github.com/purescript-open-community/purescript-open-memoize.git
-        version: v6.1.0
-        dependencies:
-          - console
-          - effect
-          - either
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - psci-support
-          - strings
-          - tuples
-      open-pairing:
-        repo: https://github.com/purescript-open-community/purescript-open-pairing.git
-        version: v6.1.0
-        dependencies:
-          - console
-          - control
-          - effect
-          - either
-          - free
-          - functors
-          - identity
-          - newtype
-          - prelude
-          - psci-support
-          - transformers
-          - tuples
-      options:
-        repo: https://github.com/purescript-contrib/purescript-options.git
-        version: v7.0.0
-        dependencies:
-          - contravariant
-          - foreign
-          - foreign-object
-          - maybe
-          - tuples
-      optparse:
-        repo: https://github.com/f-o-a-m/purescript-optparse.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - control
-          - effect
-          - either
-          - enums
-          - exists
-          - exitcodes
-          - foldable-traversable
-          - free
-          - gen
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - newtype
-          - node-buffer
-          - node-process
-          - node-streams
-          - nonempty
-          - numbers
-          - open-memoize
-          - partial
-          - prelude
-          - quickcheck
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-      ordered-collections:
-        repo: https://github.com/purescript/purescript-ordered-collections.git
-        version: v3.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - gen
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - unfoldable
-      ordered-set:
-        repo: https://github.com/flip111/purescript-ordered-set.git
-        version: v0.4.0
-        dependencies:
-          - argonaut-codecs
-          - arrays
-          - partial
-          - prelude
-          - unfoldable
-      orders:
-        repo: https://github.com/purescript/purescript-orders.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      pairs:
-        repo: https://github.com/sharkdp/purescript-pairs.git
-        version: v9.0.0
-        dependencies:
-          - console
-          - distributive
-          - foldable-traversable
-          - quickcheck
-      parallel:
-        repo: https://github.com/purescript/purescript-parallel.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - functors
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - refs
-          - transformers
-      parsing:
-        repo: https://github.com/purescript-contrib/purescript-parsing.git
-        version: v9.1.0
-        dependencies:
-          - arrays
-          - either
-          - foldable-traversable
-          - identity
-          - integers
-          - lists
-          - maybe
-          - nullable
-          - prelude
-          - strings
-          - transformers
-          - unicode
-      parsing-dataview:
-        repo: https://github.com/jamesdbrock/purescript-parsing-dataview.git
-        version: v3.1.0
-        dependencies:
-          - arraybuffer
-          - arraybuffer-types
-          - effect
-          - float32
-          - maybe
-          - parsing
-          - prelude
-          - transformers
-          - tuples
-          - uint
-      partial:
-        repo: https://github.com/purescript/purescript-partial.git
-        version: v4.0.0
-        dependencies: []
-      pathy:
-        repo: https://github.com/purescript-contrib/purescript-pathy.git
-        version: v9.0.0
-        dependencies:
-          - console
-          - exceptions
-          - lists
-          - partial
-          - profunctor
-          - strings
-          - transformers
-          - typelevel-prelude
-          - unsafe-coerce
-      pha:
-        repo: https://github.com/gbagan/purescript-pha.git
-        version: v0.9.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - datetime
-          - effect
-          - foldable-traversable
-          - free
-          - integers
-          - maybe
-          - prelude
-          - profunctor-lenses
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-          - unsafe-reference
-          - web-dom
-          - web-events
-          - web-html
-          - web-pointerevents
-          - web-uievents
-      phaser:
-        repo: https://github.com/lfarroco/purescript-phaser.git
-        version: v0.6.0
-        dependencies:
-          - canvas
-          - console
-          - effect
-          - maybe
-          - nullable
-          - options
-          - prelude
-          - web-html
-      pipes:
-        repo: https://github.com/felixschl/purescript-pipes.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - lists
-          - mmorph
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      point-free:
-        repo: https://github.com/ursi/purescript-point-free.git
-        version: v1.0.0
-        dependencies:
-          - prelude
-      polymorphic-vectors:
-        repo: https://github.com/artemisSystem/purescript-polymorphic-vectors.git
-        version: v4.0.0
-        dependencies:
-          - distributive
-          - foldable-traversable
-          - numbers
-          - prelude
-          - record
-          - safe-coerce
-          - type-equality
-          - typelevel-prelude
-      posix-types:
-        repo: https://github.com/purescript-node/purescript-posix-types.git
-        version: v6.0.0
-        dependencies:
-          - maybe
-          - prelude
-      precise:
-        repo: https://github.com/purescript-contrib/purescript-precise.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - exceptions
-          - gen
-          - integers
-          - lists
-          - numbers
-          - prelude
-          - strings
-      precise-datetime:
-        repo: https://github.com/awakesecurity/purescript-precise-datetime.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - datetime
-          - decimals
-          - either
-          - enums
-          - foldable-traversable
-          - formatters
-          - integers
-          - js-date
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - strings
-          - tuples
-          - unicode
-      prelude:
-        repo: https://github.com/purescript/purescript-prelude.git
-        version: v6.0.0
-        dependencies: []
-      prettier-printer:
-        repo: https://github.com/paulyoung/purescript-prettier-printer.git
-        version: v3.0.0
-        dependencies:
-          - console
-          - lists
-          - prelude
-          - strings
-          - tuples
-      profunctor:
-        repo: https://github.com/purescript/purescript-profunctor.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - distributive
-          - either
-          - exists
-          - invariant
-          - newtype
-          - prelude
-          - tuples
-      profunctor-lenses:
-        repo: https://github.com/purescript-contrib/purescript-profunctor-lenses.git
-        version: v8.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - const
-          - control
-          - distributive
-          - either
-          - foldable-traversable
-          - foreign-object
-          - functors
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - ordered-collections
-          - partial
-          - prelude
-          - profunctor
-          - record
-          - transformers
-          - tuples
-      protobuf:
-        repo: https://github.com/xc-jp/purescript-protobuf.git
-        version: v4.0.0
-        dependencies:
-          - arraybuffer
-          - arraybuffer-builder
-          - arraybuffer-types
-          - arrays
-          - control
-          - effect
-          - either
-          - enums
-          - exceptions
-          - float32
-          - foldable-traversable
-          - functions
-          - int64
-          - maybe
-          - newtype
-          - parsing
-          - parsing-dataview
-          - prelude
-          - record
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-          - uint
-          - web-encoding
-      ps-cst:
-        repo: https://github.com/purescript-codegen/purescript-ps-cst.git
-        version: v1.2.0
-        dependencies:
-          - ansi
-          - console
-          - dodo-printer
-          - effect
-          - node-fs-aff
-          - node-path
-          - psci-support
-          - record
-          - strings
-      psa-utils:
-        repo: https://github.com/natefaubion/purescript-psa-utils.git
-        version: v8.0.0
-        dependencies:
-          - ansi
-          - argonaut-codecs
-          - argonaut-core
-          - arrays
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - maybe
-          - node-path
-          - ordered-collections
-          - prelude
-          - strings
-          - tuples
-          - unsafe-coerce
-      psc-ide:
-        repo: https://github.com/kRITZCREEK/purescript-psc-ide.git
-        version: v19.0.0
-        dependencies:
-          - aff
-          - argonaut
-          - arrays
-          - console
-          - maybe
-          - node-child-process
-          - node-fs
-          - parallel
-          - random
-      psci-support:
-        repo: https://github.com/purescript/purescript-psci-support.git
-        version: v6.0.0
-        dependencies:
-          - console
-          - effect
-          - prelude
-      qualified-do:
-        repo: https://github.com/artemisSystem/purescript-qualified-do.git
-        version: v2.2.0
-        dependencies:
-          - arrays
-          - control
-          - foldable-traversable
-          - parallel
-          - prelude
-          - unfoldable
-      quantities:
-        repo: https://github.com/sharkdp/purescript-quantities.git
-        version: v12.0.1
-        dependencies:
-          - decimals
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - newtype
-          - nonempty
-          - numbers
-          - pairs
-          - prelude
-          - tuples
-      quickcheck:
-        repo: https://github.com/purescript/purescript-quickcheck.git
-        version: v8.0.1
-        dependencies:
-          - arrays
-          - console
-          - control
-          - effect
-          - either
-          - enums
-          - exceptions
-          - foldable-traversable
-          - gen
-          - identity
-          - integers
-          - lazy
-          - lcg
-          - lists
-          - maybe
-          - newtype
-          - nonempty
-          - numbers
-          - partial
-          - prelude
-          - record
-          - st
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-          - unfoldable
-      quickcheck-combinators:
-        repo: https://github.com/athanclark/purescript-quickcheck-combinators.git
-        version: v0.1.3
-        dependencies:
-          - quickcheck
-          - typelevel
-      quickcheck-laws:
-        repo: https://github.com/purescript-contrib/purescript-quickcheck-laws.git
-        version: v7.0.0
-        dependencies:
-          - enums
-          - quickcheck
-      quickcheck-utf8:
-        repo: https://github.com/openchronology/purescript-quickcheck-utf8.git
-        version: v0.0.0
-        dependencies:
-          - quickcheck
-      quotient:
-        repo: https://github.com/rightfold/purescript-quotient.git
-        version: v3.0.0
-        dependencies:
-          - prelude
-          - quickcheck
-      random:
-        repo: https://github.com/purescript/purescript-random.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - integers
-      rationals:
-        repo: https://github.com/anttih/purescript-rationals.git
-        version: v5.0.0
-        dependencies:
-          - integers
-          - prelude
-      react:
-        repo: https://github.com/purescript-contrib/purescript-react.git
-        version: v10.0.1
-        dependencies:
-          - effect
-          - exceptions
-          - maybe
-          - nullable
-          - prelude
-          - typelevel-prelude
-          - unsafe-coerce
-      react-basic:
-        repo: https://github.com/lumihq/purescript-react-basic.git
-        version: v17.0.0
-        dependencies:
-          - effect
-          - prelude
-          - record
-      react-basic-dom:
-        repo: https://github.com/lumihq/purescript-react-basic-dom.git
-        version: v5.0.0
-        dependencies:
-          - effect
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - nullable
-          - prelude
-          - react-basic
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-file
-          - web-html
-      react-basic-hooks:
-        repo: https://github.com/megamaddu/purescript-react-basic-hooks.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - aff-promise
-          - bifunctors
-          - console
-          - control
-          - datetime
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - functions
-          - indexed-monad
-          - integers
-          - maybe
-          - newtype
-          - now
-          - nullable
-          - ordered-collections
-          - prelude
-          - react-basic
-          - refs
-          - tuples
-          - type-equality
-          - unsafe-coerce
-          - unsafe-reference
-          - web-html
-      react-dom:
-        repo: https://github.com/purescript-contrib/purescript-react-dom.git
-        version: v8.0.0
-        dependencies:
-          - effect
-          - react
-          - web-dom
-      read:
-        repo: https://github.com/truqu/purescript-read.git
-        version: v1.0.1
-        dependencies:
-          - maybe
-          - prelude
-          - strings
-      record:
-        repo: https://github.com/purescript/purescript-record.git
-        version: v4.0.0
-        dependencies:
-          - functions
-          - prelude
-          - unsafe-coerce
-      refined:
-        repo: https://github.com/danieljharvey/purescript-refined.git
-        version: v1.0.0
-        dependencies:
-          - argonaut
-          - effect
-          - prelude
-          - quickcheck
-          - typelevel
-      refs:
-        repo: https://github.com/purescript/purescript-refs.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - prelude
-      remotedata:
-        repo: https://github.com/krisajenkins/purescript-remotedata.git
-        version: v5.0.0
-        dependencies:
-          - bifunctors
-          - either
-          - profunctor-lenses
-      resource:
-        repo: https://github.com/joneshf/purescript-resource.git
-        version: v2.0.1
-        dependencies:
-          - aff
-          - console
-          - control
-          - effect
-          - newtype
-          - prelude
-          - psci-support
-          - refs
-      resourcet:
-        repo: https://github.com/robertdp/purescript-resourcet.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - effect
-          - foldable-traversable
-          - maybe
-          - ordered-collections
-          - parallel
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-      result:
-        repo: https://github.com/ad-si/purescript-result.git
-        version: v1.0.3
-        dependencies:
-          - either
-          - foldable-traversable
-          - prelude
-      return:
-        repo: https://github.com/ursi/purescript-return.git
-        version: v0.2.0
-        dependencies:
-          - foldable-traversable
-          - point-free
-          - prelude
-      ring-modules:
-        repo: https://github.com/f-o-a-m/purescript-ring-modules.git
-        version: v5.0.1
-        dependencies:
-          - prelude
-      routing:
-        repo: https://github.com/purescript-contrib/purescript-routing.git
-        version: v11.0.0
-        dependencies:
-          - aff
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - integers
-          - js-uri
-          - lists
-          - maybe
-          - numbers
-          - partial
-          - prelude
-          - semirings
-          - tuples
-          - validation
-          - web-html
-      routing-duplex:
-        repo: https://github.com/natefaubion/purescript-routing-duplex.git
-        version: v0.6.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - js-uri
-          - lazy
-          - numbers
-          - prelude
-          - profunctor
-          - record
-          - strings
-          - typelevel-prelude
-      run:
-        repo: https://github.com/natefaubion/purescript-run.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - free
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - tailrec
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - variant
-      safe-coerce:
-        repo: https://github.com/purescript/purescript-safe-coerce.git
-        version: v2.0.0
-        dependencies:
-          - unsafe-coerce
-      safely:
-        repo: https://github.com/paf31/purescript-safely.git
-        version: v4.0.1
-        dependencies:
-          - freet
-          - lists
-      selection-foldable:
-        repo: https://github.com/jamieyung/purescript-selection-foldable.git
-        version: v0.2.0
-        dependencies:
-          - filterable
-          - foldable-traversable
-          - maybe
-          - prelude
-      semirings:
-        repo: https://github.com/purescript/purescript-semirings.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - lists
-          - newtype
-          - prelude
-      signal:
-        repo: https://github.com/bodil/purescript-signal.git
-        version: v13.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - foldable-traversable
-          - maybe
-          - prelude
-      simple-emitter:
-        repo: https://github.com/oreshinya/purescript-simple-emitter.git
-        version: v2.0.0
-        dependencies:
-          - ordered-collections
-          - refs
-      sized-matrices:
-        repo: https://github.com/csicar/purescript-sized-matrices.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - distributive
-          - foldable-traversable
-          - maybe
-          - prelude
-          - sized-vectors
-          - strings
-          - typelevel
-          - unfoldable
-          - vectorfield
-      sized-vectors:
-        repo: https://github.com/bodil/purescript-sized-vectors.git
-        version: v5.0.2
-        dependencies:
-          - argonaut
-          - arrays
-          - distributive
-          - foldable-traversable
-          - maybe
-          - prelude
-          - quickcheck
-          - typelevel
-          - unfoldable
-      slug:
-        repo: https://github.com/thomashoneyman/purescript-slug.git
-        version: v3.0.1
-        dependencies:
-          - argonaut-codecs
-          - maybe
-          - prelude
-          - strings
-          - unicode
-      soundfonts:
-        repo: https://github.com/newlandsvalley/purescript-soundfonts.git
-        version: v4.1.0
-        dependencies:
-          - aff
-          - affjax
-          - affjax-web
-          - argonaut-core
-          - arraybuffer-types
-          - arrays
-          - b64
-          - bifunctors
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign-object
-          - http-methods
-          - integers
-          - lists
-          - maybe
-          - midi
-          - ordered-collections
-          - parallel
-          - partial
-          - prelude
-          - strings
-          - transformers
-          - tuples
-      sparse-matrices:
-        repo: https://github.com/Ebmtranceboy/purescript-sparse-matrices.git
-        version: v1.2.1
-        dependencies:
-          - console
-          - effect
-          - prelude
-          - sparse-polynomials
-      sparse-polynomials:
-        repo: https://github.com/Ebmtranceboy/purescript-sparse-polynomials.git
-        version: v1.0.5
-        dependencies:
-          - cartesian
-          - console
-          - effect
-          - ordered-collections
-          - prelude
-          - rationals
-          - tuples
-      spec:
-        repo: https://github.com/purescript-spec/purescript-spec.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - ansi
-          - avar
-          - console
-          - exceptions
-          - foldable-traversable
-          - fork
-          - now
-          - pipes
-          - prelude
-          - strings
-          - transformers
-      spec-discovery:
-        repo: https://github.com/purescript-spec/purescript-spec-discovery.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - aff-promise
-          - arrays
-          - console
-          - effect
-          - foldable-traversable
-          - node-fs
-          - prelude
-          - spec
-      spec-quickcheck:
-        repo: https://github.com/purescript-spec/purescript-spec-quickcheck.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - prelude
-          - quickcheck
-          - random
-          - spec
-      ssrs:
-        repo: https://github.com/PureFunctor/purescript-ssrs.git
-        version: v1.0.0
-        dependencies:
-          - dissect
-          - either
-          - fixed-points
-          - free
-          - lists
-          - prelude
-          - safe-coerce
-          - tailrec
-          - tuples
-          - variant
-      st:
-        repo: https://github.com/purescript/purescript-st.git
-        version: v6.0.0
-        dependencies:
-          - partial
-          - prelude
-          - tailrec
-          - unsafe-coerce
-      strictlypositiveint:
-        repo: https://github.com/jamieyung/purescript-strictlypositiveint.git
-        version: v1.0.1
-        dependencies:
-          - prelude
-      string-parsers:
-        repo: https://github.com/purescript-contrib/purescript-string-parsers.git
-        version: v8.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - prelude
-          - strings
-          - tailrec
-      strings:
-        repo: https://github.com/purescript/purescript-strings.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - enums
-          - foldable-traversable
-          - gen
-          - integers
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-          - unsafe-coerce
-      strings-extra:
-        repo: https://github.com/purescript-contrib/purescript-strings-extra.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - maybe
-          - prelude
-          - strings
-          - unicode
-      stringutils:
-        repo: https://github.com/menelaos/purescript-stringutils.git
-        version: v0.0.12
-        dependencies:
-          - arrays
-          - integers
-          - maybe
-          - partial
-          - prelude
-          - strings
-      substitute:
-        repo: https://github.com/ursi/purescript-substitute.git
-        version: v0.2.3
-        dependencies:
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - prelude
-          - return
-          - strings
-      supply:
-        repo: https://github.com/ajnsit/purescript-supply.git
-        version: v0.2.0
-        dependencies:
-          - console
-          - control
-          - effect
-          - lazy
-          - prelude
-          - refs
-          - tuples
-      tailrec:
-        repo: https://github.com/purescript/purescript-tailrec.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - effect
-          - either
-          - identity
-          - maybe
-          - partial
-          - prelude
-          - refs
-      test-unit:
-        repo: https://github.com/bodil/purescript-test-unit.git
-        version: v17.0.0
-        dependencies:
-          - aff
-          - avar
-          - effect
-          - either
-          - free
-          - js-timers
-          - lists
-          - prelude
-          - quickcheck
-          - strings
-      thermite:
-        repo: https://github.com/paf31/purescript-thermite.git
-        version: v6.3.1
-        dependencies:
-          - aff
-          - coroutines
-          - freet
-          - profunctor-lenses
-          - react
-      thermite-dom:
-        repo: https://github.com/athanclark/purescript-thermite-dom.git
-        version: v0.3.1
-        dependencies:
-          - react
-          - react-dom
-          - thermite
-          - web-html
-      these:
-        repo: https://github.com/purescript-contrib/purescript-these.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - gen
-          - lists
-          - quickcheck
-          - quickcheck-laws
-          - tuples
-      transformers:
-        repo: https://github.com/purescript/purescript-transformers.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - distributive
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - identity
-          - lazy
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      tree-rose:
-        repo: https://github.com/jordanmartinez/purescript-tree-rose.git
-        version: v4.0.2
-        dependencies:
-          - control
-          - foldable-traversable
-          - free
-          - lists
-          - maybe
-          - prelude
-          - tailrec
-      tuples:
-        repo: https://github.com/purescript/purescript-tuples.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - invariant
-          - prelude
-      two-or-more:
-        repo: https://github.com/i-am-the-slime/purescript-two-or-more.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - foldable-traversable
-          - maybe
-          - partial
-          - prelude
-          - psci-support
-          - tuples
-      type-equality:
-        repo: https://github.com/purescript/purescript-type-equality.git
-        version: v4.0.1
-        dependencies: []
-      typelevel:
-        repo: https://github.com/bodil/purescript-typelevel.git
-        version: v6.0.0
-        dependencies:
-          - partial
-          - prelude
-          - tuples
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-lists:
-        repo: https://github.com/PureFunctor/purescript-typelevel-lists.git
-        version: v2.1.0
-        dependencies:
-          - prelude
-          - tuples
-          - typelevel-peano
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-peano:
-        repo: https://github.com/csicar/purescript-typelevel-peano.git
-        version: v1.0.1
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - prelude
-          - psci-support
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-prelude:
-        repo: https://github.com/purescript/purescript-typelevel-prelude.git
-        version: v7.0.0
-        dependencies:
-          - prelude
-          - type-equality
-      typelevel-rows:
-        repo: https://github.com/jordanmartinez/purescript-typelevel-rows.git
-        version: v0.1.0
-        dependencies:
-          - prelude
-      uint:
-        repo: https://github.com/purescript-contrib/purescript-uint.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - enums
-          - gen
-          - maybe
-          - numbers
-          - prelude
-      uncurried-transformers:
-        repo: https://github.com/PureFunctor/purescript-uncurried-transformers.git
-        version: v1.1.0
-        dependencies:
-          - control
-          - effect
-          - either
-          - functions
-          - identity
-          - prelude
-          - safe-coerce
-          - tailrec
-          - transformers
-          - tuples
-      undefined-is-not-a-problem:
-        repo: https://github.com/paluh/purescript-undefined-is-not-a-problem.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - assert
-          - effect
-          - either
-          - foreign
-          - maybe
-          - newtype
-          - prelude
-          - random
-          - tuples
-          - type-equality
-          - unsafe-coerce
-      unfoldable:
-        repo: https://github.com/purescript/purescript-unfoldable.git
-        version: v6.0.0
-        dependencies:
-          - foldable-traversable
-          - maybe
-          - partial
-          - prelude
-          - tuples
-      unicode:
-        repo: https://github.com/purescript-contrib/purescript-unicode.git
-        version: v6.0.0
-        dependencies:
-          - foldable-traversable
-          - maybe
-          - strings
-      unlift:
-        repo: https://github.com/tweag/purescript-unlift.git
-        version: v1.0.1
-        dependencies:
-          - aff
-          - effect
-          - either
-          - freet
-          - identity
-          - lists
-          - maybe
-          - monad-control
-          - prelude
-          - st
-          - transformers
-          - tuples
-      unsafe-coerce:
-        repo: https://github.com/purescript/purescript-unsafe-coerce.git
-        version: v6.0.0
-        dependencies: []
-      unsafe-reference:
-        repo: https://github.com/purescript-contrib/purescript-unsafe-reference.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-      uri:
-        repo: https://github.com/purescript-contrib/purescript-uri.git
-        version: v9.0.0
-        dependencies:
-          - arrays
-          - integers
-          - js-uri
-          - numbers
-          - parsing
-          - prelude
-          - profunctor-lenses
-          - these
-          - transformers
-          - unfoldable
-      validation:
-        repo: https://github.com/purescript/purescript-validation.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - newtype
-          - prelude
-      variant:
-        repo: https://github.com/natefaubion/purescript-variant.git
-        version: v8.0.0
-        dependencies:
-          - enums
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - record
-          - tuples
-          - unsafe-coerce
-      vectorfield:
-        repo: https://github.com/csicar/purescript-vectorfield.git
-        version: v1.0.1
-        dependencies:
-          - console
-          - effect
-          - group
-          - prelude
-          - psci-support
-      versions:
-        repo: https://github.com/hdgarrood/purescript-versions.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - either
-          - foldable-traversable
-          - functions
-          - integers
-          - lists
-          - maybe
-          - orders
-          - parsing
-          - partial
-          - strings
-      web-clipboard:
-        repo: https://github.com/purescript-web/purescript-web-clipboard.git
-        version: v4.0.0
-        dependencies:
-          - web-html
-      web-cssom:
-        repo: https://github.com/purescript-web/purescript-web-cssom.git
-        version: v2.0.0
-        dependencies:
-          - web-dom
-          - web-html
-          - web-uievents
-      web-dom:
-        repo: https://github.com/purescript-web/purescript-web-dom.git
-        version: v6.0.0
-        dependencies:
-          - web-events
-      web-dom-parser:
-        repo: https://github.com/purescript-web/purescript-web-dom-parser.git
-        version: v8.0.0
-        dependencies:
-          - effect
-          - partial
-          - prelude
-          - web-dom
-      web-dom-xpath:
-        repo: https://github.com/purescript-web/purescript-web-dom-xpath.git
-        version: v3.0.0
-        dependencies:
-          - web-dom
-      web-encoding:
-        repo: https://github.com/purescript-web/purescript-web-encoding.git
-        version: v3.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - newtype
-          - prelude
-      web-events:
-        repo: https://github.com/purescript-web/purescript-web-events.git
-        version: v4.0.0
-        dependencies:
-          - datetime
-          - enums
-          - foreign
-          - nullable
-      web-fetch:
-        repo: https://github.com/purescript-web/purescript-web-fetch.git
-        version: v3.0.0
-        dependencies:
-          - effect
-          - foreign-object
-          - http-methods
-          - prelude
-          - record
-          - typelevel-prelude
-          - web-file
-          - web-promise
-          - web-streams
-      web-file:
-        repo: https://github.com/purescript-web/purescript-web-file.git
-        version: v4.0.0
-        dependencies:
-          - foreign
-          - media-types
-          - web-dom
-      web-html:
-        repo: https://github.com/purescript-web/purescript-web-html.git
-        version: v4.0.0
-        dependencies:
-          - js-date
-          - web-dom
-          - web-file
-          - web-storage
-      web-page-visibility:
-        repo: https://git.sr.ht/~toastal/purescript-web-page-visibility
-        version: v2.0.0
-        dependencies:
-          - effect
-          - enums
-          - exceptions
-          - maybe
-          - prelude
-          - strings
-          - web-events
-          - web-html
-      web-pointerevents:
-        repo: https://github.com/purescript-web/purescript-web-pointerevents.git
-        version: v1.0.0
-        dependencies:
-          - effect
-          - maybe
-          - prelude
-          - web-dom
-          - web-uievents
-      web-promise:
-        repo: https://github.com/purescript-web/purescript-web-promise.git
-        version: v3.0.0
-        dependencies:
-          - effect
-          - exceptions
-          - foldable-traversable
-          - functions
-          - maybe
-          - prelude
-      web-socket:
-        repo: https://github.com/purescript-web/purescript-web-socket.git
-        version: v4.0.0
-        dependencies:
-          - arraybuffer-types
-          - web-file
-      web-storage:
-        repo: https://github.com/purescript-web/purescript-web-storage.git
-        version: v5.0.0
-        dependencies:
-          - nullable
-          - web-events
-      web-streams:
-        repo: https://github.com/purescript-web/purescript-web-streams.git
-        version: v3.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - exceptions
-          - nullable
-          - prelude
-          - tuples
-          - web-promise
-      web-touchevents:
-        repo: https://github.com/purescript-web/purescript-web-touchevents.git
-        version: v4.0.0
-        dependencies:
-          - web-uievents
-      web-uievents:
-        repo: https://github.com/purescript-web/purescript-web-uievents.git
-        version: v4.0.0
-        dependencies:
-          - web-html
-      web-workers:
-        repo: https://github.com/gbagan/purescript-web-workers.git
-        version: v1.1.0
-        dependencies:
-          - effect
-          - foreign
-          - maybe
-          - prelude
-          - unsafe-coerce
-          - web-events
-      web-xhr:
-        repo: https://github.com/purescript-web/purescript-web-xhr.git
-        version: v5.0.0
-        dependencies:
-          - arraybuffer-types
-          - datetime
-          - http-methods
-          - web-dom
-          - web-file
-          - web-html
-      yoga-fetch:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-fetch.git
-        version: v1.0.1
-        dependencies:
-          - aff
-          - aff-promise
-          - arraybuffer-types
-          - effect
-          - foreign
-          - foreign-object
-          - newtype
-          - prelude
-          - typelevel-prelude
-          - unsafe-coerce
-      yoga-json:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-json.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - identity
-          - lists
-          - maybe
-          - nullable
-          - partial
-          - prelude
-          - record
-          - transformers
-          - typelevel-prelude
-          - variant
-      yoga-postgres:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-postgres.git
-        version: v6.0.0
-        dependencies:
-          - aff
-          - arrays
-          - datetime
-          - effect
-          - either
-          - enums
-          - foldable-traversable
-          - foreign
-          - integers
-          - maybe
-          - nullable
-          - prelude
-          - transformers
-          - unsafe-coerce
+      abc-parser: 2.0.0
+      ace: 9.0.0
+      aff: 7.1.0
+      aff-bus: 6.0.0
+      aff-coroutines: 9.0.0
+      aff-promise: 4.0.0
+      aff-retry: 2.0.0
+      affjax: 13.0.0
+      affjax-node: 1.0.0
+      affjax-web: 1.0.0
+      ansi: 7.0.0
+      argonaut: 9.0.0
+      argonaut-aeson-generic: 0.4.1
+      argonaut-codecs: 9.1.0
+      argonaut-core: 7.0.0
+      argonaut-generic: 8.0.0
+      argonaut-traversals: 10.0.0
+      argparse-basic: 2.0.0
+      array-builder: 0.1.2
+      arraybuffer: 13.1.1
+      arraybuffer-builder: 3.1.0
+      arraybuffer-types: 3.0.2
+      arrays: 7.1.0
+      arrays-zipper: 2.0.1
+      ask: 1.0.0
+      assert: 6.0.0
+      avar: 5.0.0
+      b64: 0.0.8
+      barbies: 1.0.1
+      barlow-lens: 0.9.0
+      basic-auth: 3.0.1
+      bifunctors: 6.0.0
+      bigints: 7.0.1
+      bolson: 0.3.1
+      bower-json: 3.0.0
+      bucketchain: 1.0.1
+      bucketchain-basic-auth: 1.0.1
+      bucketchain-conditional: 1.0.1
+      bucketchain-cors: 1.0.1
+      bucketchain-csrf: 1.0.1
+      bucketchain-header-utils: 1.0.1
+      bucketchain-health: 1.0.1
+      bucketchain-history-api-fallback: 1.0.1
+      bucketchain-logger: 1.0.1
+      bucketchain-secure: 1.0.1
+      bucketchain-simple-api: 5.0.1
+      bucketchain-sslify: 1.0.1
+      bucketchain-static: 1.0.1
+      call-by-name: 4.0.1
+      canvas: 6.0.0
+      canvas-action: 9.0.0
+      cartesian: 1.0.6
+      catenable-lists: 7.0.0
+      channel: 1.0.0
+      checked-exceptions: 3.1.1
+      classless: 0.1.1
+      classless-arbitrary: 0.1.1
+      classless-decode-json: 0.1.1
+      classless-encode-json: 0.1.3
+      classnames: 2.0.0
+      codec: 6.0.0
+      codec-argonaut: 10.0.0
+      colors: 7.0.1
+      concur-core: 0.5.0
+      concur-react: 0.5.0
+      concurrent-queues: 3.0.0
+      console: 6.0.0
+      const: 6.0.0
+      contravariant: 6.0.0
+      control: 6.0.0
+      convertable-options: 1.0.0
+      coroutines: 7.0.0
+      crypto: 5.0.1
+      css: 6.0.0
+      datetime: 6.1.0
+      datetime-parsing: 0.2.0
+      debug: 6.0.2
+      decimals: 7.1.0
+      default-values: 1.0.1
+      deku: 0.9.9
+      deno: 0.0.5
+      dissect: 1.0.0
+      distributive: 6.0.0
+      dodo-printer: 2.2.1
+      dom-filereader: 7.0.0
+      dom-indexed: 11.0.0
+      dotenv: 3.0.0
+      droplet: 0.5.0
+      dynamic-buffer: 3.0.1
+      echarts-simple: 0.0.1
+      effect: 4.0.0
+      either: 6.1.0
+      elmish: 0.8.3
+      elmish-enzyme: 0.1.1
+      elmish-hooks: 0.9.1
+      elmish-html: 0.7.2
+      elmish-testing-library: 0.3.1
+      email-validate: 7.0.0
+      encoding: 0.0.8
+      enums: 6.0.1
+      error: 2.0.0
+      exceptions: 6.0.0
+      exists: 6.0.0
+      exitcodes: 4.0.0
+      expect-inferred: 3.0.0
+      fahrtwind: 2.0.0
+      fallback: 0.1.0
+      fast-vect: 1.1.0
+      fetch: 1.1.4
+      fetch-argonaut: 1.0.0
+      fetch-core: 4.0.4
+      fetch-yoga-json: 1.1.0
+      filterable: 5.0.0
+      fixed-points: 7.0.0
+      fixed-precision: 5.0.0
+      flame: 1.2.0
+      float32: 2.0.0
+      foldable-traversable: 6.0.0
+      foreign: 7.0.0
+      foreign-object: 4.1.0
+      foreign-readwrite: 3.4.0
+      fork: 6.0.0
+      form-urlencoded: 7.0.0
+      formatters: 7.0.0
+      framer-motion: 1.0.1
+      free: 7.0.0
+      freeap: 7.0.0
+      freer-free: 0.0.1
+      freet: 7.0.0
+      functions: 6.0.0
+      functor1: 3.0.0
+      functors: 5.0.0
+      fuzzy: 0.4.0
+      gen: 4.0.0
+      generate-values: 1.0.1
+      generic-router: 0.0.1
+      geometry-plane: 1.0.3
+      github-actions-toolkit: 0.5.0
+      grain: 3.0.0
+      grain-router: 3.0.0
+      grain-virtualized: 3.0.0
+      graphql-client: 9.3.2
+      graphs: 8.1.0
+      group: 4.1.1
+      halogen: 7.0.0
+      halogen-bootstrap5: 2.1.0
+      halogen-css: 10.0.0
+      halogen-echarts-simple: 0.0.4
+      halogen-formless: 4.0.2
+      halogen-hooks: 0.6.3
+      halogen-hooks-extra: 0.9.0
+      halogen-store: 0.5.4
+      halogen-storybook: 2.0.0
+      halogen-subscriptions: 2.0.0
+      halogen-svg-elems: 7.0.0
+      halogen-vdom: 8.0.0
+      halogen-vdom-string-renderer: 0.5.0
+      heckin: 2.0.1
+      heterogeneous: 0.6.0
+      homogeneous: 0.4.0
+      http-methods: 6.0.0
+      httpure: 0.16.0
+      httpurple: 3.0.1
+      httpurple-argonaut: 1.0.1
+      httpurple-yoga-json: 1.0.0
+      humdrum: 0.0.1
+      hyrule: 2.3.5
+      identity: 6.0.0
+      identy: 4.0.1
+      indexed-monad: 2.1.0
+      int64: 3.0.0
+      integers: 6.0.0
+      interpolate: 5.0.2
+      invariant: 6.0.0
+      jarilo: 1.0.1
+      jelly: 0.9.1
+      jelly-hooks: 0.3.1
+      jelly-router: 0.2.2
+      jelly-signal: 0.3.0
+      jest: 1.0.0
+      js-bigints: 1.2.0
+      js-date: 8.0.0
+      js-fileio: 3.0.0
+      js-promise: 1.0.0
+      js-promise-aff: 1.0.0
+      js-timers: 6.1.0
+      js-uri: 3.1.0
+      justifill: 0.5.0
+      jwt: 0.0.9
+      language-cst-parser: 0.12.1
+      lazy: 6.0.0
+      lazy-joe: 1.0.0
+      lcg: 4.0.0
+      leibniz: 5.0.0
+      linalg: 5.1.0
+      lists: 7.0.0
+      literals: 1.0.2
+      logging: 3.0.0
+      logging-journald: 0.4.0
+      machines: 7.0.0
+      marionette: 1.0.0
+      marionette-commander: 0.1.1
+      marionette-react-basic-hooks: 0.1.1
+      matrices: 5.0.1
+      matryoshka: 1.0.0
+      maybe: 6.0.0
+      mdast-util-from-markdown: 0.2.1
+      media-types: 6.0.0
+      midi: 4.0.0
+      milkis: 9.0.0
+      minibench: 4.0.1
+      mmorph: 7.0.0
+      monad-control: 5.0.0
+      monad-logger: 1.3.1
+      monad-loops: 0.5.0
+      monad-unlift: 1.0.1
+      monoid-extras: 0.0.1
+      monoidal: 0.16.0
+      morello: 0.4.0
+      mote: 3.0.0
+      motsunabe: 2.0.0
+      mysql: 6.0.1
+      n3: 0.1.0
+      nano-id: 1.1.0
+      naturals: 3.0.0
+      nested-functor: 0.2.1
+      newtype: 5.0.0
+      nextui: 0.1.0
+      node-buffer: 8.0.0
+      node-buffer-blob: 1.0.0
+      node-child-process: 9.0.0
+      node-fs: 8.1.1
+      node-fs-aff: 9.1.0
+      node-http: 8.0.0
+      node-net: 4.0.0
+      node-path: 5.0.0
+      node-process: 10.0.0
+      node-readline: 7.0.0
+      node-sqlite3: 8.0.0
+      node-streams: 7.0.0
+      node-streams-aff: 4.0.1
+      node-url: 6.0.0
+      nodemailer: 4.0.1
+      nonempty: 7.0.0
+      now: 6.0.0
+      npm-package-json: 2.0.0
+      nullable: 6.0.0
+      numbers: 9.0.0
+      object-maps: 0.1.1
+      ocarina: 1.5.2
+      open-folds: 6.3.0
+      open-memoize: 6.1.0
+      open-pairing: 6.1.0
+      options: 7.0.0
+      optparse: 5.0.0
+      ordered-collections: 3.0.0
+      ordered-set: 0.4.0
+      orders: 6.0.0
+      pairs: 9.0.0
+      parallel: 6.0.0
+      parsing: 10.2.0
+      parsing-dataview: 3.2.4
+      partial: 4.0.0
+      pathy: 9.0.0
+      pha: 0.9.0
+      phaser: 0.6.0
+      pipes: 8.0.0
+      pirates-charm: 0.0.1
+      point-free: 1.0.0
+      pointed-list: 0.5.1
+      polymorphic-vectors: 4.0.0
+      posix-types: 6.0.0
+      precise: 6.0.0
+      precise-datetime: 7.0.0
+      prelude: 6.0.1
+      prettier-printer: 3.0.0
+      profunctor: 6.0.0
+      profunctor-lenses: 8.0.0
+      protobuf: 4.2.0
+      ps-cst: 1.2.0
+      psa-utils: 8.0.0
+      psc-ide: 19.0.0
+      psci-support: 6.0.0
+      qualified-do: 2.2.0
+      quantities: 12.1.0
+      quickcheck: 8.0.1
+      quickcheck-combinators: 0.1.3
+      quickcheck-laws: 7.0.0
+      quickcheck-utf8: 0.0.0
+      random: 6.0.0
+      rationals: 5.0.1
+      rdf: 0.1.0
+      react: 10.0.1
+      react-aria: 0.2.0
+      react-basic: 17.0.0
+      react-basic-classic: 3.0.0
+      react-basic-dnd: 10.1.0
+      react-basic-dom: 6.0.0
+      react-basic-emotion: 7.1.0
+      react-basic-hooks: 8.1.2
+      react-basic-storybook: 2.0.0
+      react-dom: 8.0.0
+      react-halo: 3.0.0
+      react-icons: 1.0.8
+      react-testing-library: 4.0.1
+      react-virtuoso: 1.0.0
+      read: 1.0.1
+      record: 4.0.0
+      record-extra: 5.0.1
+      record-studio: 1.0.4
+      refs: 6.0.0
+      remotedata: 5.0.0
+      resource: 2.0.1
+      resourcet: 1.0.0
+      result: 1.0.3
+      return: 0.2.0
+      ring-modules: 5.0.1
+      rito: 0.3.2
+      routing: 11.0.0
+      routing-duplex: 0.7.0
+      run: 5.0.0
+      safe-coerce: 2.0.0
+      safely: 4.0.1
+      school-of-music: 1.3.0
+      selection-foldable: 0.2.0
+      semirings: 7.0.0
+      signal: 13.0.0
+      simple-emitter: 3.0.1
+      simple-i18n: 2.0.1
+      simple-json: 9.0.0
+      simple-jwt: 4.0.1
+      simple-ulid: 3.0.0
+      sized-matrices: 1.0.0
+      sized-vectors: 5.0.2
+      slug: 3.0.8
+      small-ffi: 4.0.1
+      soundfonts: 4.1.0
+      sparse-matrices: 1.2.1
+      sparse-polynomials: 1.0.5
+      spec: 7.2.0
+      spec-discovery: 8.0.1
+      spec-quickcheck: 5.0.0
+      splitmix: 2.1.0
+      ssrs: 1.0.0
+      st: 6.2.0
+      strictlypositiveint: 1.0.1
+      string-parsers: 8.0.0
+      strings: 6.0.1
+      strings-extra: 4.0.0
+      stringutils: 0.0.12
+      substitute: 0.2.3
+      sunde: 3.0.0
+      supply: 0.2.0
+      svg-parser: 3.0.0
+      systemd-journald: 0.3.0
+      tagged: 4.0.2
+      tailrec: 6.1.0
+      tecton: 0.1.6
+      tecton-halogen: 0.1.3
+      test-unit: 17.0.0
+      thermite: 6.3.1
+      thermite-dom: 0.3.1
+      these: 6.0.0
+      toppokki: 4.0.0
+      transformers: 6.0.0
+      tree-rose: 4.0.2
+      tuples: 7.0.0
+      two-or-more: 1.0.0
+      type-equality: 4.0.1
+      typelevel: 6.0.0
+      typelevel-lists: 2.1.0
+      typelevel-peano: 1.0.1
+      typelevel-prelude: 7.0.0
+      typelevel-rows: 0.1.0
+      uint: 7.0.0
+      ulid: 3.0.1
+      uncurried-transformers: 1.1.0
+      undefined: 2.0.0
+      undefined-is-not-a-problem: 1.1.0
+      unfoldable: 6.0.0
+      unicode: 6.0.0
+      unlift: 1.0.1
+      unordered-collections: 3.0.1
+      unsafe-coerce: 6.0.0
+      unsafe-reference: 5.0.0
+      untagged-to-tagged: 0.1.4
+      untagged-union: 1.0.0
+      uri: 9.0.0
+      uuid: 9.0.0
+      uuidv4: 1.0.0
+      validation: 6.0.0
+      variant: 8.0.0
+      vectorfield: 1.0.1
+      vectors: 2.1.0
+      versions: 7.0.0
+      visx: 0.0.2
+      web-clipboard: 5.0.0
+      web-cssom: 2.0.0
+      web-dom: 6.0.0
+      web-dom-parser: 8.0.0
+      web-dom-xpath: 3.0.0
+      web-encoding: 3.0.0
+      web-events: 4.0.0
+      web-fetch: 3.0.0
+      web-file: 4.0.0
+      web-html: 4.1.0
+      web-pointerevents: 1.0.0
+      web-proletarian: 1.0.0
+      web-promise: 3.1.0
+      web-resize-observer: 2.0.0
+      web-router: 1.0.0
+      web-socket: 4.0.0
+      web-storage: 5.0.0
+      web-streams: 3.0.0
+      web-touchevents: 4.0.0
+      web-uievents: 4.0.0
+      web-url: 2.0.0
+      web-workers: 1.1.0
+      web-xhr: 5.0.0
+      which: 2.0.0
+      yoga-fetch: 1.0.1
+      yoga-json: 4.0.1
+      yoga-om: 0.1.0
+      yoga-postgres: 6.0.0
+      yoga-tree: 1.0.0
   extra_packages: {}
 packages:
   aff:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-aff.git
-    rev: 2d44d9f9d0d6a416a4103fba2fb39e5160f80e36
+    type: registry
+    version: 7.1.0
+    integrity: sha256-7hOC6uQO9XBAI5FD8F33ChLjFAiZVfd4BJMqlMh7TNU=
     dependencies:
+      - arrays
+      - bifunctors
+      - control
       - datetime
       - effect
+      - either
       - exceptions
+      - foldable-traversable
       - functions
+      - maybe
+      - newtype
       - parallel
+      - prelude
+      - refs
+      - tailrec
       - transformers
       - unsafe-coerce
   arrays:
-    type: git
-    url: https://github.com/purescript/purescript-arrays.git
-    rev: d20bae2f76db6cf29b7b75e26e82b8a54c32295e
+    type: registry
+    version: 7.1.0
+    integrity: sha256-Rvb3AVLal0ZLpmpABgOPIUeYHa4M+c5GwcUP5rQ2trA=
     dependencies:
       - bifunctors
       - control
@@ -3524,15 +534,16 @@ packages:
       - nonempty
       - partial
       - prelude
+      - safe-coerce
       - st
       - tailrec
       - tuples
       - unfoldable
       - unsafe-coerce
   avar:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-avar.git
-    rev: d00f5784d9cc8f079babd62740f5c52b87e5caa5
+    type: registry
+    version: 5.0.0
+    integrity: sha256-e7hf0x4hEpcygXP0LtvfvAQ49Bbj2aWtZT3gqM///0A=
     dependencies:
       - aff
       - effect
@@ -3541,9 +552,9 @@ packages:
       - functions
       - maybe
   bifunctors:
-    type: git
-    url: https://github.com/purescript/purescript-bifunctors.git
-    rev: 16ba2fb6dd7f05528ebd9e2f9ca3a068b325e5b3
+    type: registry
+    version: 6.0.0
+    integrity: sha256-/gZwC9YhNxZNQpnHa5BIYerCGM2jeX9ukZiEvYxm5Nw=
     dependencies:
       - const
       - either
@@ -3551,9 +562,9 @@ packages:
       - prelude
       - tuples
   catenable-lists:
-    type: git
-    url: https://github.com/purescript/purescript-catenable-lists.git
-    rev: 09abe1f4888bc00841ad2b59e56a9e7ce7ebd4ab
+    type: registry
+    version: 7.0.0
+    integrity: sha256-76vYENhwF4BWTBsjeLuErCH2jqVT4M3R1HX+4RwSftA=
     dependencies:
       - control
       - foldable-traversable
@@ -3563,24 +574,24 @@ packages:
       - tuples
       - unfoldable
   console:
-    type: git
-    url: https://github.com/purescript/purescript-console.git
-    rev: 3b83d7b792d03872afeea5e62b4f686ab0f09842
+    type: registry
+    version: 6.0.0
+    integrity: sha256-gJpJ53fCDAL8BiCiJXH0HNAJ9K3gJtLo8GDaCK6hA5U=
     dependencies:
       - effect
       - prelude
   const:
-    type: git
-    url: https://github.com/purescript/purescript-const.git
-    rev: ab9570cf2b6e67f7e441178211db1231cfd75c37
+    type: registry
+    version: 6.0.0
+    integrity: sha256-tNrxDW8D8H4jdHE2HiPzpLy08zkzJMmGHdRqt5BQuTc=
     dependencies:
       - invariant
       - newtype
       - prelude
   contravariant:
-    type: git
-    url: https://github.com/purescript/purescript-contravariant.git
-    rev: 9ad3e105b8855bcc25f4e0893c784789d05a58de
+    type: registry
+    version: 6.0.0
+    integrity: sha256-TP+ooAp3vvmdjfQsQJSichF5B4BPDHp3wAJoWchip6c=
     dependencies:
       - const
       - either
@@ -3588,16 +599,16 @@ packages:
       - prelude
       - tuples
   control:
-    type: git
-    url: https://github.com/purescript/purescript-control.git
-    rev: a6033808790879a17b2729e73747a9ed3fb2264e
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sH7Pg9E96JCPF9PIA6oQ8+BjTyO/BH1ZuE/bOcyj4Jk=
     dependencies:
       - newtype
       - prelude
   datetime:
-    type: git
-    url: https://github.com/purescript/purescript-datetime.git
-    rev: a6a0cf1b0324964ad1854bc3377ed8766ba90e6f
+    type: registry
+    version: 6.1.0
+    integrity: sha256-g/5X5BBegQWLpI9IWD+sY6mcaYpzzlW5lz5NBzaMtyI=
     dependencies:
       - bifunctors
       - control
@@ -3616,9 +627,9 @@ packages:
       - prelude
       - tuples
   distributive:
-    type: git
-    url: https://github.com/purescript/purescript-distributive.git
-    rev: 6005e513642e855ebf6f884d24a35c2803ca252a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-HTDdmEnzigMl+02SJB88j+gAXDx9VKsbvR4MJGDPbOQ=
     dependencies:
       - identity
       - newtype
@@ -3626,24 +637,24 @@ packages:
       - tuples
       - type-equality
   effect:
-    type: git
-    url: https://github.com/purescript/purescript-effect.git
-    rev: a192ddb923027d426d6ea3d8deb030c9aa7c7dda
+    type: registry
+    version: 4.0.0
+    integrity: sha256-eBtZu+HZcMa5HilvI6kaDyVX3ji8p0W9MGKy2K4T6+M=
     dependencies:
       - prelude
   either:
-    type: git
-    url: https://github.com/purescript/purescript-either.git
-    rev: af655a04ed2fd694b6688af39ee20d7907ad0763
+    type: registry
+    version: 6.1.0
+    integrity: sha256-6hgTPisnMWVwQivOu2PKYcH8uqjEOOqDyaDQVUchTpY=
     dependencies:
       - control
       - invariant
       - maybe
       - prelude
   enums:
-    type: git
-    url: https://github.com/purescript/purescript-enums.git
-    rev: bae47961d401f9acf88da38f32e87403e5f0cf2f
+    type: registry
+    version: 6.0.1
+    integrity: sha256-HWaD73JFLorc4A6trKIRUeDMdzE+GpkJaEOM1nTNkC8=
     dependencies:
       - control
       - either
@@ -3656,24 +667,24 @@ packages:
       - tuples
       - unfoldable
   exceptions:
-    type: git
-    url: https://github.com/purescript/purescript-exceptions.git
-    rev: afab3c07c820bb49b6c5be50049db46a964a6161
+    type: registry
+    version: 6.0.0
+    integrity: sha256-y/xTAEIZIARCE+50/u1di0ncebJ+CIwNOLswyOWzMTw=
     dependencies:
       - effect
       - either
       - maybe
       - prelude
   exists:
-    type: git
-    url: https://github.com/purescript/purescript-exists.git
-    rev: f765b4ace7869c27b9c05949e18c843881f9173b
+    type: registry
+    version: 6.0.0
+    integrity: sha256-A0JQHpTfo1dNOj9U5/Fd3xndlRSE0g2IQWOGor2yXn8=
     dependencies:
       - unsafe-coerce
   foldable-traversable:
-    type: git
-    url: https://github.com/purescript/purescript-foldable-traversable.git
-    rev: b3926f870532d287ea59e2d5cd3873b81ef2a93a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-fLeqRYM4jUrZD5H4WqcwUgzU7XfYkzO4zhgtNc3jcWM=
     dependencies:
       - bifunctors
       - const
@@ -3687,9 +698,9 @@ packages:
       - prelude
       - tuples
   free:
-    type: git
-    url: https://github.com/purescript/purescript-free.git
-    rev: e2d8fa8023a864363857834e11393483bced5e38
+    type: registry
+    version: 7.0.0
+    integrity: sha256-72auTIZAG6fhz4F94rxyDwgfnHwp+/89rujZpZWrV0w=
     dependencies:
       - catenable-lists
       - control
@@ -3706,15 +717,15 @@ packages:
       - tuples
       - unsafe-coerce
   functions:
-    type: git
-    url: https://github.com/purescript/purescript-functions.git
-    rev: f626f20580483977c5b27a01aac6471e28aff367
+    type: registry
+    version: 6.0.0
+    integrity: sha256-adMyJNEnhGde2unHHAP79gPtlNjNqzgLB8arEOn9hLI=
     dependencies:
       - prelude
   functors:
-    type: git
-    url: https://github.com/purescript/purescript-functors.git
-    rev: 022ffd7a2a7ec12080314f3d217b400674a247b4
+    type: registry
+    version: 5.0.0
+    integrity: sha256-zfPWWYisbD84MqwpJSZFlvM6v86McM68ob8p9s27ywU=
     dependencies:
       - bifunctors
       - const
@@ -3730,9 +741,9 @@ packages:
       - tuples
       - unsafe-coerce
   gen:
-    type: git
-    url: https://github.com/purescript/purescript-gen.git
-    rev: 9fbcc2a1261c32e30d79c5418edef4d96fe76931
+    type: registry
+    version: 4.0.0
+    integrity: sha256-f7yzAXWwr+xnaqEOcvyO3ezKdoes8+WXWdXIHDBCAPI=
     dependencies:
       - either
       - foldable-traversable
@@ -3745,48 +756,48 @@ packages:
       - tuples
       - unfoldable
   identity:
-    type: git
-    url: https://github.com/purescript/purescript-identity.git
-    rev: ef6768f8a52ab0bc943a85f5761ba07c257f639f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-4wY0XZbAksjY6UAg99WkuKyJlQlWAfTi2ssadH0wVMY=
     dependencies:
       - control
       - invariant
       - newtype
       - prelude
   integers:
-    type: git
-    url: https://github.com/purescript/purescript-integers.git
-    rev: 54d712b25c594833083d15dc9ff2418eb9c52822
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sf+sK26R1hzwl3NhXR7WAu9zCDjQnfoXwcyGoseX158=
     dependencies:
       - maybe
       - numbers
       - prelude
   invariant:
-    type: git
-    url: https://github.com/purescript/purescript-invariant.git
-    rev: 1d2a196d51e90623adb88496c2cfd759c6736894
+    type: registry
+    version: 6.0.0
+    integrity: sha256-RGWWyYrz0Hs1KjPDA+87Kia67ZFBhfJ5lMGOMCEFoLo=
     dependencies:
       - control
       - prelude
   js-timers:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-js-timers.git
-    rev: 7cb728b3e6dc29f355143617e6e9ac770ecd9273
+    type: registry
+    version: 6.1.0
+    integrity: sha256-znHWLSSOYw15P5DTcsAdal2lf7nGA2yayLdOZ2t5r7o=
     dependencies:
       - effect
   lazy:
-    type: git
-    url: https://github.com/purescript/purescript-lazy.git
-    rev: 48347841226b27af5205a1a8ec71e27a93ce86fd
+    type: registry
+    version: 6.0.0
+    integrity: sha256-lMsfFOnlqfe4KzRRiW8ot5ge6HtcU3Eyh2XkXcP5IgU=
     dependencies:
       - control
       - foldable-traversable
       - invariant
       - prelude
   lcg:
-    type: git
-    url: https://github.com/purescript/purescript-lcg.git
-    rev: 67c6c6483a563a59ae036d9dca0f1be2835326a5
+    type: registry
+    version: 4.0.0
+    integrity: sha256-h7ME5cthLfbgJOJdsZcSfFpwXsx4rf8YmhebU+3iSYg=
     dependencies:
       - effect
       - integers
@@ -3795,9 +806,9 @@ packages:
       - prelude
       - random
   lists:
-    type: git
-    url: https://github.com/purescript/purescript-lists.git
-    rev: b113451e5b41cad87d669a3165f955c71cd863e2
+    type: registry
+    version: 7.0.0
+    integrity: sha256-EKF15qYqucuXP2lT/xPxhqy58f0FFT6KHdIB/yBOayI=
     dependencies:
       - bifunctors
       - control
@@ -3812,25 +823,25 @@ packages:
       - tuples
       - unfoldable
   maybe:
-    type: git
-    url: https://github.com/purescript/purescript-maybe.git
-    rev: c6f98ac1088766287106c5d9c8e30e7648d36786
+    type: registry
+    version: 6.0.0
+    integrity: sha256-5cCIb0wPwbat2PRkQhUeZO0jcAmf8jCt2qE0wbC3v2Q=
     dependencies:
       - control
       - invariant
       - newtype
       - prelude
   newtype:
-    type: git
-    url: https://github.com/purescript/purescript-newtype.git
-    rev: 29d8e6dd77aec2c975c948364ec3faf26e14ee7b
+    type: registry
+    version: 5.0.0
+    integrity: sha256-gdrQu8oGe9eZE6L3wOI8ql/igOg+zEGB5ITh2g+uttw=
     dependencies:
       - prelude
       - safe-coerce
   nonempty:
-    type: git
-    url: https://github.com/purescript/purescript-nonempty.git
-    rev: 28150ecc7419238b187abd609a92a645273348bb
+    type: registry
+    version: 7.0.0
+    integrity: sha256-54ablJZUHGvvlTJzi3oXyPCuvY6zsrWJuH/dMJ/MFLs=
     dependencies:
       - control
       - foldable-traversable
@@ -3839,16 +850,16 @@ packages:
       - tuples
       - unfoldable
   numbers:
-    type: git
-    url: https://github.com/purescript/purescript-numbers.git
-    rev: 2a53528f18f9415334bae28e7bb3cf3be86342c2
+    type: registry
+    version: 9.0.0
+    integrity: sha256-fDKXExFxMRFgy+v+kbjVbGBIOOQkWGnmm0vtnE3zWRE=
     dependencies:
       - functions
       - maybe
   ordered-collections:
-    type: git
-    url: https://github.com/purescript/purescript-ordered-collections.git
-    rev: 9826b7632d0d0a691173bde308a634195f42a419
+    type: registry
+    version: 3.0.0
+    integrity: sha256-R9WddNBRPkY37gw8XkDCLX2vJ5eI9qdaWDdCp61r2+M=
     dependencies:
       - arrays
       - foldable-traversable
@@ -3862,16 +873,16 @@ packages:
       - tuples
       - unfoldable
   orders:
-    type: git
-    url: https://github.com/purescript/purescript-orders.git
-    rev: f86db621ec5eef1274145f8b1fd8ebbfe0ed4a2c
+    type: registry
+    version: 6.0.0
+    integrity: sha256-nBA0g3/ai0euH8q9pSbGqk53W2q6agm/dECZTHcoink=
     dependencies:
       - newtype
       - prelude
   parallel:
-    type: git
-    url: https://github.com/purescript/purescript-parallel.git
-    rev: 85290dca837771ac4870071008c933d315ef678f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-VJbkGD0rAKX+NUEeBJbYJ78bEKaZbgow+QwQEfPB6ko=
     dependencies:
       - control
       - effect
@@ -3885,19 +896,19 @@ packages:
       - refs
       - transformers
   partial:
-    type: git
-    url: https://github.com/purescript/purescript-partial.git
-    rev: 0fa0646f5ea1ec5f0c46dcbd770c705a6c9ad3ec
+    type: registry
+    version: 4.0.0
+    integrity: sha256-fwXerld6Xw1VkReh8yeQsdtLVrjfGiVuC5bA1Wyo/J4=
     dependencies: []
   prelude:
-    type: git
-    url: https://github.com/purescript/purescript-prelude.git
-    rev: 32787f4399c92459c41602131a5858559eb868c5
+    type: registry
+    version: 6.0.1
+    integrity: sha256-o8p6SLYmVPqzXZhQFd2hGAWEwBoXl1swxLG/scpJ0V0=
     dependencies: []
   profunctor:
-    type: git
-    url: https://github.com/purescript/purescript-profunctor.git
-    rev: 0a966a14e7b0c827d44657dc1710cdc712d2e034
+    type: registry
+    version: 6.0.0
+    integrity: sha256-99NzxFgTr4CGlCSRYG1kShL+JhYbihhHtbOk1/0R5zI=
     dependencies:
       - control
       - distributive
@@ -3908,9 +919,9 @@ packages:
       - prelude
       - tuples
   quickcheck:
-    type: git
-    url: https://github.com/purescript/purescript-quickcheck.git
-    rev: bf5029f97e6c0d7552d3a08d2ab793a19e2c5e3d
+    type: registry
+    version: 8.0.1
+    integrity: sha256-ZvpccKQCvgslTXZCNmpYW4bUsFzhZd/kQUr2WmxFTGY=
     dependencies:
       - arrays
       - console
@@ -3940,46 +951,46 @@ packages:
       - tuples
       - unfoldable
   random:
-    type: git
-    url: https://github.com/purescript/purescript-random.git
-    rev: 9540bc965a9596da02fefd9949418bb19c92533a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-CJ611a35MPCE7XQMp0rdC6MCn76znlhisiCRgboAG+Q=
     dependencies:
       - effect
       - integers
   record:
-    type: git
-    url: https://github.com/purescript/purescript-record.git
-    rev: c89cd1ada6b636692571fc374196b1c39c4c9f70
+    type: registry
+    version: 4.0.0
+    integrity: sha256-Za5U85bTRJEfGK5Sk4hM41oXy84YQI0I8TL3WUn1Qzg=
     dependencies:
       - functions
       - prelude
       - unsafe-coerce
   refs:
-    type: git
-    url: https://github.com/purescript/purescript-refs.git
-    rev: f8e6216da4cb9309fde1f20cd6f69ac3a3b7f9e8
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Vgwne7jIbD3ZMoLNNETLT8Litw6lIYo3MfYNdtYWj9s=
     dependencies:
       - effect
       - prelude
   safe-coerce:
-    type: git
-    url: https://github.com/purescript/purescript-safe-coerce.git
-    rev: 7fa799ae80a38b8d948efcb52608e58e198b3da7
+    type: registry
+    version: 2.0.0
+    integrity: sha256-a1ibQkiUcbODbLE/WAq7Ttbbh9ex+x33VCQ7GngKudU=
     dependencies:
       - unsafe-coerce
   st:
-    type: git
-    url: https://github.com/purescript/purescript-st.git
-    rev: 2cc7ae1c3318a303378c4a9f3fa0f10ee7cc3589
+    type: registry
+    version: 6.2.0
+    integrity: sha256-z9X0WsOUlPwNx9GlCC+YccCyz8MejC8Wb0C4+9fiBRY=
     dependencies:
       - partial
       - prelude
       - tailrec
       - unsafe-coerce
   strings:
-    type: git
-    url: https://github.com/purescript/purescript-strings.git
-    rev: 4bc6954448d056f8aa7a659695a6ad60ad4fdf19
+    type: registry
+    version: 6.0.1
+    integrity: sha256-WssD3DbX4OPzxSdjvRMX0yvc9+pS7n5gyPv5I2Trb7k=
     dependencies:
       - arrays
       - control
@@ -3998,9 +1009,9 @@ packages:
       - unfoldable
       - unsafe-coerce
   tailrec:
-    type: git
-    url: https://github.com/purescript/purescript-tailrec.git
-    rev: 5e2104aa734b31a17074cc805bf087d72b65afd1
+    type: registry
+    version: 6.1.0
+    integrity: sha256-Xx19ECVDRrDWpz9D2GxQHHV89vd61dnXxQm0IcYQHGk=
     dependencies:
       - bifunctors
       - effect
@@ -4011,9 +1022,9 @@ packages:
       - prelude
       - refs
   test-unit:
-    type: git
-    url: https://github.com/bodil/purescript-test-unit.git
-    rev: 3112d7ebe06d467238058a6384dc75ffd960d335
+    type: registry
+    version: 17.0.0
+    integrity: sha256-aITJ2KngFFjASmG0JjnjybaKWl9dn7Hf2B3Wk4engNs=
     dependencies:
       - aff
       - avar
@@ -4026,9 +1037,9 @@ packages:
       - quickcheck
       - strings
   transformers:
-    type: git
-    url: https://github.com/purescript/purescript-transformers.git
-    rev: be72ab52357d9a665cbf93d73ba1c07c4b0957ee
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Pzw40HjthX77tdPAYzjx43LK3X5Bb7ZspYAp27wksFA=
     dependencies:
       - control
       - distributive
@@ -4045,22 +1056,22 @@ packages:
       - tuples
       - unfoldable
   tuples:
-    type: git
-    url: https://github.com/purescript/purescript-tuples.git
-    rev: 4f52da2729b448c8564369378f1232d8d2dc1d8b
+    type: registry
+    version: 7.0.0
+    integrity: sha256-1rXgTomes9105BjgXqIw0FL6Fz1lqqUTLWOumhWec1M=
     dependencies:
       - control
       - invariant
       - prelude
   type-equality:
-    type: git
-    url: https://github.com/purescript/purescript-type-equality.git
-    rev: 0525b7d39e0fbd81b4209518139fb8ab02695774
+    type: registry
+    version: 4.0.1
+    integrity: sha256-Hs9D6Y71zFi/b+qu5NSbuadUQXe5iv5iWx0226vOHUw=
     dependencies: []
   unfoldable:
-    type: git
-    url: https://github.com/purescript/purescript-unfoldable.git
-    rev: 493dfe04ed590e20d8f69079df2f58486882748d
+    type: registry
+    version: 6.0.0
+    integrity: sha256-JtikvJdktRap7vr/K4ITlxUX1QexpnqBq0G/InLr6eg=
     dependencies:
       - foldable-traversable
       - maybe
@@ -4068,7 +1079,7 @@ packages:
       - prelude
       - tuples
   unsafe-coerce:
-    type: git
-    url: https://github.com/purescript/purescript-unsafe-coerce.git
-    rev: ab956f82e66e633f647fb3098e8ddd3ec58d689f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-IqIYW4Vkevn8sI+6aUwRGvd87tVL36BBeOr0cGAE7t0=
     dependencies: []

--- a/exercises/chapter5/spago.yaml
+++ b/exercises/chapter5/spago.yaml
@@ -1,0 +1,18 @@
+package:
+  dependencies:
+    - arrays
+    - console
+    - control
+    - effect
+    - foldable-traversable
+    - integers
+    - maybe
+    - prelude
+    - strings
+    - test-unit
+    - tuples
+  name: my-project
+workspace:
+  extraPackages: {}
+  packageSet:
+    url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json

--- a/exercises/chapter5/spago.yaml
+++ b/exercises/chapter5/spago.yaml
@@ -15,4 +15,4 @@ package:
 workspace:
   extraPackages: {}
   packageSet:
-    url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
+    registry: 10.0.0

--- a/exercises/chapter6/spago.lock
+++ b/exercises/chapter6/spago.lock
@@ -72,3452 +72,462 @@ workspace:
         - unsafe-coerce
   package_set:
     address:
-      url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
-    compiler: ">=0.15.0 <0.16.0"
+      registry: 10.0.0
+    compiler: ">=0.15.4 <0.16.0"
     content:
-      ace:
-        repo: https://github.com/purescript-contrib/purescript-ace.git
-        version: v9.0.0
-        dependencies:
-          - arrays
-          - effect
-          - foreign
-          - nullable
-          - prelude
-          - web-html
-          - web-uievents
-      aff:
-        repo: https://github.com/purescript-contrib/purescript-aff.git
-        version: v7.0.0
-        dependencies:
-          - datetime
-          - effect
-          - exceptions
-          - functions
-          - parallel
-          - transformers
-          - unsafe-coerce
-      aff-bus:
-        repo: https://github.com/purescript-contrib/purescript-aff-bus.git
-        version: v6.0.0
-        dependencies:
-          - aff
-          - avar
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - lists
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-      aff-coroutines:
-        repo: https://github.com/purescript-contrib/purescript-aff-coroutines.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - avar
-          - coroutines
-          - effect
-      aff-promise:
-        repo: https://github.com/nwolverson/purescript-aff-promise.git
-        version: v4.0.0
-        dependencies:
-          - aff
-          - foreign
-      aff-retry:
-        repo: https://github.com/Unisay/purescript-aff-retry.git
-        version: v2.0.0
-        dependencies:
-          - aff
-          - arrays
-          - datetime
-          - effect
-          - either
-          - exceptions
-          - integers
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - random
-          - transformers
-      affjax:
-        repo: https://github.com/purescript-contrib/purescript-affjax.git
-        version: v13.0.0
-        dependencies:
-          - aff
-          - argonaut-core
-          - arraybuffer-types
-          - foreign
-          - form-urlencoded
-          - http-methods
-          - integers
-          - media-types
-          - nullable
-          - refs
-          - unsafe-coerce
-          - web-xhr
-      affjax-node:
-        repo: https://github.com/purescript-contrib/purescript-affjax-node.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - affjax
-          - either
-          - maybe
-          - prelude
-      affjax-web:
-        repo: https://github.com/purescript-contrib/purescript-affjax-web.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - affjax
-          - either
-          - maybe
-          - prelude
-      ansi:
-        repo: https://github.com/hdgarrood/purescript-ansi.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - lists
-          - strings
-      argonaut:
-        repo: https://github.com/purescript-contrib/purescript-argonaut.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - argonaut-traversals
-      argonaut-codecs:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-codecs.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-core
-          - arrays
-          - effect
-          - foreign-object
-          - identity
-          - integers
-          - maybe
-          - nonempty
-          - ordered-collections
-          - prelude
-          - record
-      argonaut-core:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-core.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - foreign-object
-          - functions
-          - gen
-          - maybe
-          - nonempty
-          - prelude
-          - strings
-          - tailrec
-      argonaut-generic:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-generic.git
-        version: v8.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - prelude
-          - record
-      argonaut-traversals:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-traversals.git
-        version: v10.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - profunctor-lenses
-      argparse-basic:
-        repo: https://github.com/natefaubion/purescript-argparse-basic.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - record
-          - strings
-          - tuples
-          - unfoldable
-      arraybuffer:
-        repo: https://github.com/purescript-contrib/purescript-arraybuffer.git
-        version: v13.0.0
-        dependencies:
-          - arraybuffer-types
-          - arrays
-          - effect
-          - float32
-          - functions
-          - gen
-          - maybe
-          - nullable
-          - prelude
-          - tailrec
-          - uint
-          - unfoldable
-      arraybuffer-builder:
-        repo: https://github.com/jamesdbrock/purescript-arraybuffer-builder.git
-        version: v3.0.1
-        dependencies:
-          - arraybuffer
-          - arraybuffer-types
-          - effect
-          - float32
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - transformers
-          - uint
-      arraybuffer-types:
-        repo: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
-        version: v3.0.2
-        dependencies: []
-      arrays:
-        repo: https://github.com/purescript/purescript-arrays.git
-        version: v7.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - foldable-traversable
-          - maybe
-          - nonempty
-          - partial
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - unfoldable
-          - unsafe-coerce
-      arrays-zipper:
-        repo: https://github.com/JordanMartinez/purescript-arrays-zipper.git
-        version: v2.0.1
-        dependencies:
-          - arrays
-          - control
-          - quickcheck
-      ask:
-        repo: https://github.com/Mateiadrielrafael/purescript-ask.git
-        version: v1.0.0
-        dependencies:
-          - unsafe-coerce
-      assert:
-        repo: https://github.com/purescript/purescript-assert.git
-        version: v6.0.0
-        dependencies:
-          - console
-          - effect
-          - prelude
-      avar:
-        repo: https://github.com/purescript-contrib/purescript-avar.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - exceptions
-          - functions
-          - maybe
-      b64:
-        repo: https://github.com/menelaos/purescript-b64.git
-        version: v0.0.8
-        dependencies:
-          - arraybuffer-types
-          - either
-          - encoding
-          - enums
-          - exceptions
-          - functions
-          - partial
-          - prelude
-          - strings
-      barlow-lens:
-        repo: https://github.com/sigma-andex/purescript-barlow-lens.git
-        version: v0.9.0
-        dependencies:
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - profunctor-lenses
-          - tuples
-          - typelevel-prelude
-      bifunctors:
-        repo: https://github.com/purescript/purescript-bifunctors.git
-        version: v6.0.0
-        dependencies:
-          - const
-          - either
-          - newtype
-          - prelude
-          - tuples
-      bigints:
-        repo: https://github.com/sharkdp/purescript-bigints.git
-        version: v7.0.1
-        dependencies:
-          - integers
-          - maybe
-          - strings
-      bower-json:
-        repo: https://github.com/klntsky/purescript-bower-json.git
-        version: v3.0.0
-        dependencies:
-          - argonaut-codecs
-          - arrays
-          - either
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - newtype
-          - prelude
-          - tuples
-      call-by-name:
-        repo: https://github.com/natefaubion/purescript-call-by-name.git
-        version: v4.0.1
-        dependencies:
-          - control
-          - either
-          - lazy
-          - maybe
-          - unsafe-coerce
-      canvas:
-        repo: https://github.com/purescript-web/purescript-canvas.git
-        version: v6.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - exceptions
-          - functions
-          - maybe
-      canvas-action:
-        repo: https://github.com/artemisSystem/purescript-canvas-action.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - arrays
-          - canvas
-          - colors
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - maybe
-          - numbers
-          - polymorphic-vectors
-          - prelude
-          - refs
-          - run
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-html
-      cartesian:
-        repo: https://github.com/Ebmtranceboy/purescript-cartesian.git
-        version: v1.0.6
-        dependencies:
-          - console
-          - effect
-          - integers
-          - psci-support
-      catenable-lists:
-        repo: https://github.com/purescript/purescript-catenable-lists.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - lists
-          - maybe
-          - prelude
-          - tuples
-          - unfoldable
-      channel:
-        repo: https://github.com/ConnorDillon/purescript-channel.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - assert
-          - avar
-          - console
-          - contravariant
-          - control
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - lazy
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      checked-exceptions:
-        repo: https://github.com/natefaubion/purescript-checked-exceptions.git
-        version: v3.1.1
-        dependencies:
-          - prelude
-          - transformers
-          - variant
-      codec:
-        repo: https://github.com/garyb/purescript-codec.git
-        version: v5.0.0
-        dependencies:
-          - profunctor
-          - transformers
-      codec-argonaut:
-        repo: https://github.com/garyb/purescript-codec-argonaut.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-core
-          - codec
-          - ordered-collections
-          - type-equality
-          - variant
-      colors:
-        repo: https://github.com/purescript-contrib/purescript-colors.git
-        version: v7.0.1
-        dependencies:
-          - arrays
-          - integers
-          - lists
-          - numbers
-          - partial
-          - strings
-      concurrent-queues:
-        repo: https://github.com/purescript-contrib/purescript-concurrent-queues.git
-        version: v3.0.0
-        dependencies:
-          - aff
-          - avar
-          - effect
-      console:
-        repo: https://github.com/purescript/purescript-console.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - prelude
-      const:
-        repo: https://github.com/purescript/purescript-const.git
-        version: v6.0.0
-        dependencies:
-          - invariant
-          - newtype
-          - prelude
-      contravariant:
-        repo: https://github.com/purescript/purescript-contravariant.git
-        version: v6.0.0
-        dependencies:
-          - const
-          - either
-          - newtype
-          - prelude
-          - tuples
-      control:
-        repo: https://github.com/purescript/purescript-control.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      convertable-options:
-        repo: https://github.com/natefaubion/purescript-convertable-options.git
-        version: v1.0.0
-        dependencies:
-          - console
-          - effect
-          - maybe
-          - record
-      coroutines:
-        repo: https://github.com/purescript-contrib/purescript-coroutines.git
-        version: v7.0.0
-        dependencies:
-          - freet
-          - parallel
-          - profunctor
-      css:
-        repo: https://github.com/purescript-contrib/purescript-css.git
-        version: v6.0.0
-        dependencies:
-          - colors
-          - console
-          - effect
-          - nonempty
-          - profunctor
-          - strings
-          - these
-          - transformers
-      datetime:
-        repo: https://github.com/purescript/purescript-datetime.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - either
-          - enums
-          - foldable-traversable
-          - functions
-          - gen
-          - integers
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - ordered-collections
-          - partial
-          - prelude
-          - tuples
-      datetime-parsing:
-        repo: https://github.com/flounders/purescript-datetime-parsing.git
-        version: v0.2.0
-        dependencies:
-          - arrays
-          - datetime
-          - either
-          - enums
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - numbers
-          - parsing
-          - prelude
-          - strings
-          - unicode
-      debug:
-        repo: https://github.com/garyb/purescript-debug.git
-        version: v6.0.0
-        dependencies:
-          - functions
-          - prelude
-      decimals:
-        repo: https://github.com/sharkdp/purescript-decimals.git
-        version: v7.0.0
-        dependencies:
-          - maybe
-      dissect:
-        repo: https://github.com/PureFunctor/purescript-dissect.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - foreign-object
-          - functors
-          - newtype
-          - partial
-          - prelude
-          - tailrec
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - variant
-      distributive:
-        repo: https://github.com/purescript/purescript-distributive.git
-        version: v6.0.0
-        dependencies:
-          - identity
-          - newtype
-          - prelude
-          - tuples
-          - type-equality
-      dodo-printer:
-        repo: https://github.com/natefaubion/purescript-dodo-printer.git
-        version: v2.2.0
-        dependencies:
-          - aff
-          - ansi
-          - avar
-          - console
-          - effect
-          - foldable-traversable
-          - lists
-          - maybe
-          - minibench
-          - node-child-process
-          - node-fs-aff
-          - node-process
-          - psci-support
-          - strings
-      dom-indexed:
-        repo: https://github.com/purescript-halogen/purescript-dom-indexed.git
-        version: v11.0.0
-        dependencies:
-          - media-types
-          - prelude
-          - web-clipboard
-          - web-pointerevents
-          - web-touchevents
-      droplet:
-        repo: https://github.com/easafe/purescript-droplet.git
-        version: v0.4.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - bigints
-          - datetime
-          - debug
-          - effect
-          - either
-          - enums
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - integers
-          - maybe
-          - newtype
-          - nullable
-          - ordered-collections
-          - partial
-          - prelude
-          - profunctor
-          - record
-          - spec
-          - strings
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-      dynamic-buffer:
-        repo: https://github.com/kritzcreek/purescript-dynamic-buffer.git
-        version: v3.0.1
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - refs
-      effect:
-        repo: https://github.com/purescript/purescript-effect.git
-        version: v4.0.0
-        dependencies:
-          - prelude
-      either:
-        repo: https://github.com/purescript/purescript-either.git
-        version: v6.1.0
-        dependencies:
-          - control
-          - invariant
-          - maybe
-          - prelude
-      elmish:
-        repo: https://github.com/collegevine/purescript-elmish.git
-        version: v0.8.1
-        dependencies:
-          - aff
-          - argonaut-core
-          - arrays
-          - bifunctors
-          - console
-          - debug
-          - effect
-          - either
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - functions
-          - integers
-          - js-date
-          - maybe
-          - nullable
-          - partial
-          - prelude
-          - refs
-          - typelevel-prelude
-          - undefined-is-not-a-problem
-          - unsafe-coerce
-          - web-dom
-          - web-html
-      elmish-enzyme:
-        repo: https://github.com/collegevine/purescript-elmish-enzyme.git
-        version: v0.1.1
-        dependencies:
-          - aff
-          - aff-promise
-          - arrays
-          - console
-          - debug
-          - effect
-          - elmish
-          - foldable-traversable
-          - foreign
-          - functions
-          - prelude
-          - transformers
-          - unsafe-coerce
-      elmish-hooks:
-        repo: https://github.com/collegevine/purescript-elmish-hooks.git
-        version: v0.8.2
-        dependencies:
-          - aff
-          - debug
-          - elmish
-          - maybe
-          - prelude
-          - tuples
-          - undefined-is-not-a-problem
-      elmish-html:
-        repo: https://github.com/collegevine/purescript-elmish-html.git
-        version: v0.7.1
-        dependencies:
-          - effect
-          - elmish
-          - foreign
-          - foreign-object
-          - prelude
-          - record
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-html
-      email-validate:
-        repo: https://github.com/cdepillabout/purescript-email-validate.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - string-parsers
-          - transformers
-      encoding:
-        repo: https://github.com/menelaos/purescript-encoding.git
-        version: v0.0.8
-        dependencies:
-          - arraybuffer-types
-          - either
-          - exceptions
-          - functions
-          - prelude
-      enums:
-        repo: https://github.com/purescript/purescript-enums.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - either
-          - gen
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tuples
-          - unfoldable
-      exceptions:
-        repo: https://github.com/purescript/purescript-exceptions.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - either
-          - maybe
-          - prelude
-      exists:
-        repo: https://github.com/purescript/purescript-exists.git
-        version: v6.0.0
-        dependencies:
-          - unsafe-coerce
-      exitcodes:
-        repo: https://github.com/Risto-Stevcev/purescript-exitcodes.git
-        version: v4.0.0
-        dependencies:
-          - enums
-      expect-inferred:
-        repo: https://github.com/justinwoo/purescript-expect-inferred.git
-        version: v3.0.0
-        dependencies:
-          - prelude
-          - typelevel-prelude
-      fast-vect:
-        repo: https://github.com/sigma-andex/purescript-fast-vect.git
-        version: v0.7.0
-        dependencies:
-          - arrays
-          - filterable
-          - foldable-traversable
-          - lists
-          - maybe
-          - ordered-collections
-          - prelude
-          - profunctor
-          - tuples
-          - unfoldable
-      filterable:
-        repo: https://github.com/purescript/purescript-filterable.git
-        version: v5.0.0
-        dependencies:
-          - arrays
-          - either
-          - foldable-traversable
-          - identity
-          - lists
-          - ordered-collections
-      fixed-points:
-        repo: https://github.com/purescript-contrib/purescript-fixed-points.git
-        version: v7.0.0
-        dependencies:
-          - exists
-          - newtype
-          - prelude
-          - transformers
-      fixed-precision:
-        repo: https://github.com/lumihq/purescript-fixed-precision.git
-        version: v5.0.0
-        dependencies:
-          - arrays
-          - bigints
-          - control
-          - integers
-          - maybe
-          - numbers
-          - partial
-          - prelude
-          - strings
-      flame:
-        repo: https://github.com/easafe/purescript-flame.git
-        version: v1.2.0
-        dependencies:
-          - aff
-          - argonaut-codecs
-          - argonaut-core
-          - argonaut-generic
-          - arrays
-          - bifunctors
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - maybe
-          - newtype
-          - nullable
-          - partial
-          - prelude
-          - random
-          - refs
-          - spec
-          - strings
-          - tuples
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-html
-          - web-uievents
-      float32:
-        repo: https://github.com/purescript-contrib/purescript-float32.git
-        version: v2.0.0
-        dependencies:
-          - gen
-          - maybe
-          - prelude
-      foldable-traversable:
-        repo: https://github.com/purescript/purescript-foldable-traversable.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - const
-          - control
-          - either
-          - functors
-          - identity
-          - maybe
-          - newtype
-          - orders
-          - prelude
-          - tuples
-      foreign:
-        repo: https://github.com/purescript/purescript-foreign.git
-        version: v7.0.0
-        dependencies:
-          - either
-          - functions
-          - identity
-          - integers
-          - lists
-          - maybe
-          - prelude
-          - strings
-          - transformers
-      foreign-object:
-        repo: https://github.com/purescript/purescript-foreign-object.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - functions
-          - gen
-          - lists
-          - maybe
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - typelevel-prelude
-          - unfoldable
-      foreign-readwrite:
-        repo: https://github.com/artemisSystem/purescript-foreign-readwrite.git
-        version: v3.0.0
-        dependencies:
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - record
-          - safe-coerce
-          - transformers
-          - unsafe-coerce
-      fork:
-        repo: https://github.com/purescript-contrib/purescript-fork.git
-        version: v6.0.0
-        dependencies:
-          - aff
-      form-urlencoded:
-        repo: https://github.com/purescript-contrib/purescript-form-urlencoded.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - js-uri
-          - maybe
-          - newtype
-          - prelude
-          - strings
-          - tuples
-      formatters:
-        repo: https://github.com/purescript-contrib/purescript-formatters.git
-        version: v7.0.0
-        dependencies:
-          - datetime
-          - fixed-points
-          - lists
-          - numbers
-          - parsing
-          - prelude
-          - transformers
-      free:
-        repo: https://github.com/purescript/purescript-free.git
-        version: v7.0.0
-        dependencies:
-          - catenable-lists
-          - control
-          - distributive
-          - either
-          - exists
-          - foldable-traversable
-          - invariant
-          - lazy
-          - maybe
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-      freeap:
-        repo: https://github.com/ethul/purescript-freeap.git
-        version: v7.0.0
-        dependencies:
-          - const
-          - exists
-          - gen
-          - lists
-      freet:
-        repo: https://github.com/purescript-contrib/purescript-freet.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - bifunctors
-          - effect
-          - either
-          - exists
-          - free
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      functions:
-        repo: https://github.com/purescript/purescript-functions.git
-        version: v6.0.0
-        dependencies:
-          - prelude
-      functors:
-        repo: https://github.com/purescript/purescript-functors.git
-        version: v5.0.0
-        dependencies:
-          - bifunctors
-          - const
-          - contravariant
-          - control
-          - distributive
-          - either
-          - invariant
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - tuples
-          - unsafe-coerce
-      fuzzy:
-        repo: https://github.com/citizennet/purescript-fuzzy.git
-        version: v0.4.0
-        dependencies:
-          - foldable-traversable
-          - foreign-object
-          - newtype
-          - ordered-collections
-          - prelude
-          - rationals
-          - strings
-          - tuples
-      gen:
-        repo: https://github.com/purescript/purescript-gen.git
-        version: v4.0.0
-        dependencies:
-          - either
-          - foldable-traversable
-          - identity
-          - maybe
-          - newtype
-          - nonempty
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      generate-values:
-        repo: https://github.com/jordanmartinez/purescript-generate-values.git
-        version: v1.0.1
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - enums
-          - foldable-traversable
-          - gen
-          - identity
-          - integers
-          - lcg
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - partial
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      geometry-plane:
-        repo: https://github.com/Ebmtranceboy/purescript-geometry-plane.git
-        version: v1.0.3
-        dependencies:
-          - console
-          - effect
-          - psci-support
-          - sparse-polynomials
-      github-actions-toolkit:
-        repo: https://github.com/purescript-contrib/purescript-github-actions-toolkit.git
-        version: v0.5.0
-        dependencies:
-          - aff
-          - aff-promise
-          - effect
-          - foreign-object
-          - node-buffer
-          - node-path
-          - node-streams
-          - nullable
-          - transformers
-      graphs:
-        repo: https://github.com/purescript/purescript-graphs.git
-        version: v8.0.0
-        dependencies:
-          - catenable-lists
-          - ordered-collections
-      group:
-        repo: https://github.com/morganthomas/purescript-group.git
-        version: v4.1.1
-        dependencies:
-          - lists
-      halogen:
-        repo: https://github.com/purescript-halogen/purescript-halogen.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - avar
-          - console
-          - const
-          - dom-indexed
-          - effect
-          - foreign
-          - fork
-          - free
-          - freeap
-          - halogen-subscriptions
-          - halogen-vdom
-          - media-types
-          - nullable
-          - ordered-collections
-          - parallel
-          - profunctor
-          - transformers
-          - unsafe-coerce
-          - unsafe-reference
-          - web-file
-          - web-uievents
-      halogen-css:
-        repo: https://github.com/purescript-halogen/purescript-halogen-css.git
-        version: v10.0.0
-        dependencies:
-          - css
-          - halogen
-      halogen-formless:
-        repo: https://github.com/thomashoneyman/purescript-halogen-formless.git
-        version: v4.0.0
-        dependencies:
-          - convertable-options
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - halogen
-          - heterogeneous
-          - maybe
-          - prelude
-          - record
-          - safe-coerce
-          - type-equality
-          - unsafe-coerce
-          - unsafe-reference
-          - variant
-          - web-events
-          - web-uievents
-      halogen-hooks:
-        repo: https://github.com/thomashoneyman/purescript-halogen-hooks.git
-        version: v0.6.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - effect
-          - exceptions
-          - foldable-traversable
-          - foreign-object
-          - free
-          - freeap
-          - halogen
-          - halogen-subscriptions
-          - maybe
-          - newtype
-          - ordered-collections
-          - parallel
-          - partial
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-          - unsafe-reference
-          - web-dom
-          - web-html
-      halogen-hooks-extra:
-        repo: https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git
-        version: v0.9.0
-        dependencies:
-          - halogen-hooks
-      halogen-store:
-        repo: https://github.com/thomashoneyman/purescript-halogen-store.git
-        version: v0.5.0
-        dependencies:
-          - aff
-          - distributive
-          - effect
-          - fork
-          - halogen
-          - halogen-hooks
-          - halogen-subscriptions
-          - maybe
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-reference
-      halogen-storybook:
-        repo: https://github.com/rnons/purescript-halogen-storybook.git
-        version: v2.0.0
-        dependencies:
-          - foreign-object
-          - halogen
-          - prelude
-          - routing
-      halogen-subscriptions:
-        repo: https://github.com/purescript-halogen/purescript-halogen-subscriptions.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - effect
-          - foldable-traversable
-          - functors
-          - refs
-          - safe-coerce
-          - unsafe-reference
-      halogen-svg-elems:
-        repo: https://github.com/JordanMartinez/purescript-halogen-svg-elems.git
-        version: v6.0.0
-        dependencies:
-          - halogen
-      halogen-vdom:
-        repo: https://github.com/purescript-halogen/purescript-halogen-vdom.git
-        version: v8.0.0
-        dependencies:
-          - bifunctors
-          - effect
-          - foreign
-          - foreign-object
-          - maybe
-          - prelude
-          - refs
-          - tuples
-          - unsafe-coerce
-          - web-html
-      halogen-vdom-string-renderer:
-        repo: https://github.com/purescript-halogen/purescript-halogen-vdom-string-renderer.git
-        version: v0.5.0
-        dependencies:
-          - foreign
-          - halogen-vdom
-          - ordered-collections
-          - prelude
-      heckin:
-        repo: https://github.com/maxdeviant/purescript-heckin.git
-        version: v2.0.1
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - maybe
-          - prelude
-          - strings
-          - transformers
-          - tuples
-          - unicode
-      heterogeneous:
-        repo: https://github.com/natefaubion/purescript-heterogeneous.git
-        version: v0.6.0
-        dependencies:
-          - either
-          - functors
-          - prelude
-          - record
-          - tuples
-          - variant
-      heterogeneous-extrablatt:
-        repo: https://github.com/sigma-andex/purescript-heterogeneous-extrablatt.git
-        version: v0.2.1
-        dependencies:
-          - heterogeneous
-          - prelude
-          - record
-      http-methods:
-        repo: https://github.com/purescript-contrib/purescript-http-methods.git
-        version: v6.0.0
-        dependencies:
-          - either
-          - prelude
-          - strings
-      httpure:
-        repo: https://github.com/citizennet/purescript-httpure.git
-        version: v0.15.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - js-uri
-          - maybe
-          - newtype
-          - node-buffer
-          - node-fs
-          - node-http
-          - node-streams
-          - options
-          - ordered-collections
-          - prelude
-          - refs
-          - strings
-          - tuples
-          - type-equality
-      httpurple:
-        repo: https://github.com/sigma-andex/purescript-httpurple.git
-        version: v1.3.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - js-uri
-          - justifill
-          - maybe
-          - newtype
-          - node-buffer
-          - node-fs
-          - node-http
-          - node-net
-          - node-process
-          - node-streams
-          - options
-          - ordered-collections
-          - posix-types
-          - prelude
-          - profunctor
-          - record
-          - refs
-          - routing-duplex
-          - strings
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-      httpurple-argonaut:
-        repo: https://github.com/sigma-andex/purescript-httpurple-argonaut.git
-        version: v1.0.1
-        dependencies:
-          - argonaut
-          - console
-          - effect
-          - either
-          - httpurple
-          - prelude
-      httpurple-yoga-json:
-        repo: https://github.com/sigma-andex/purescript-httpurple-yoga-json.git
-        version: v1.0.0
-        dependencies:
-          - console
-          - effect
-          - either
-          - foreign
-          - httpurple
-          - lists
-          - prelude
-          - yoga-json
-      identity:
-        repo: https://github.com/purescript/purescript-identity.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - invariant
-          - newtype
-          - prelude
-      indexed-monad:
-        repo: https://github.com/garyb/purescript-indexed-monad.git
-        version: v2.1.0
-        dependencies:
-          - control
-          - newtype
-      int64:
-        repo: https://github.com/purescript-contrib/purescript-int64.git
-        version: v2.0.0
-        dependencies:
-          - effect
-          - foreign
-          - functions
-          - integers
-          - maybe
-          - nullable
-          - prelude
-          - quickcheck
-      integers:
-        repo: https://github.com/purescript/purescript-integers.git
-        version: v6.0.0
-        dependencies:
-          - maybe
-          - numbers
-          - prelude
-      interpolate:
-        repo: https://github.com/jordanmartinez/purescript-interpolate.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-      invariant:
-        repo: https://github.com/purescript/purescript-invariant.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - prelude
-      js-date:
-        repo: https://github.com/purescript-contrib/purescript-js-date.git
-        version: v8.0.0
-        dependencies:
-          - datetime
-          - effect
-          - exceptions
-          - foreign
-          - integers
-          - now
-      js-fileio:
-        repo: https://github.com/newlandsvalley/purescript-js-fileio.git
-        version: v3.0.0
-        dependencies:
-          - aff
-          - effect
-          - prelude
-      js-timers:
-        repo: https://github.com/purescript-contrib/purescript-js-timers.git
-        version: v6.1.0
-        dependencies:
-          - effect
-      js-uri:
-        repo: https://github.com/purescript-contrib/purescript-js-uri.git
-        version: v3.0.0
-        dependencies:
-          - functions
-          - maybe
-      justifill:
-        repo: https://github.com/i-am-the-slime/purescript-justifill.git
-        version: v0.5.0
-        dependencies:
-          - maybe
-          - prelude
-          - record
-          - typelevel-prelude
-      jwt:
-        repo: https://github.com/menelaos/purescript-jwt.git
-        version: v0.0.9
-        dependencies:
-          - argonaut-core
-          - arrays
-          - b64
-          - either
-          - exceptions
-          - prelude
-          - profunctor-lenses
-          - strings
-      language-cst-parser:
-        repo: https://github.com/natefaubion/purescript-language-cst-parser.git
-        version: v0.12.0
-        dependencies:
-          - arrays
-          - const
-          - control
-          - either
-          - foldable-traversable
-          - free
-          - functions
-          - functors
-          - identity
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - ordered-collections
-          - partial
-          - prelude
-          - st
-          - strings
-          - transformers
-          - tuples
-          - typelevel-prelude
-          - unfoldable
-          - unsafe-coerce
-      lazy:
-        repo: https://github.com/purescript/purescript-lazy.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - invariant
-          - prelude
-      lcg:
-        repo: https://github.com/purescript/purescript-lcg.git
-        version: v4.0.0
-        dependencies:
-          - effect
-          - integers
-          - maybe
-          - partial
-          - prelude
-          - random
-      leibniz:
-        repo: https://github.com/paf31/purescript-leibniz.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-          - unsafe-coerce
-      linalg:
-        repo: https://github.com/gbagan/purescript-linalg.git
-        version: v5.1.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - functions
-          - maybe
-          - prelude
-          - tuples
-      lists:
-        repo: https://github.com/purescript/purescript-lists.git
-        version: v7.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - foldable-traversable
-          - lazy
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      logging:
-        repo: https://github.com/rightfold/purescript-logging.git
-        version: v3.0.0
-        dependencies:
-          - console
-          - contravariant
-          - effect
-          - either
-          - prelude
-          - transformers
-          - tuples
-      machines:
-        repo: https://github.com/purescript-contrib/purescript-machines.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - lists
-          - maybe
-          - prelude
-          - profunctor
-          - tuples
-          - unfoldable
-      matrices:
-        repo: https://github.com/kRITZCREEK/purescript-matrices.git
-        version: v5.0.1
-        dependencies:
-          - arrays
-          - strings
-      matryoshka:
-        repo: https://github.com/purescript-contrib/purescript-matryoshka.git
-        version: v1.0.0
-        dependencies:
-          - fixed-points
-          - free
-          - prelude
-          - profunctor
-          - transformers
-      maybe:
-        repo: https://github.com/purescript/purescript-maybe.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - invariant
-          - newtype
-          - prelude
-      media-types:
-        repo: https://github.com/purescript-contrib/purescript-media-types.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      metadata:
-        repo: https://github.com/purescript/purescript-metadata.git
-        version: v0.15.0
-        dependencies: []
-      midi:
-        repo: https://github.com/newlandsvalley/purescript-midi.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - ordered-collections
-          - prelude
-          - signal
-          - string-parsers
-          - strings
-          - tuples
-          - unfoldable
-      minibench:
-        repo: https://github.com/purescript/purescript-minibench.git
-        version: v4.0.0
-        dependencies:
-          - console
-          - effect
-          - integers
-          - numbers
-          - partial
-          - prelude
-          - refs
-      mmorph:
-        repo: https://github.com/Thimoteus/purescript-mmorph.git
-        version: v7.0.0
-        dependencies:
-          - free
-          - functors
-          - transformers
-      monad-control:
-        repo: https://github.com/athanclark/purescript-monad-control.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - freet
-          - identity
-          - lists
-      monad-logger:
-        repo: https://github.com/cprussin/purescript-monad-logger.git
-        version: v1.3.1
-        dependencies:
-          - aff
-          - ansi
-          - argonaut
-          - arrays
-          - console
-          - control
-          - effect
-          - foldable-traversable
-          - foreign-object
-          - integers
-          - js-date
-          - maybe
-          - newtype
-          - ordered-collections
-          - prelude
-          - strings
-          - transformers
-          - tuples
-      monad-loops:
-        repo: https://github.com/mlang/purescript-monad-loops.git
-        version: v0.5.0
-        dependencies:
-          - lists
-          - maybe
-          - prelude
-          - tailrec
-          - tuples
-      monad-unlift:
-        repo: https://github.com/athanclark/purescript-monad-unlift.git
-        version: v1.0.1
-        dependencies:
-          - monad-control
-      monoidal:
-        repo: https://github.com/mcneissue/purescript-monoidal.git
-        version: v0.16.0
-        dependencies:
-          - either
-          - profunctor
-          - these
-          - tuples
-      morello:
-        repo: https://github.com/sigma-andex/purescript-morello.git
-        version: v0.3.2
-        dependencies:
-          - arrays
-          - barlow-lens
-          - foldable-traversable
-          - heterogeneous
-          - heterogeneous-extrablatt
-          - newtype
-          - prelude
-          - profunctor
-          - profunctor-lenses
-          - record
-          - tuples
-          - typelevel-prelude
-          - validation
-      motsunabe:
-        repo: https://github.com/justinwoo/purescript-motsunabe.git
-        version: v2.0.0
-        dependencies:
-          - lists
-          - strings
-      nano-id:
-        repo: https://github.com/eikooc/nano-id.git
-        version: v1.1.0
-        dependencies:
-          - aff
-          - effect
-          - lists
-          - maybe
-          - prelude
-          - random
-          - spec
-          - strings
-          - stringutils
-      naturals:
-        repo: https://github.com/LiamGoodacre/purescript-naturals.git
-        version: v3.0.0
-        dependencies:
-          - enums
-          - maybe
-          - prelude
-      nested-functor:
-        repo: https://github.com/acple/purescript-nested-functor.git
-        version: v0.2.1
-        dependencies:
-          - prelude
-          - type-equality
-      newtype:
-        repo: https://github.com/purescript/purescript-newtype.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-          - safe-coerce
-      node-buffer:
-        repo: https://github.com/purescript-node/purescript-node-buffer.git
-        version: v8.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - maybe
-          - st
-          - unsafe-coerce
-      node-buffer-blob:
-        repo: https://github.com/purescript-node/purescript-node-buffer-blob.git
-        version: v1.0.0
-        dependencies:
-          - aff-promise
-          - arraybuffer-types
-          - arrays
-          - console
-          - effect
-          - maybe
-          - media-types
-          - newtype
-          - node-buffer
-          - nullable
-          - prelude
-          - web-streams
-      node-child-process:
-        repo: https://github.com/purescript-node/purescript-node-child-process.git
-        version: v9.0.0
-        dependencies:
-          - exceptions
-          - foreign
-          - foreign-object
-          - functions
-          - node-fs
-          - node-streams
-          - nullable
-          - posix-types
-          - unsafe-coerce
-      node-fs:
-        repo: https://github.com/purescript-node/purescript-node-fs.git
-        version: v8.0.0
-        dependencies:
-          - datetime
-          - effect
-          - either
-          - enums
-          - exceptions
-          - functions
-          - integers
-          - js-date
-          - maybe
-          - node-buffer
-          - node-path
-          - node-streams
-          - nullable
-          - partial
-          - prelude
-          - strings
-          - unsafe-coerce
-      node-fs-aff:
-        repo: https://github.com/purescript-node/purescript-node-fs-aff.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - either
-          - node-fs
-          - node-path
-      node-http:
-        repo: https://github.com/purescript-node/purescript-node-http.git
-        version: v8.0.0
-        dependencies:
-          - arraybuffer-types
-          - contravariant
-          - effect
-          - foreign
-          - foreign-object
-          - maybe
-          - node-buffer
-          - node-net
-          - node-streams
-          - node-url
-          - nullable
-          - options
-          - prelude
-          - unsafe-coerce
-      node-net:
-        repo: https://github.com/purescript-node/purescript-node-net.git
-        version: v4.0.0
-        dependencies:
-          - effect
-          - either
-          - exceptions
-          - foreign
-          - maybe
-          - node-buffer
-          - node-fs
-          - nullable
-          - options
-          - prelude
-          - transformers
-      node-path:
-        repo: https://github.com/purescript-node/purescript-node-path.git
-        version: v5.0.0
-        dependencies:
-          - effect
-      node-process:
-        repo: https://github.com/purescript-node/purescript-node-process.git
-        version: v10.0.0
-        dependencies:
-          - effect
-          - foreign-object
-          - maybe
-          - node-streams
-          - posix-types
-          - prelude
-          - unsafe-coerce
-      node-readline:
-        repo: https://github.com/purescript-node/purescript-node-readline.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - foreign
-          - node-process
-          - node-streams
-          - options
-          - prelude
-      node-streams:
-        repo: https://github.com/purescript-node/purescript-node-streams.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - either
-          - exceptions
-          - node-buffer
-          - nullable
-          - prelude
-      node-streams-aff:
-        repo: https://github.com/jamesdbrock/purescript-node-streams-aff.git
-        version: v2.0.0
-        dependencies:
-          - aff
-          - arrays
-          - effect
-          - either
-          - exceptions
-          - maybe
-          - node-buffer
-          - node-streams
-          - prelude
-          - st
-          - tuples
-      node-url:
-        repo: https://github.com/purescript-node/purescript-node-url.git
-        version: v6.0.0
-        dependencies:
-          - nullable
-      nonempty:
-        repo: https://github.com/purescript/purescript-nonempty.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - maybe
-          - prelude
-          - tuples
-          - unfoldable
-      now:
-        repo: https://github.com/purescript-contrib/purescript-now.git
-        version: v6.0.0
-        dependencies:
-          - datetime
-          - effect
-      npm-package-json:
-        repo: https://github.com/maxdeviant/purescript-npm-package-json.git
-        version: v2.0.0
-        dependencies:
-          - argonaut
-          - control
-          - either
-          - foreign-object
-          - maybe
-          - ordered-collections
-          - prelude
-      nullable:
-        repo: https://github.com/purescript-contrib/purescript-nullable.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - functions
-          - maybe
-      numbers:
-        repo: https://github.com/purescript/purescript-numbers.git
-        version: v9.0.0
-        dependencies:
-          - functions
-          - maybe
-      open-folds:
-        repo: https://github.com/purescript-open-community/purescript-open-folds.git
-        version: v6.3.0
-        dependencies:
-          - bifunctors
-          - console
-          - control
-          - distributive
-          - effect
-          - either
-          - foldable-traversable
-          - identity
-          - invariant
-          - maybe
-          - newtype
-          - ordered-collections
-          - prelude
-          - profunctor
-          - psci-support
-          - tuples
-      open-memoize:
-        repo: https://github.com/purescript-open-community/purescript-open-memoize.git
-        version: v6.1.0
-        dependencies:
-          - console
-          - effect
-          - either
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - psci-support
-          - strings
-          - tuples
-      open-pairing:
-        repo: https://github.com/purescript-open-community/purescript-open-pairing.git
-        version: v6.1.0
-        dependencies:
-          - console
-          - control
-          - effect
-          - either
-          - free
-          - functors
-          - identity
-          - newtype
-          - prelude
-          - psci-support
-          - transformers
-          - tuples
-      options:
-        repo: https://github.com/purescript-contrib/purescript-options.git
-        version: v7.0.0
-        dependencies:
-          - contravariant
-          - foreign
-          - foreign-object
-          - maybe
-          - tuples
-      optparse:
-        repo: https://github.com/f-o-a-m/purescript-optparse.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - control
-          - effect
-          - either
-          - enums
-          - exists
-          - exitcodes
-          - foldable-traversable
-          - free
-          - gen
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - newtype
-          - node-buffer
-          - node-process
-          - node-streams
-          - nonempty
-          - numbers
-          - open-memoize
-          - partial
-          - prelude
-          - quickcheck
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-      ordered-collections:
-        repo: https://github.com/purescript/purescript-ordered-collections.git
-        version: v3.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - gen
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - unfoldable
-      ordered-set:
-        repo: https://github.com/flip111/purescript-ordered-set.git
-        version: v0.4.0
-        dependencies:
-          - argonaut-codecs
-          - arrays
-          - partial
-          - prelude
-          - unfoldable
-      orders:
-        repo: https://github.com/purescript/purescript-orders.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      pairs:
-        repo: https://github.com/sharkdp/purescript-pairs.git
-        version: v9.0.0
-        dependencies:
-          - console
-          - distributive
-          - foldable-traversable
-          - quickcheck
-      parallel:
-        repo: https://github.com/purescript/purescript-parallel.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - functors
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - refs
-          - transformers
-      parsing:
-        repo: https://github.com/purescript-contrib/purescript-parsing.git
-        version: v9.1.0
-        dependencies:
-          - arrays
-          - either
-          - foldable-traversable
-          - identity
-          - integers
-          - lists
-          - maybe
-          - nullable
-          - prelude
-          - strings
-          - transformers
-          - unicode
-      parsing-dataview:
-        repo: https://github.com/jamesdbrock/purescript-parsing-dataview.git
-        version: v3.1.0
-        dependencies:
-          - arraybuffer
-          - arraybuffer-types
-          - effect
-          - float32
-          - maybe
-          - parsing
-          - prelude
-          - transformers
-          - tuples
-          - uint
-      partial:
-        repo: https://github.com/purescript/purescript-partial.git
-        version: v4.0.0
-        dependencies: []
-      pathy:
-        repo: https://github.com/purescript-contrib/purescript-pathy.git
-        version: v9.0.0
-        dependencies:
-          - console
-          - exceptions
-          - lists
-          - partial
-          - profunctor
-          - strings
-          - transformers
-          - typelevel-prelude
-          - unsafe-coerce
-      pha:
-        repo: https://github.com/gbagan/purescript-pha.git
-        version: v0.9.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - datetime
-          - effect
-          - foldable-traversable
-          - free
-          - integers
-          - maybe
-          - prelude
-          - profunctor-lenses
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-          - unsafe-reference
-          - web-dom
-          - web-events
-          - web-html
-          - web-pointerevents
-          - web-uievents
-      phaser:
-        repo: https://github.com/lfarroco/purescript-phaser.git
-        version: v0.6.0
-        dependencies:
-          - canvas
-          - console
-          - effect
-          - maybe
-          - nullable
-          - options
-          - prelude
-          - web-html
-      pipes:
-        repo: https://github.com/felixschl/purescript-pipes.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - lists
-          - mmorph
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      point-free:
-        repo: https://github.com/ursi/purescript-point-free.git
-        version: v1.0.0
-        dependencies:
-          - prelude
-      polymorphic-vectors:
-        repo: https://github.com/artemisSystem/purescript-polymorphic-vectors.git
-        version: v4.0.0
-        dependencies:
-          - distributive
-          - foldable-traversable
-          - numbers
-          - prelude
-          - record
-          - safe-coerce
-          - type-equality
-          - typelevel-prelude
-      posix-types:
-        repo: https://github.com/purescript-node/purescript-posix-types.git
-        version: v6.0.0
-        dependencies:
-          - maybe
-          - prelude
-      precise:
-        repo: https://github.com/purescript-contrib/purescript-precise.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - exceptions
-          - gen
-          - integers
-          - lists
-          - numbers
-          - prelude
-          - strings
-      precise-datetime:
-        repo: https://github.com/awakesecurity/purescript-precise-datetime.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - datetime
-          - decimals
-          - either
-          - enums
-          - foldable-traversable
-          - formatters
-          - integers
-          - js-date
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - strings
-          - tuples
-          - unicode
-      prelude:
-        repo: https://github.com/purescript/purescript-prelude.git
-        version: v6.0.0
-        dependencies: []
-      prettier-printer:
-        repo: https://github.com/paulyoung/purescript-prettier-printer.git
-        version: v3.0.0
-        dependencies:
-          - console
-          - lists
-          - prelude
-          - strings
-          - tuples
-      profunctor:
-        repo: https://github.com/purescript/purescript-profunctor.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - distributive
-          - either
-          - exists
-          - invariant
-          - newtype
-          - prelude
-          - tuples
-      profunctor-lenses:
-        repo: https://github.com/purescript-contrib/purescript-profunctor-lenses.git
-        version: v8.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - const
-          - control
-          - distributive
-          - either
-          - foldable-traversable
-          - foreign-object
-          - functors
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - ordered-collections
-          - partial
-          - prelude
-          - profunctor
-          - record
-          - transformers
-          - tuples
-      protobuf:
-        repo: https://github.com/xc-jp/purescript-protobuf.git
-        version: v4.0.0
-        dependencies:
-          - arraybuffer
-          - arraybuffer-builder
-          - arraybuffer-types
-          - arrays
-          - control
-          - effect
-          - either
-          - enums
-          - exceptions
-          - float32
-          - foldable-traversable
-          - functions
-          - int64
-          - maybe
-          - newtype
-          - parsing
-          - parsing-dataview
-          - prelude
-          - record
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-          - uint
-          - web-encoding
-      ps-cst:
-        repo: https://github.com/purescript-codegen/purescript-ps-cst.git
-        version: v1.2.0
-        dependencies:
-          - ansi
-          - console
-          - dodo-printer
-          - effect
-          - node-fs-aff
-          - node-path
-          - psci-support
-          - record
-          - strings
-      psa-utils:
-        repo: https://github.com/natefaubion/purescript-psa-utils.git
-        version: v8.0.0
-        dependencies:
-          - ansi
-          - argonaut-codecs
-          - argonaut-core
-          - arrays
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - maybe
-          - node-path
-          - ordered-collections
-          - prelude
-          - strings
-          - tuples
-          - unsafe-coerce
-      psc-ide:
-        repo: https://github.com/kRITZCREEK/purescript-psc-ide.git
-        version: v19.0.0
-        dependencies:
-          - aff
-          - argonaut
-          - arrays
-          - console
-          - maybe
-          - node-child-process
-          - node-fs
-          - parallel
-          - random
-      psci-support:
-        repo: https://github.com/purescript/purescript-psci-support.git
-        version: v6.0.0
-        dependencies:
-          - console
-          - effect
-          - prelude
-      qualified-do:
-        repo: https://github.com/artemisSystem/purescript-qualified-do.git
-        version: v2.2.0
-        dependencies:
-          - arrays
-          - control
-          - foldable-traversable
-          - parallel
-          - prelude
-          - unfoldable
-      quantities:
-        repo: https://github.com/sharkdp/purescript-quantities.git
-        version: v12.0.1
-        dependencies:
-          - decimals
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - newtype
-          - nonempty
-          - numbers
-          - pairs
-          - prelude
-          - tuples
-      quickcheck:
-        repo: https://github.com/purescript/purescript-quickcheck.git
-        version: v8.0.1
-        dependencies:
-          - arrays
-          - console
-          - control
-          - effect
-          - either
-          - enums
-          - exceptions
-          - foldable-traversable
-          - gen
-          - identity
-          - integers
-          - lazy
-          - lcg
-          - lists
-          - maybe
-          - newtype
-          - nonempty
-          - numbers
-          - partial
-          - prelude
-          - record
-          - st
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-          - unfoldable
-      quickcheck-combinators:
-        repo: https://github.com/athanclark/purescript-quickcheck-combinators.git
-        version: v0.1.3
-        dependencies:
-          - quickcheck
-          - typelevel
-      quickcheck-laws:
-        repo: https://github.com/purescript-contrib/purescript-quickcheck-laws.git
-        version: v7.0.0
-        dependencies:
-          - enums
-          - quickcheck
-      quickcheck-utf8:
-        repo: https://github.com/openchronology/purescript-quickcheck-utf8.git
-        version: v0.0.0
-        dependencies:
-          - quickcheck
-      quotient:
-        repo: https://github.com/rightfold/purescript-quotient.git
-        version: v3.0.0
-        dependencies:
-          - prelude
-          - quickcheck
-      random:
-        repo: https://github.com/purescript/purescript-random.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - integers
-      rationals:
-        repo: https://github.com/anttih/purescript-rationals.git
-        version: v5.0.0
-        dependencies:
-          - integers
-          - prelude
-      react:
-        repo: https://github.com/purescript-contrib/purescript-react.git
-        version: v10.0.1
-        dependencies:
-          - effect
-          - exceptions
-          - maybe
-          - nullable
-          - prelude
-          - typelevel-prelude
-          - unsafe-coerce
-      react-basic:
-        repo: https://github.com/lumihq/purescript-react-basic.git
-        version: v17.0.0
-        dependencies:
-          - effect
-          - prelude
-          - record
-      react-basic-dom:
-        repo: https://github.com/lumihq/purescript-react-basic-dom.git
-        version: v5.0.0
-        dependencies:
-          - effect
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - nullable
-          - prelude
-          - react-basic
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-file
-          - web-html
-      react-basic-hooks:
-        repo: https://github.com/megamaddu/purescript-react-basic-hooks.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - aff-promise
-          - bifunctors
-          - console
-          - control
-          - datetime
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - functions
-          - indexed-monad
-          - integers
-          - maybe
-          - newtype
-          - now
-          - nullable
-          - ordered-collections
-          - prelude
-          - react-basic
-          - refs
-          - tuples
-          - type-equality
-          - unsafe-coerce
-          - unsafe-reference
-          - web-html
-      react-dom:
-        repo: https://github.com/purescript-contrib/purescript-react-dom.git
-        version: v8.0.0
-        dependencies:
-          - effect
-          - react
-          - web-dom
-      read:
-        repo: https://github.com/truqu/purescript-read.git
-        version: v1.0.1
-        dependencies:
-          - maybe
-          - prelude
-          - strings
-      record:
-        repo: https://github.com/purescript/purescript-record.git
-        version: v4.0.0
-        dependencies:
-          - functions
-          - prelude
-          - unsafe-coerce
-      refined:
-        repo: https://github.com/danieljharvey/purescript-refined.git
-        version: v1.0.0
-        dependencies:
-          - argonaut
-          - effect
-          - prelude
-          - quickcheck
-          - typelevel
-      refs:
-        repo: https://github.com/purescript/purescript-refs.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - prelude
-      remotedata:
-        repo: https://github.com/krisajenkins/purescript-remotedata.git
-        version: v5.0.0
-        dependencies:
-          - bifunctors
-          - either
-          - profunctor-lenses
-      resource:
-        repo: https://github.com/joneshf/purescript-resource.git
-        version: v2.0.1
-        dependencies:
-          - aff
-          - console
-          - control
-          - effect
-          - newtype
-          - prelude
-          - psci-support
-          - refs
-      resourcet:
-        repo: https://github.com/robertdp/purescript-resourcet.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - effect
-          - foldable-traversable
-          - maybe
-          - ordered-collections
-          - parallel
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-      result:
-        repo: https://github.com/ad-si/purescript-result.git
-        version: v1.0.3
-        dependencies:
-          - either
-          - foldable-traversable
-          - prelude
-      return:
-        repo: https://github.com/ursi/purescript-return.git
-        version: v0.2.0
-        dependencies:
-          - foldable-traversable
-          - point-free
-          - prelude
-      ring-modules:
-        repo: https://github.com/f-o-a-m/purescript-ring-modules.git
-        version: v5.0.1
-        dependencies:
-          - prelude
-      routing:
-        repo: https://github.com/purescript-contrib/purescript-routing.git
-        version: v11.0.0
-        dependencies:
-          - aff
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - integers
-          - js-uri
-          - lists
-          - maybe
-          - numbers
-          - partial
-          - prelude
-          - semirings
-          - tuples
-          - validation
-          - web-html
-      routing-duplex:
-        repo: https://github.com/natefaubion/purescript-routing-duplex.git
-        version: v0.6.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - js-uri
-          - lazy
-          - numbers
-          - prelude
-          - profunctor
-          - record
-          - strings
-          - typelevel-prelude
-      run:
-        repo: https://github.com/natefaubion/purescript-run.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - free
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - tailrec
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - variant
-      safe-coerce:
-        repo: https://github.com/purescript/purescript-safe-coerce.git
-        version: v2.0.0
-        dependencies:
-          - unsafe-coerce
-      safely:
-        repo: https://github.com/paf31/purescript-safely.git
-        version: v4.0.1
-        dependencies:
-          - freet
-          - lists
-      selection-foldable:
-        repo: https://github.com/jamieyung/purescript-selection-foldable.git
-        version: v0.2.0
-        dependencies:
-          - filterable
-          - foldable-traversable
-          - maybe
-          - prelude
-      semirings:
-        repo: https://github.com/purescript/purescript-semirings.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - lists
-          - newtype
-          - prelude
-      signal:
-        repo: https://github.com/bodil/purescript-signal.git
-        version: v13.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - foldable-traversable
-          - maybe
-          - prelude
-      simple-emitter:
-        repo: https://github.com/oreshinya/purescript-simple-emitter.git
-        version: v2.0.0
-        dependencies:
-          - ordered-collections
-          - refs
-      sized-matrices:
-        repo: https://github.com/csicar/purescript-sized-matrices.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - distributive
-          - foldable-traversable
-          - maybe
-          - prelude
-          - sized-vectors
-          - strings
-          - typelevel
-          - unfoldable
-          - vectorfield
-      sized-vectors:
-        repo: https://github.com/bodil/purescript-sized-vectors.git
-        version: v5.0.2
-        dependencies:
-          - argonaut
-          - arrays
-          - distributive
-          - foldable-traversable
-          - maybe
-          - prelude
-          - quickcheck
-          - typelevel
-          - unfoldable
-      slug:
-        repo: https://github.com/thomashoneyman/purescript-slug.git
-        version: v3.0.1
-        dependencies:
-          - argonaut-codecs
-          - maybe
-          - prelude
-          - strings
-          - unicode
-      soundfonts:
-        repo: https://github.com/newlandsvalley/purescript-soundfonts.git
-        version: v4.1.0
-        dependencies:
-          - aff
-          - affjax
-          - affjax-web
-          - argonaut-core
-          - arraybuffer-types
-          - arrays
-          - b64
-          - bifunctors
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign-object
-          - http-methods
-          - integers
-          - lists
-          - maybe
-          - midi
-          - ordered-collections
-          - parallel
-          - partial
-          - prelude
-          - strings
-          - transformers
-          - tuples
-      sparse-matrices:
-        repo: https://github.com/Ebmtranceboy/purescript-sparse-matrices.git
-        version: v1.2.1
-        dependencies:
-          - console
-          - effect
-          - prelude
-          - sparse-polynomials
-      sparse-polynomials:
-        repo: https://github.com/Ebmtranceboy/purescript-sparse-polynomials.git
-        version: v1.0.5
-        dependencies:
-          - cartesian
-          - console
-          - effect
-          - ordered-collections
-          - prelude
-          - rationals
-          - tuples
-      spec:
-        repo: https://github.com/purescript-spec/purescript-spec.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - ansi
-          - avar
-          - console
-          - exceptions
-          - foldable-traversable
-          - fork
-          - now
-          - pipes
-          - prelude
-          - strings
-          - transformers
-      spec-discovery:
-        repo: https://github.com/purescript-spec/purescript-spec-discovery.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - aff-promise
-          - arrays
-          - console
-          - effect
-          - foldable-traversable
-          - node-fs
-          - prelude
-          - spec
-      spec-quickcheck:
-        repo: https://github.com/purescript-spec/purescript-spec-quickcheck.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - prelude
-          - quickcheck
-          - random
-          - spec
-      ssrs:
-        repo: https://github.com/PureFunctor/purescript-ssrs.git
-        version: v1.0.0
-        dependencies:
-          - dissect
-          - either
-          - fixed-points
-          - free
-          - lists
-          - prelude
-          - safe-coerce
-          - tailrec
-          - tuples
-          - variant
-      st:
-        repo: https://github.com/purescript/purescript-st.git
-        version: v6.0.0
-        dependencies:
-          - partial
-          - prelude
-          - tailrec
-          - unsafe-coerce
-      strictlypositiveint:
-        repo: https://github.com/jamieyung/purescript-strictlypositiveint.git
-        version: v1.0.1
-        dependencies:
-          - prelude
-      string-parsers:
-        repo: https://github.com/purescript-contrib/purescript-string-parsers.git
-        version: v8.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - prelude
-          - strings
-          - tailrec
-      strings:
-        repo: https://github.com/purescript/purescript-strings.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - enums
-          - foldable-traversable
-          - gen
-          - integers
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-          - unsafe-coerce
-      strings-extra:
-        repo: https://github.com/purescript-contrib/purescript-strings-extra.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - maybe
-          - prelude
-          - strings
-          - unicode
-      stringutils:
-        repo: https://github.com/menelaos/purescript-stringutils.git
-        version: v0.0.12
-        dependencies:
-          - arrays
-          - integers
-          - maybe
-          - partial
-          - prelude
-          - strings
-      substitute:
-        repo: https://github.com/ursi/purescript-substitute.git
-        version: v0.2.3
-        dependencies:
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - prelude
-          - return
-          - strings
-      supply:
-        repo: https://github.com/ajnsit/purescript-supply.git
-        version: v0.2.0
-        dependencies:
-          - console
-          - control
-          - effect
-          - lazy
-          - prelude
-          - refs
-          - tuples
-      tailrec:
-        repo: https://github.com/purescript/purescript-tailrec.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - effect
-          - either
-          - identity
-          - maybe
-          - partial
-          - prelude
-          - refs
-      test-unit:
-        repo: https://github.com/bodil/purescript-test-unit.git
-        version: v17.0.0
-        dependencies:
-          - aff
-          - avar
-          - effect
-          - either
-          - free
-          - js-timers
-          - lists
-          - prelude
-          - quickcheck
-          - strings
-      thermite:
-        repo: https://github.com/paf31/purescript-thermite.git
-        version: v6.3.1
-        dependencies:
-          - aff
-          - coroutines
-          - freet
-          - profunctor-lenses
-          - react
-      thermite-dom:
-        repo: https://github.com/athanclark/purescript-thermite-dom.git
-        version: v0.3.1
-        dependencies:
-          - react
-          - react-dom
-          - thermite
-          - web-html
-      these:
-        repo: https://github.com/purescript-contrib/purescript-these.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - gen
-          - lists
-          - quickcheck
-          - quickcheck-laws
-          - tuples
-      transformers:
-        repo: https://github.com/purescript/purescript-transformers.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - distributive
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - identity
-          - lazy
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      tree-rose:
-        repo: https://github.com/jordanmartinez/purescript-tree-rose.git
-        version: v4.0.2
-        dependencies:
-          - control
-          - foldable-traversable
-          - free
-          - lists
-          - maybe
-          - prelude
-          - tailrec
-      tuples:
-        repo: https://github.com/purescript/purescript-tuples.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - invariant
-          - prelude
-      two-or-more:
-        repo: https://github.com/i-am-the-slime/purescript-two-or-more.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - foldable-traversable
-          - maybe
-          - partial
-          - prelude
-          - psci-support
-          - tuples
-      type-equality:
-        repo: https://github.com/purescript/purescript-type-equality.git
-        version: v4.0.1
-        dependencies: []
-      typelevel:
-        repo: https://github.com/bodil/purescript-typelevel.git
-        version: v6.0.0
-        dependencies:
-          - partial
-          - prelude
-          - tuples
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-lists:
-        repo: https://github.com/PureFunctor/purescript-typelevel-lists.git
-        version: v2.1.0
-        dependencies:
-          - prelude
-          - tuples
-          - typelevel-peano
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-peano:
-        repo: https://github.com/csicar/purescript-typelevel-peano.git
-        version: v1.0.1
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - prelude
-          - psci-support
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-prelude:
-        repo: https://github.com/purescript/purescript-typelevel-prelude.git
-        version: v7.0.0
-        dependencies:
-          - prelude
-          - type-equality
-      typelevel-rows:
-        repo: https://github.com/jordanmartinez/purescript-typelevel-rows.git
-        version: v0.1.0
-        dependencies:
-          - prelude
-      uint:
-        repo: https://github.com/purescript-contrib/purescript-uint.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - enums
-          - gen
-          - maybe
-          - numbers
-          - prelude
-      uncurried-transformers:
-        repo: https://github.com/PureFunctor/purescript-uncurried-transformers.git
-        version: v1.1.0
-        dependencies:
-          - control
-          - effect
-          - either
-          - functions
-          - identity
-          - prelude
-          - safe-coerce
-          - tailrec
-          - transformers
-          - tuples
-      undefined-is-not-a-problem:
-        repo: https://github.com/paluh/purescript-undefined-is-not-a-problem.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - assert
-          - effect
-          - either
-          - foreign
-          - maybe
-          - newtype
-          - prelude
-          - random
-          - tuples
-          - type-equality
-          - unsafe-coerce
-      unfoldable:
-        repo: https://github.com/purescript/purescript-unfoldable.git
-        version: v6.0.0
-        dependencies:
-          - foldable-traversable
-          - maybe
-          - partial
-          - prelude
-          - tuples
-      unicode:
-        repo: https://github.com/purescript-contrib/purescript-unicode.git
-        version: v6.0.0
-        dependencies:
-          - foldable-traversable
-          - maybe
-          - strings
-      unlift:
-        repo: https://github.com/tweag/purescript-unlift.git
-        version: v1.0.1
-        dependencies:
-          - aff
-          - effect
-          - either
-          - freet
-          - identity
-          - lists
-          - maybe
-          - monad-control
-          - prelude
-          - st
-          - transformers
-          - tuples
-      unsafe-coerce:
-        repo: https://github.com/purescript/purescript-unsafe-coerce.git
-        version: v6.0.0
-        dependencies: []
-      unsafe-reference:
-        repo: https://github.com/purescript-contrib/purescript-unsafe-reference.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-      uri:
-        repo: https://github.com/purescript-contrib/purescript-uri.git
-        version: v9.0.0
-        dependencies:
-          - arrays
-          - integers
-          - js-uri
-          - numbers
-          - parsing
-          - prelude
-          - profunctor-lenses
-          - these
-          - transformers
-          - unfoldable
-      validation:
-        repo: https://github.com/purescript/purescript-validation.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - newtype
-          - prelude
-      variant:
-        repo: https://github.com/natefaubion/purescript-variant.git
-        version: v8.0.0
-        dependencies:
-          - enums
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - record
-          - tuples
-          - unsafe-coerce
-      vectorfield:
-        repo: https://github.com/csicar/purescript-vectorfield.git
-        version: v1.0.1
-        dependencies:
-          - console
-          - effect
-          - group
-          - prelude
-          - psci-support
-      versions:
-        repo: https://github.com/hdgarrood/purescript-versions.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - either
-          - foldable-traversable
-          - functions
-          - integers
-          - lists
-          - maybe
-          - orders
-          - parsing
-          - partial
-          - strings
-      web-clipboard:
-        repo: https://github.com/purescript-web/purescript-web-clipboard.git
-        version: v4.0.0
-        dependencies:
-          - web-html
-      web-cssom:
-        repo: https://github.com/purescript-web/purescript-web-cssom.git
-        version: v2.0.0
-        dependencies:
-          - web-dom
-          - web-html
-          - web-uievents
-      web-dom:
-        repo: https://github.com/purescript-web/purescript-web-dom.git
-        version: v6.0.0
-        dependencies:
-          - web-events
-      web-dom-parser:
-        repo: https://github.com/purescript-web/purescript-web-dom-parser.git
-        version: v8.0.0
-        dependencies:
-          - effect
-          - partial
-          - prelude
-          - web-dom
-      web-dom-xpath:
-        repo: https://github.com/purescript-web/purescript-web-dom-xpath.git
-        version: v3.0.0
-        dependencies:
-          - web-dom
-      web-encoding:
-        repo: https://github.com/purescript-web/purescript-web-encoding.git
-        version: v3.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - newtype
-          - prelude
-      web-events:
-        repo: https://github.com/purescript-web/purescript-web-events.git
-        version: v4.0.0
-        dependencies:
-          - datetime
-          - enums
-          - foreign
-          - nullable
-      web-fetch:
-        repo: https://github.com/purescript-web/purescript-web-fetch.git
-        version: v3.0.0
-        dependencies:
-          - effect
-          - foreign-object
-          - http-methods
-          - prelude
-          - record
-          - typelevel-prelude
-          - web-file
-          - web-promise
-          - web-streams
-      web-file:
-        repo: https://github.com/purescript-web/purescript-web-file.git
-        version: v4.0.0
-        dependencies:
-          - foreign
-          - media-types
-          - web-dom
-      web-html:
-        repo: https://github.com/purescript-web/purescript-web-html.git
-        version: v4.0.0
-        dependencies:
-          - js-date
-          - web-dom
-          - web-file
-          - web-storage
-      web-page-visibility:
-        repo: https://git.sr.ht/~toastal/purescript-web-page-visibility
-        version: v2.0.0
-        dependencies:
-          - effect
-          - enums
-          - exceptions
-          - maybe
-          - prelude
-          - strings
-          - web-events
-          - web-html
-      web-pointerevents:
-        repo: https://github.com/purescript-web/purescript-web-pointerevents.git
-        version: v1.0.0
-        dependencies:
-          - effect
-          - maybe
-          - prelude
-          - web-dom
-          - web-uievents
-      web-promise:
-        repo: https://github.com/purescript-web/purescript-web-promise.git
-        version: v3.0.0
-        dependencies:
-          - effect
-          - exceptions
-          - foldable-traversable
-          - functions
-          - maybe
-          - prelude
-      web-socket:
-        repo: https://github.com/purescript-web/purescript-web-socket.git
-        version: v4.0.0
-        dependencies:
-          - arraybuffer-types
-          - web-file
-      web-storage:
-        repo: https://github.com/purescript-web/purescript-web-storage.git
-        version: v5.0.0
-        dependencies:
-          - nullable
-          - web-events
-      web-streams:
-        repo: https://github.com/purescript-web/purescript-web-streams.git
-        version: v3.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - exceptions
-          - nullable
-          - prelude
-          - tuples
-          - web-promise
-      web-touchevents:
-        repo: https://github.com/purescript-web/purescript-web-touchevents.git
-        version: v4.0.0
-        dependencies:
-          - web-uievents
-      web-uievents:
-        repo: https://github.com/purescript-web/purescript-web-uievents.git
-        version: v4.0.0
-        dependencies:
-          - web-html
-      web-workers:
-        repo: https://github.com/gbagan/purescript-web-workers.git
-        version: v1.1.0
-        dependencies:
-          - effect
-          - foreign
-          - maybe
-          - prelude
-          - unsafe-coerce
-          - web-events
-      web-xhr:
-        repo: https://github.com/purescript-web/purescript-web-xhr.git
-        version: v5.0.0
-        dependencies:
-          - arraybuffer-types
-          - datetime
-          - http-methods
-          - web-dom
-          - web-file
-          - web-html
-      yoga-fetch:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-fetch.git
-        version: v1.0.1
-        dependencies:
-          - aff
-          - aff-promise
-          - arraybuffer-types
-          - effect
-          - foreign
-          - foreign-object
-          - newtype
-          - prelude
-          - typelevel-prelude
-          - unsafe-coerce
-      yoga-json:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-json.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - identity
-          - lists
-          - maybe
-          - nullable
-          - partial
-          - prelude
-          - record
-          - transformers
-          - typelevel-prelude
-          - variant
-      yoga-postgres:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-postgres.git
-        version: v6.0.0
-        dependencies:
-          - aff
-          - arrays
-          - datetime
-          - effect
-          - either
-          - enums
-          - foldable-traversable
-          - foreign
-          - integers
-          - maybe
-          - nullable
-          - prelude
-          - transformers
-          - unsafe-coerce
+      abc-parser: 2.0.0
+      ace: 9.0.0
+      aff: 7.1.0
+      aff-bus: 6.0.0
+      aff-coroutines: 9.0.0
+      aff-promise: 4.0.0
+      aff-retry: 2.0.0
+      affjax: 13.0.0
+      affjax-node: 1.0.0
+      affjax-web: 1.0.0
+      ansi: 7.0.0
+      argonaut: 9.0.0
+      argonaut-aeson-generic: 0.4.1
+      argonaut-codecs: 9.1.0
+      argonaut-core: 7.0.0
+      argonaut-generic: 8.0.0
+      argonaut-traversals: 10.0.0
+      argparse-basic: 2.0.0
+      array-builder: 0.1.2
+      arraybuffer: 13.1.1
+      arraybuffer-builder: 3.1.0
+      arraybuffer-types: 3.0.2
+      arrays: 7.1.0
+      arrays-zipper: 2.0.1
+      ask: 1.0.0
+      assert: 6.0.0
+      avar: 5.0.0
+      b64: 0.0.8
+      barbies: 1.0.1
+      barlow-lens: 0.9.0
+      basic-auth: 3.0.1
+      bifunctors: 6.0.0
+      bigints: 7.0.1
+      bolson: 0.3.1
+      bower-json: 3.0.0
+      bucketchain: 1.0.1
+      bucketchain-basic-auth: 1.0.1
+      bucketchain-conditional: 1.0.1
+      bucketchain-cors: 1.0.1
+      bucketchain-csrf: 1.0.1
+      bucketchain-header-utils: 1.0.1
+      bucketchain-health: 1.0.1
+      bucketchain-history-api-fallback: 1.0.1
+      bucketchain-logger: 1.0.1
+      bucketchain-secure: 1.0.1
+      bucketchain-simple-api: 5.0.1
+      bucketchain-sslify: 1.0.1
+      bucketchain-static: 1.0.1
+      call-by-name: 4.0.1
+      canvas: 6.0.0
+      canvas-action: 9.0.0
+      cartesian: 1.0.6
+      catenable-lists: 7.0.0
+      channel: 1.0.0
+      checked-exceptions: 3.1.1
+      classless: 0.1.1
+      classless-arbitrary: 0.1.1
+      classless-decode-json: 0.1.1
+      classless-encode-json: 0.1.3
+      classnames: 2.0.0
+      codec: 6.0.0
+      codec-argonaut: 10.0.0
+      colors: 7.0.1
+      concur-core: 0.5.0
+      concur-react: 0.5.0
+      concurrent-queues: 3.0.0
+      console: 6.0.0
+      const: 6.0.0
+      contravariant: 6.0.0
+      control: 6.0.0
+      convertable-options: 1.0.0
+      coroutines: 7.0.0
+      crypto: 5.0.1
+      css: 6.0.0
+      datetime: 6.1.0
+      datetime-parsing: 0.2.0
+      debug: 6.0.2
+      decimals: 7.1.0
+      default-values: 1.0.1
+      deku: 0.9.9
+      deno: 0.0.5
+      dissect: 1.0.0
+      distributive: 6.0.0
+      dodo-printer: 2.2.1
+      dom-filereader: 7.0.0
+      dom-indexed: 11.0.0
+      dotenv: 3.0.0
+      droplet: 0.5.0
+      dynamic-buffer: 3.0.1
+      echarts-simple: 0.0.1
+      effect: 4.0.0
+      either: 6.1.0
+      elmish: 0.8.3
+      elmish-enzyme: 0.1.1
+      elmish-hooks: 0.9.1
+      elmish-html: 0.7.2
+      elmish-testing-library: 0.3.1
+      email-validate: 7.0.0
+      encoding: 0.0.8
+      enums: 6.0.1
+      error: 2.0.0
+      exceptions: 6.0.0
+      exists: 6.0.0
+      exitcodes: 4.0.0
+      expect-inferred: 3.0.0
+      fahrtwind: 2.0.0
+      fallback: 0.1.0
+      fast-vect: 1.1.0
+      fetch: 1.1.4
+      fetch-argonaut: 1.0.0
+      fetch-core: 4.0.4
+      fetch-yoga-json: 1.1.0
+      filterable: 5.0.0
+      fixed-points: 7.0.0
+      fixed-precision: 5.0.0
+      flame: 1.2.0
+      float32: 2.0.0
+      foldable-traversable: 6.0.0
+      foreign: 7.0.0
+      foreign-object: 4.1.0
+      foreign-readwrite: 3.4.0
+      fork: 6.0.0
+      form-urlencoded: 7.0.0
+      formatters: 7.0.0
+      framer-motion: 1.0.1
+      free: 7.0.0
+      freeap: 7.0.0
+      freer-free: 0.0.1
+      freet: 7.0.0
+      functions: 6.0.0
+      functor1: 3.0.0
+      functors: 5.0.0
+      fuzzy: 0.4.0
+      gen: 4.0.0
+      generate-values: 1.0.1
+      generic-router: 0.0.1
+      geometry-plane: 1.0.3
+      github-actions-toolkit: 0.5.0
+      grain: 3.0.0
+      grain-router: 3.0.0
+      grain-virtualized: 3.0.0
+      graphql-client: 9.3.2
+      graphs: 8.1.0
+      group: 4.1.1
+      halogen: 7.0.0
+      halogen-bootstrap5: 2.1.0
+      halogen-css: 10.0.0
+      halogen-echarts-simple: 0.0.4
+      halogen-formless: 4.0.2
+      halogen-hooks: 0.6.3
+      halogen-hooks-extra: 0.9.0
+      halogen-store: 0.5.4
+      halogen-storybook: 2.0.0
+      halogen-subscriptions: 2.0.0
+      halogen-svg-elems: 7.0.0
+      halogen-vdom: 8.0.0
+      halogen-vdom-string-renderer: 0.5.0
+      heckin: 2.0.1
+      heterogeneous: 0.6.0
+      homogeneous: 0.4.0
+      http-methods: 6.0.0
+      httpure: 0.16.0
+      httpurple: 3.0.1
+      httpurple-argonaut: 1.0.1
+      httpurple-yoga-json: 1.0.0
+      humdrum: 0.0.1
+      hyrule: 2.3.5
+      identity: 6.0.0
+      identy: 4.0.1
+      indexed-monad: 2.1.0
+      int64: 3.0.0
+      integers: 6.0.0
+      interpolate: 5.0.2
+      invariant: 6.0.0
+      jarilo: 1.0.1
+      jelly: 0.9.1
+      jelly-hooks: 0.3.1
+      jelly-router: 0.2.2
+      jelly-signal: 0.3.0
+      jest: 1.0.0
+      js-bigints: 1.2.0
+      js-date: 8.0.0
+      js-fileio: 3.0.0
+      js-promise: 1.0.0
+      js-promise-aff: 1.0.0
+      js-timers: 6.1.0
+      js-uri: 3.1.0
+      justifill: 0.5.0
+      jwt: 0.0.9
+      language-cst-parser: 0.12.1
+      lazy: 6.0.0
+      lazy-joe: 1.0.0
+      lcg: 4.0.0
+      leibniz: 5.0.0
+      linalg: 5.1.0
+      lists: 7.0.0
+      literals: 1.0.2
+      logging: 3.0.0
+      logging-journald: 0.4.0
+      machines: 7.0.0
+      marionette: 1.0.0
+      marionette-commander: 0.1.1
+      marionette-react-basic-hooks: 0.1.1
+      matrices: 5.0.1
+      matryoshka: 1.0.0
+      maybe: 6.0.0
+      mdast-util-from-markdown: 0.2.1
+      media-types: 6.0.0
+      midi: 4.0.0
+      milkis: 9.0.0
+      minibench: 4.0.1
+      mmorph: 7.0.0
+      monad-control: 5.0.0
+      monad-logger: 1.3.1
+      monad-loops: 0.5.0
+      monad-unlift: 1.0.1
+      monoid-extras: 0.0.1
+      monoidal: 0.16.0
+      morello: 0.4.0
+      mote: 3.0.0
+      motsunabe: 2.0.0
+      mysql: 6.0.1
+      n3: 0.1.0
+      nano-id: 1.1.0
+      naturals: 3.0.0
+      nested-functor: 0.2.1
+      newtype: 5.0.0
+      nextui: 0.1.0
+      node-buffer: 8.0.0
+      node-buffer-blob: 1.0.0
+      node-child-process: 9.0.0
+      node-fs: 8.1.1
+      node-fs-aff: 9.1.0
+      node-http: 8.0.0
+      node-net: 4.0.0
+      node-path: 5.0.0
+      node-process: 10.0.0
+      node-readline: 7.0.0
+      node-sqlite3: 8.0.0
+      node-streams: 7.0.0
+      node-streams-aff: 4.0.1
+      node-url: 6.0.0
+      nodemailer: 4.0.1
+      nonempty: 7.0.0
+      now: 6.0.0
+      npm-package-json: 2.0.0
+      nullable: 6.0.0
+      numbers: 9.0.0
+      object-maps: 0.1.1
+      ocarina: 1.5.2
+      open-folds: 6.3.0
+      open-memoize: 6.1.0
+      open-pairing: 6.1.0
+      options: 7.0.0
+      optparse: 5.0.0
+      ordered-collections: 3.0.0
+      ordered-set: 0.4.0
+      orders: 6.0.0
+      pairs: 9.0.0
+      parallel: 6.0.0
+      parsing: 10.2.0
+      parsing-dataview: 3.2.4
+      partial: 4.0.0
+      pathy: 9.0.0
+      pha: 0.9.0
+      phaser: 0.6.0
+      pipes: 8.0.0
+      pirates-charm: 0.0.1
+      point-free: 1.0.0
+      pointed-list: 0.5.1
+      polymorphic-vectors: 4.0.0
+      posix-types: 6.0.0
+      precise: 6.0.0
+      precise-datetime: 7.0.0
+      prelude: 6.0.1
+      prettier-printer: 3.0.0
+      profunctor: 6.0.0
+      profunctor-lenses: 8.0.0
+      protobuf: 4.2.0
+      ps-cst: 1.2.0
+      psa-utils: 8.0.0
+      psc-ide: 19.0.0
+      psci-support: 6.0.0
+      qualified-do: 2.2.0
+      quantities: 12.1.0
+      quickcheck: 8.0.1
+      quickcheck-combinators: 0.1.3
+      quickcheck-laws: 7.0.0
+      quickcheck-utf8: 0.0.0
+      random: 6.0.0
+      rationals: 5.0.1
+      rdf: 0.1.0
+      react: 10.0.1
+      react-aria: 0.2.0
+      react-basic: 17.0.0
+      react-basic-classic: 3.0.0
+      react-basic-dnd: 10.1.0
+      react-basic-dom: 6.0.0
+      react-basic-emotion: 7.1.0
+      react-basic-hooks: 8.1.2
+      react-basic-storybook: 2.0.0
+      react-dom: 8.0.0
+      react-halo: 3.0.0
+      react-icons: 1.0.8
+      react-testing-library: 4.0.1
+      react-virtuoso: 1.0.0
+      read: 1.0.1
+      record: 4.0.0
+      record-extra: 5.0.1
+      record-studio: 1.0.4
+      refs: 6.0.0
+      remotedata: 5.0.0
+      resource: 2.0.1
+      resourcet: 1.0.0
+      result: 1.0.3
+      return: 0.2.0
+      ring-modules: 5.0.1
+      rito: 0.3.2
+      routing: 11.0.0
+      routing-duplex: 0.7.0
+      run: 5.0.0
+      safe-coerce: 2.0.0
+      safely: 4.0.1
+      school-of-music: 1.3.0
+      selection-foldable: 0.2.0
+      semirings: 7.0.0
+      signal: 13.0.0
+      simple-emitter: 3.0.1
+      simple-i18n: 2.0.1
+      simple-json: 9.0.0
+      simple-jwt: 4.0.1
+      simple-ulid: 3.0.0
+      sized-matrices: 1.0.0
+      sized-vectors: 5.0.2
+      slug: 3.0.8
+      small-ffi: 4.0.1
+      soundfonts: 4.1.0
+      sparse-matrices: 1.2.1
+      sparse-polynomials: 1.0.5
+      spec: 7.2.0
+      spec-discovery: 8.0.1
+      spec-quickcheck: 5.0.0
+      splitmix: 2.1.0
+      ssrs: 1.0.0
+      st: 6.2.0
+      strictlypositiveint: 1.0.1
+      string-parsers: 8.0.0
+      strings: 6.0.1
+      strings-extra: 4.0.0
+      stringutils: 0.0.12
+      substitute: 0.2.3
+      sunde: 3.0.0
+      supply: 0.2.0
+      svg-parser: 3.0.0
+      systemd-journald: 0.3.0
+      tagged: 4.0.2
+      tailrec: 6.1.0
+      tecton: 0.1.6
+      tecton-halogen: 0.1.3
+      test-unit: 17.0.0
+      thermite: 6.3.1
+      thermite-dom: 0.3.1
+      these: 6.0.0
+      toppokki: 4.0.0
+      transformers: 6.0.0
+      tree-rose: 4.0.2
+      tuples: 7.0.0
+      two-or-more: 1.0.0
+      type-equality: 4.0.1
+      typelevel: 6.0.0
+      typelevel-lists: 2.1.0
+      typelevel-peano: 1.0.1
+      typelevel-prelude: 7.0.0
+      typelevel-rows: 0.1.0
+      uint: 7.0.0
+      ulid: 3.0.1
+      uncurried-transformers: 1.1.0
+      undefined: 2.0.0
+      undefined-is-not-a-problem: 1.1.0
+      unfoldable: 6.0.0
+      unicode: 6.0.0
+      unlift: 1.0.1
+      unordered-collections: 3.0.1
+      unsafe-coerce: 6.0.0
+      unsafe-reference: 5.0.0
+      untagged-to-tagged: 0.1.4
+      untagged-union: 1.0.0
+      uri: 9.0.0
+      uuid: 9.0.0
+      uuidv4: 1.0.0
+      validation: 6.0.0
+      variant: 8.0.0
+      vectorfield: 1.0.1
+      vectors: 2.1.0
+      versions: 7.0.0
+      visx: 0.0.2
+      web-clipboard: 5.0.0
+      web-cssom: 2.0.0
+      web-dom: 6.0.0
+      web-dom-parser: 8.0.0
+      web-dom-xpath: 3.0.0
+      web-encoding: 3.0.0
+      web-events: 4.0.0
+      web-fetch: 3.0.0
+      web-file: 4.0.0
+      web-html: 4.1.0
+      web-pointerevents: 1.0.0
+      web-proletarian: 1.0.0
+      web-promise: 3.1.0
+      web-resize-observer: 2.0.0
+      web-router: 1.0.0
+      web-socket: 4.0.0
+      web-storage: 5.0.0
+      web-streams: 3.0.0
+      web-touchevents: 4.0.0
+      web-uievents: 4.0.0
+      web-url: 2.0.0
+      web-workers: 1.1.0
+      web-xhr: 5.0.0
+      which: 2.0.0
+      yoga-fetch: 1.0.1
+      yoga-json: 4.0.1
+      yoga-om: 0.1.0
+      yoga-postgres: 6.0.0
+      yoga-tree: 1.0.0
   extra_packages: {}
 packages:
   aff:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-aff.git
-    rev: 2d44d9f9d0d6a416a4103fba2fb39e5160f80e36
+    type: registry
+    version: 7.1.0
+    integrity: sha256-7hOC6uQO9XBAI5FD8F33ChLjFAiZVfd4BJMqlMh7TNU=
     dependencies:
+      - arrays
+      - bifunctors
+      - control
       - datetime
       - effect
+      - either
       - exceptions
+      - foldable-traversable
       - functions
+      - maybe
+      - newtype
       - parallel
+      - prelude
+      - refs
+      - tailrec
       - transformers
       - unsafe-coerce
   arrays:
-    type: git
-    url: https://github.com/purescript/purescript-arrays.git
-    rev: d20bae2f76db6cf29b7b75e26e82b8a54c32295e
+    type: registry
+    version: 7.1.0
+    integrity: sha256-Rvb3AVLal0ZLpmpABgOPIUeYHa4M+c5GwcUP5rQ2trA=
     dependencies:
       - bifunctors
       - control
@@ -3526,15 +536,16 @@ packages:
       - nonempty
       - partial
       - prelude
+      - safe-coerce
       - st
       - tailrec
       - tuples
       - unfoldable
       - unsafe-coerce
   avar:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-avar.git
-    rev: d00f5784d9cc8f079babd62740f5c52b87e5caa5
+    type: registry
+    version: 5.0.0
+    integrity: sha256-e7hf0x4hEpcygXP0LtvfvAQ49Bbj2aWtZT3gqM///0A=
     dependencies:
       - aff
       - effect
@@ -3543,9 +554,9 @@ packages:
       - functions
       - maybe
   bifunctors:
-    type: git
-    url: https://github.com/purescript/purescript-bifunctors.git
-    rev: 16ba2fb6dd7f05528ebd9e2f9ca3a068b325e5b3
+    type: registry
+    version: 6.0.0
+    integrity: sha256-/gZwC9YhNxZNQpnHa5BIYerCGM2jeX9ukZiEvYxm5Nw=
     dependencies:
       - const
       - either
@@ -3553,9 +564,9 @@ packages:
       - prelude
       - tuples
   catenable-lists:
-    type: git
-    url: https://github.com/purescript/purescript-catenable-lists.git
-    rev: 09abe1f4888bc00841ad2b59e56a9e7ce7ebd4ab
+    type: registry
+    version: 7.0.0
+    integrity: sha256-76vYENhwF4BWTBsjeLuErCH2jqVT4M3R1HX+4RwSftA=
     dependencies:
       - control
       - foldable-traversable
@@ -3565,24 +576,24 @@ packages:
       - tuples
       - unfoldable
   console:
-    type: git
-    url: https://github.com/purescript/purescript-console.git
-    rev: 3b83d7b792d03872afeea5e62b4f686ab0f09842
+    type: registry
+    version: 6.0.0
+    integrity: sha256-gJpJ53fCDAL8BiCiJXH0HNAJ9K3gJtLo8GDaCK6hA5U=
     dependencies:
       - effect
       - prelude
   const:
-    type: git
-    url: https://github.com/purescript/purescript-const.git
-    rev: ab9570cf2b6e67f7e441178211db1231cfd75c37
+    type: registry
+    version: 6.0.0
+    integrity: sha256-tNrxDW8D8H4jdHE2HiPzpLy08zkzJMmGHdRqt5BQuTc=
     dependencies:
       - invariant
       - newtype
       - prelude
   contravariant:
-    type: git
-    url: https://github.com/purescript/purescript-contravariant.git
-    rev: 9ad3e105b8855bcc25f4e0893c784789d05a58de
+    type: registry
+    version: 6.0.0
+    integrity: sha256-TP+ooAp3vvmdjfQsQJSichF5B4BPDHp3wAJoWchip6c=
     dependencies:
       - const
       - either
@@ -3590,16 +601,16 @@ packages:
       - prelude
       - tuples
   control:
-    type: git
-    url: https://github.com/purescript/purescript-control.git
-    rev: a6033808790879a17b2729e73747a9ed3fb2264e
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sH7Pg9E96JCPF9PIA6oQ8+BjTyO/BH1ZuE/bOcyj4Jk=
     dependencies:
       - newtype
       - prelude
   datetime:
-    type: git
-    url: https://github.com/purescript/purescript-datetime.git
-    rev: a6a0cf1b0324964ad1854bc3377ed8766ba90e6f
+    type: registry
+    version: 6.1.0
+    integrity: sha256-g/5X5BBegQWLpI9IWD+sY6mcaYpzzlW5lz5NBzaMtyI=
     dependencies:
       - bifunctors
       - control
@@ -3618,9 +629,9 @@ packages:
       - prelude
       - tuples
   distributive:
-    type: git
-    url: https://github.com/purescript/purescript-distributive.git
-    rev: 6005e513642e855ebf6f884d24a35c2803ca252a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-HTDdmEnzigMl+02SJB88j+gAXDx9VKsbvR4MJGDPbOQ=
     dependencies:
       - identity
       - newtype
@@ -3628,24 +639,24 @@ packages:
       - tuples
       - type-equality
   effect:
-    type: git
-    url: https://github.com/purescript/purescript-effect.git
-    rev: a192ddb923027d426d6ea3d8deb030c9aa7c7dda
+    type: registry
+    version: 4.0.0
+    integrity: sha256-eBtZu+HZcMa5HilvI6kaDyVX3ji8p0W9MGKy2K4T6+M=
     dependencies:
       - prelude
   either:
-    type: git
-    url: https://github.com/purescript/purescript-either.git
-    rev: af655a04ed2fd694b6688af39ee20d7907ad0763
+    type: registry
+    version: 6.1.0
+    integrity: sha256-6hgTPisnMWVwQivOu2PKYcH8uqjEOOqDyaDQVUchTpY=
     dependencies:
       - control
       - invariant
       - maybe
       - prelude
   enums:
-    type: git
-    url: https://github.com/purescript/purescript-enums.git
-    rev: bae47961d401f9acf88da38f32e87403e5f0cf2f
+    type: registry
+    version: 6.0.1
+    integrity: sha256-HWaD73JFLorc4A6trKIRUeDMdzE+GpkJaEOM1nTNkC8=
     dependencies:
       - control
       - either
@@ -3658,24 +669,24 @@ packages:
       - tuples
       - unfoldable
   exceptions:
-    type: git
-    url: https://github.com/purescript/purescript-exceptions.git
-    rev: afab3c07c820bb49b6c5be50049db46a964a6161
+    type: registry
+    version: 6.0.0
+    integrity: sha256-y/xTAEIZIARCE+50/u1di0ncebJ+CIwNOLswyOWzMTw=
     dependencies:
       - effect
       - either
       - maybe
       - prelude
   exists:
-    type: git
-    url: https://github.com/purescript/purescript-exists.git
-    rev: f765b4ace7869c27b9c05949e18c843881f9173b
+    type: registry
+    version: 6.0.0
+    integrity: sha256-A0JQHpTfo1dNOj9U5/Fd3xndlRSE0g2IQWOGor2yXn8=
     dependencies:
       - unsafe-coerce
   foldable-traversable:
-    type: git
-    url: https://github.com/purescript/purescript-foldable-traversable.git
-    rev: b3926f870532d287ea59e2d5cd3873b81ef2a93a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-fLeqRYM4jUrZD5H4WqcwUgzU7XfYkzO4zhgtNc3jcWM=
     dependencies:
       - bifunctors
       - const
@@ -3689,9 +700,9 @@ packages:
       - prelude
       - tuples
   free:
-    type: git
-    url: https://github.com/purescript/purescript-free.git
-    rev: e2d8fa8023a864363857834e11393483bced5e38
+    type: registry
+    version: 7.0.0
+    integrity: sha256-72auTIZAG6fhz4F94rxyDwgfnHwp+/89rujZpZWrV0w=
     dependencies:
       - catenable-lists
       - control
@@ -3708,15 +719,15 @@ packages:
       - tuples
       - unsafe-coerce
   functions:
-    type: git
-    url: https://github.com/purescript/purescript-functions.git
-    rev: f626f20580483977c5b27a01aac6471e28aff367
+    type: registry
+    version: 6.0.0
+    integrity: sha256-adMyJNEnhGde2unHHAP79gPtlNjNqzgLB8arEOn9hLI=
     dependencies:
       - prelude
   functors:
-    type: git
-    url: https://github.com/purescript/purescript-functors.git
-    rev: 022ffd7a2a7ec12080314f3d217b400674a247b4
+    type: registry
+    version: 5.0.0
+    integrity: sha256-zfPWWYisbD84MqwpJSZFlvM6v86McM68ob8p9s27ywU=
     dependencies:
       - bifunctors
       - const
@@ -3732,9 +743,9 @@ packages:
       - tuples
       - unsafe-coerce
   gen:
-    type: git
-    url: https://github.com/purescript/purescript-gen.git
-    rev: 9fbcc2a1261c32e30d79c5418edef4d96fe76931
+    type: registry
+    version: 4.0.0
+    integrity: sha256-f7yzAXWwr+xnaqEOcvyO3ezKdoes8+WXWdXIHDBCAPI=
     dependencies:
       - either
       - foldable-traversable
@@ -3747,48 +758,48 @@ packages:
       - tuples
       - unfoldable
   identity:
-    type: git
-    url: https://github.com/purescript/purescript-identity.git
-    rev: ef6768f8a52ab0bc943a85f5761ba07c257f639f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-4wY0XZbAksjY6UAg99WkuKyJlQlWAfTi2ssadH0wVMY=
     dependencies:
       - control
       - invariant
       - newtype
       - prelude
   integers:
-    type: git
-    url: https://github.com/purescript/purescript-integers.git
-    rev: 54d712b25c594833083d15dc9ff2418eb9c52822
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sf+sK26R1hzwl3NhXR7WAu9zCDjQnfoXwcyGoseX158=
     dependencies:
       - maybe
       - numbers
       - prelude
   invariant:
-    type: git
-    url: https://github.com/purescript/purescript-invariant.git
-    rev: 1d2a196d51e90623adb88496c2cfd759c6736894
+    type: registry
+    version: 6.0.0
+    integrity: sha256-RGWWyYrz0Hs1KjPDA+87Kia67ZFBhfJ5lMGOMCEFoLo=
     dependencies:
       - control
       - prelude
   js-timers:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-js-timers.git
-    rev: 7cb728b3e6dc29f355143617e6e9ac770ecd9273
+    type: registry
+    version: 6.1.0
+    integrity: sha256-znHWLSSOYw15P5DTcsAdal2lf7nGA2yayLdOZ2t5r7o=
     dependencies:
       - effect
   lazy:
-    type: git
-    url: https://github.com/purescript/purescript-lazy.git
-    rev: 48347841226b27af5205a1a8ec71e27a93ce86fd
+    type: registry
+    version: 6.0.0
+    integrity: sha256-lMsfFOnlqfe4KzRRiW8ot5ge6HtcU3Eyh2XkXcP5IgU=
     dependencies:
       - control
       - foldable-traversable
       - invariant
       - prelude
   lcg:
-    type: git
-    url: https://github.com/purescript/purescript-lcg.git
-    rev: 67c6c6483a563a59ae036d9dca0f1be2835326a5
+    type: registry
+    version: 4.0.0
+    integrity: sha256-h7ME5cthLfbgJOJdsZcSfFpwXsx4rf8YmhebU+3iSYg=
     dependencies:
       - effect
       - integers
@@ -3797,9 +808,9 @@ packages:
       - prelude
       - random
   lists:
-    type: git
-    url: https://github.com/purescript/purescript-lists.git
-    rev: b113451e5b41cad87d669a3165f955c71cd863e2
+    type: registry
+    version: 7.0.0
+    integrity: sha256-EKF15qYqucuXP2lT/xPxhqy58f0FFT6KHdIB/yBOayI=
     dependencies:
       - bifunctors
       - control
@@ -3814,25 +825,25 @@ packages:
       - tuples
       - unfoldable
   maybe:
-    type: git
-    url: https://github.com/purescript/purescript-maybe.git
-    rev: c6f98ac1088766287106c5d9c8e30e7648d36786
+    type: registry
+    version: 6.0.0
+    integrity: sha256-5cCIb0wPwbat2PRkQhUeZO0jcAmf8jCt2qE0wbC3v2Q=
     dependencies:
       - control
       - invariant
       - newtype
       - prelude
   newtype:
-    type: git
-    url: https://github.com/purescript/purescript-newtype.git
-    rev: 29d8e6dd77aec2c975c948364ec3faf26e14ee7b
+    type: registry
+    version: 5.0.0
+    integrity: sha256-gdrQu8oGe9eZE6L3wOI8ql/igOg+zEGB5ITh2g+uttw=
     dependencies:
       - prelude
       - safe-coerce
   nonempty:
-    type: git
-    url: https://github.com/purescript/purescript-nonempty.git
-    rev: 28150ecc7419238b187abd609a92a645273348bb
+    type: registry
+    version: 7.0.0
+    integrity: sha256-54ablJZUHGvvlTJzi3oXyPCuvY6zsrWJuH/dMJ/MFLs=
     dependencies:
       - control
       - foldable-traversable
@@ -3841,16 +852,16 @@ packages:
       - tuples
       - unfoldable
   numbers:
-    type: git
-    url: https://github.com/purescript/purescript-numbers.git
-    rev: 2a53528f18f9415334bae28e7bb3cf3be86342c2
+    type: registry
+    version: 9.0.0
+    integrity: sha256-fDKXExFxMRFgy+v+kbjVbGBIOOQkWGnmm0vtnE3zWRE=
     dependencies:
       - functions
       - maybe
   ordered-collections:
-    type: git
-    url: https://github.com/purescript/purescript-ordered-collections.git
-    rev: 9826b7632d0d0a691173bde308a634195f42a419
+    type: registry
+    version: 3.0.0
+    integrity: sha256-R9WddNBRPkY37gw8XkDCLX2vJ5eI9qdaWDdCp61r2+M=
     dependencies:
       - arrays
       - foldable-traversable
@@ -3864,16 +875,16 @@ packages:
       - tuples
       - unfoldable
   orders:
-    type: git
-    url: https://github.com/purescript/purescript-orders.git
-    rev: f86db621ec5eef1274145f8b1fd8ebbfe0ed4a2c
+    type: registry
+    version: 6.0.0
+    integrity: sha256-nBA0g3/ai0euH8q9pSbGqk53W2q6agm/dECZTHcoink=
     dependencies:
       - newtype
       - prelude
   parallel:
-    type: git
-    url: https://github.com/purescript/purescript-parallel.git
-    rev: 85290dca837771ac4870071008c933d315ef678f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-VJbkGD0rAKX+NUEeBJbYJ78bEKaZbgow+QwQEfPB6ko=
     dependencies:
       - control
       - effect
@@ -3887,19 +898,19 @@ packages:
       - refs
       - transformers
   partial:
-    type: git
-    url: https://github.com/purescript/purescript-partial.git
-    rev: 0fa0646f5ea1ec5f0c46dcbd770c705a6c9ad3ec
+    type: registry
+    version: 4.0.0
+    integrity: sha256-fwXerld6Xw1VkReh8yeQsdtLVrjfGiVuC5bA1Wyo/J4=
     dependencies: []
   prelude:
-    type: git
-    url: https://github.com/purescript/purescript-prelude.git
-    rev: 32787f4399c92459c41602131a5858559eb868c5
+    type: registry
+    version: 6.0.1
+    integrity: sha256-o8p6SLYmVPqzXZhQFd2hGAWEwBoXl1swxLG/scpJ0V0=
     dependencies: []
   profunctor:
-    type: git
-    url: https://github.com/purescript/purescript-profunctor.git
-    rev: 0a966a14e7b0c827d44657dc1710cdc712d2e034
+    type: registry
+    version: 6.0.0
+    integrity: sha256-99NzxFgTr4CGlCSRYG1kShL+JhYbihhHtbOk1/0R5zI=
     dependencies:
       - control
       - distributive
@@ -3910,9 +921,9 @@ packages:
       - prelude
       - tuples
   quickcheck:
-    type: git
-    url: https://github.com/purescript/purescript-quickcheck.git
-    rev: bf5029f97e6c0d7552d3a08d2ab793a19e2c5e3d
+    type: registry
+    version: 8.0.1
+    integrity: sha256-ZvpccKQCvgslTXZCNmpYW4bUsFzhZd/kQUr2WmxFTGY=
     dependencies:
       - arrays
       - console
@@ -3942,46 +953,46 @@ packages:
       - tuples
       - unfoldable
   random:
-    type: git
-    url: https://github.com/purescript/purescript-random.git
-    rev: 9540bc965a9596da02fefd9949418bb19c92533a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-CJ611a35MPCE7XQMp0rdC6MCn76znlhisiCRgboAG+Q=
     dependencies:
       - effect
       - integers
   record:
-    type: git
-    url: https://github.com/purescript/purescript-record.git
-    rev: c89cd1ada6b636692571fc374196b1c39c4c9f70
+    type: registry
+    version: 4.0.0
+    integrity: sha256-Za5U85bTRJEfGK5Sk4hM41oXy84YQI0I8TL3WUn1Qzg=
     dependencies:
       - functions
       - prelude
       - unsafe-coerce
   refs:
-    type: git
-    url: https://github.com/purescript/purescript-refs.git
-    rev: f8e6216da4cb9309fde1f20cd6f69ac3a3b7f9e8
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Vgwne7jIbD3ZMoLNNETLT8Litw6lIYo3MfYNdtYWj9s=
     dependencies:
       - effect
       - prelude
   safe-coerce:
-    type: git
-    url: https://github.com/purescript/purescript-safe-coerce.git
-    rev: 7fa799ae80a38b8d948efcb52608e58e198b3da7
+    type: registry
+    version: 2.0.0
+    integrity: sha256-a1ibQkiUcbODbLE/WAq7Ttbbh9ex+x33VCQ7GngKudU=
     dependencies:
       - unsafe-coerce
   st:
-    type: git
-    url: https://github.com/purescript/purescript-st.git
-    rev: 2cc7ae1c3318a303378c4a9f3fa0f10ee7cc3589
+    type: registry
+    version: 6.2.0
+    integrity: sha256-z9X0WsOUlPwNx9GlCC+YccCyz8MejC8Wb0C4+9fiBRY=
     dependencies:
       - partial
       - prelude
       - tailrec
       - unsafe-coerce
   strings:
-    type: git
-    url: https://github.com/purescript/purescript-strings.git
-    rev: 4bc6954448d056f8aa7a659695a6ad60ad4fdf19
+    type: registry
+    version: 6.0.1
+    integrity: sha256-WssD3DbX4OPzxSdjvRMX0yvc9+pS7n5gyPv5I2Trb7k=
     dependencies:
       - arrays
       - control
@@ -4000,9 +1011,9 @@ packages:
       - unfoldable
       - unsafe-coerce
   tailrec:
-    type: git
-    url: https://github.com/purescript/purescript-tailrec.git
-    rev: 5e2104aa734b31a17074cc805bf087d72b65afd1
+    type: registry
+    version: 6.1.0
+    integrity: sha256-Xx19ECVDRrDWpz9D2GxQHHV89vd61dnXxQm0IcYQHGk=
     dependencies:
       - bifunctors
       - effect
@@ -4013,9 +1024,9 @@ packages:
       - prelude
       - refs
   test-unit:
-    type: git
-    url: https://github.com/bodil/purescript-test-unit.git
-    rev: 3112d7ebe06d467238058a6384dc75ffd960d335
+    type: registry
+    version: 17.0.0
+    integrity: sha256-aITJ2KngFFjASmG0JjnjybaKWl9dn7Hf2B3Wk4engNs=
     dependencies:
       - aff
       - avar
@@ -4028,9 +1039,9 @@ packages:
       - quickcheck
       - strings
   transformers:
-    type: git
-    url: https://github.com/purescript/purescript-transformers.git
-    rev: be72ab52357d9a665cbf93d73ba1c07c4b0957ee
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Pzw40HjthX77tdPAYzjx43LK3X5Bb7ZspYAp27wksFA=
     dependencies:
       - control
       - distributive
@@ -4047,22 +1058,22 @@ packages:
       - tuples
       - unfoldable
   tuples:
-    type: git
-    url: https://github.com/purescript/purescript-tuples.git
-    rev: 4f52da2729b448c8564369378f1232d8d2dc1d8b
+    type: registry
+    version: 7.0.0
+    integrity: sha256-1rXgTomes9105BjgXqIw0FL6Fz1lqqUTLWOumhWec1M=
     dependencies:
       - control
       - invariant
       - prelude
   type-equality:
-    type: git
-    url: https://github.com/purescript/purescript-type-equality.git
-    rev: 0525b7d39e0fbd81b4209518139fb8ab02695774
+    type: registry
+    version: 4.0.1
+    integrity: sha256-Hs9D6Y71zFi/b+qu5NSbuadUQXe5iv5iWx0226vOHUw=
     dependencies: []
   unfoldable:
-    type: git
-    url: https://github.com/purescript/purescript-unfoldable.git
-    rev: 493dfe04ed590e20d8f69079df2f58486882748d
+    type: registry
+    version: 6.0.0
+    integrity: sha256-JtikvJdktRap7vr/K4ITlxUX1QexpnqBq0G/InLr6eg=
     dependencies:
       - foldable-traversable
       - maybe
@@ -4070,7 +1081,7 @@ packages:
       - prelude
       - tuples
   unsafe-coerce:
-    type: git
-    url: https://github.com/purescript/purescript-unsafe-coerce.git
-    rev: ab956f82e66e633f647fb3098e8ddd3ec58d689f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-IqIYW4Vkevn8sI+6aUwRGvd87tVL36BBeOr0cGAE7t0=
     dependencies: []

--- a/exercises/chapter6/spago.lock
+++ b/exercises/chapter6/spago.lock
@@ -1,0 +1,4076 @@
+workspace:
+  packages:
+    my-project:
+      path: ./
+      dependencies:
+        - arrays
+        - console
+        - effect
+        - either
+        - foldable-traversable
+        - lists
+        - maybe
+        - newtype
+        - partial
+        - prelude
+        - strings
+        - test-unit
+        - tuples
+      test_dependencies: []
+      build_plan:
+        - aff
+        - arrays
+        - avar
+        - bifunctors
+        - catenable-lists
+        - console
+        - const
+        - contravariant
+        - control
+        - datetime
+        - distributive
+        - effect
+        - either
+        - enums
+        - exceptions
+        - exists
+        - foldable-traversable
+        - free
+        - functions
+        - functors
+        - gen
+        - identity
+        - integers
+        - invariant
+        - js-timers
+        - lazy
+        - lcg
+        - lists
+        - maybe
+        - newtype
+        - nonempty
+        - numbers
+        - ordered-collections
+        - orders
+        - parallel
+        - partial
+        - prelude
+        - profunctor
+        - quickcheck
+        - random
+        - record
+        - refs
+        - safe-coerce
+        - st
+        - strings
+        - tailrec
+        - test-unit
+        - transformers
+        - tuples
+        - type-equality
+        - unfoldable
+        - unsafe-coerce
+  package_set:
+    address:
+      url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
+    compiler: ">=0.15.0 <0.16.0"
+    content:
+      ace:
+        repo: https://github.com/purescript-contrib/purescript-ace.git
+        version: v9.0.0
+        dependencies:
+          - arrays
+          - effect
+          - foreign
+          - nullable
+          - prelude
+          - web-html
+          - web-uievents
+      aff:
+        repo: https://github.com/purescript-contrib/purescript-aff.git
+        version: v7.0.0
+        dependencies:
+          - datetime
+          - effect
+          - exceptions
+          - functions
+          - parallel
+          - transformers
+          - unsafe-coerce
+      aff-bus:
+        repo: https://github.com/purescript-contrib/purescript-aff-bus.git
+        version: v6.0.0
+        dependencies:
+          - aff
+          - avar
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - lists
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+      aff-coroutines:
+        repo: https://github.com/purescript-contrib/purescript-aff-coroutines.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - avar
+          - coroutines
+          - effect
+      aff-promise:
+        repo: https://github.com/nwolverson/purescript-aff-promise.git
+        version: v4.0.0
+        dependencies:
+          - aff
+          - foreign
+      aff-retry:
+        repo: https://github.com/Unisay/purescript-aff-retry.git
+        version: v2.0.0
+        dependencies:
+          - aff
+          - arrays
+          - datetime
+          - effect
+          - either
+          - exceptions
+          - integers
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - random
+          - transformers
+      affjax:
+        repo: https://github.com/purescript-contrib/purescript-affjax.git
+        version: v13.0.0
+        dependencies:
+          - aff
+          - argonaut-core
+          - arraybuffer-types
+          - foreign
+          - form-urlencoded
+          - http-methods
+          - integers
+          - media-types
+          - nullable
+          - refs
+          - unsafe-coerce
+          - web-xhr
+      affjax-node:
+        repo: https://github.com/purescript-contrib/purescript-affjax-node.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - affjax
+          - either
+          - maybe
+          - prelude
+      affjax-web:
+        repo: https://github.com/purescript-contrib/purescript-affjax-web.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - affjax
+          - either
+          - maybe
+          - prelude
+      ansi:
+        repo: https://github.com/hdgarrood/purescript-ansi.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - lists
+          - strings
+      argonaut:
+        repo: https://github.com/purescript-contrib/purescript-argonaut.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - argonaut-traversals
+      argonaut-codecs:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-codecs.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-core
+          - arrays
+          - effect
+          - foreign-object
+          - identity
+          - integers
+          - maybe
+          - nonempty
+          - ordered-collections
+          - prelude
+          - record
+      argonaut-core:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-core.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - foreign-object
+          - functions
+          - gen
+          - maybe
+          - nonempty
+          - prelude
+          - strings
+          - tailrec
+      argonaut-generic:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-generic.git
+        version: v8.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - prelude
+          - record
+      argonaut-traversals:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-traversals.git
+        version: v10.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - profunctor-lenses
+      argparse-basic:
+        repo: https://github.com/natefaubion/purescript-argparse-basic.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - record
+          - strings
+          - tuples
+          - unfoldable
+      arraybuffer:
+        repo: https://github.com/purescript-contrib/purescript-arraybuffer.git
+        version: v13.0.0
+        dependencies:
+          - arraybuffer-types
+          - arrays
+          - effect
+          - float32
+          - functions
+          - gen
+          - maybe
+          - nullable
+          - prelude
+          - tailrec
+          - uint
+          - unfoldable
+      arraybuffer-builder:
+        repo: https://github.com/jamesdbrock/purescript-arraybuffer-builder.git
+        version: v3.0.1
+        dependencies:
+          - arraybuffer
+          - arraybuffer-types
+          - effect
+          - float32
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - transformers
+          - uint
+      arraybuffer-types:
+        repo: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
+        version: v3.0.2
+        dependencies: []
+      arrays:
+        repo: https://github.com/purescript/purescript-arrays.git
+        version: v7.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - foldable-traversable
+          - maybe
+          - nonempty
+          - partial
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - unfoldable
+          - unsafe-coerce
+      arrays-zipper:
+        repo: https://github.com/JordanMartinez/purescript-arrays-zipper.git
+        version: v2.0.1
+        dependencies:
+          - arrays
+          - control
+          - quickcheck
+      ask:
+        repo: https://github.com/Mateiadrielrafael/purescript-ask.git
+        version: v1.0.0
+        dependencies:
+          - unsafe-coerce
+      assert:
+        repo: https://github.com/purescript/purescript-assert.git
+        version: v6.0.0
+        dependencies:
+          - console
+          - effect
+          - prelude
+      avar:
+        repo: https://github.com/purescript-contrib/purescript-avar.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - exceptions
+          - functions
+          - maybe
+      b64:
+        repo: https://github.com/menelaos/purescript-b64.git
+        version: v0.0.8
+        dependencies:
+          - arraybuffer-types
+          - either
+          - encoding
+          - enums
+          - exceptions
+          - functions
+          - partial
+          - prelude
+          - strings
+      barlow-lens:
+        repo: https://github.com/sigma-andex/purescript-barlow-lens.git
+        version: v0.9.0
+        dependencies:
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - profunctor-lenses
+          - tuples
+          - typelevel-prelude
+      bifunctors:
+        repo: https://github.com/purescript/purescript-bifunctors.git
+        version: v6.0.0
+        dependencies:
+          - const
+          - either
+          - newtype
+          - prelude
+          - tuples
+      bigints:
+        repo: https://github.com/sharkdp/purescript-bigints.git
+        version: v7.0.1
+        dependencies:
+          - integers
+          - maybe
+          - strings
+      bower-json:
+        repo: https://github.com/klntsky/purescript-bower-json.git
+        version: v3.0.0
+        dependencies:
+          - argonaut-codecs
+          - arrays
+          - either
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - newtype
+          - prelude
+          - tuples
+      call-by-name:
+        repo: https://github.com/natefaubion/purescript-call-by-name.git
+        version: v4.0.1
+        dependencies:
+          - control
+          - either
+          - lazy
+          - maybe
+          - unsafe-coerce
+      canvas:
+        repo: https://github.com/purescript-web/purescript-canvas.git
+        version: v6.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - exceptions
+          - functions
+          - maybe
+      canvas-action:
+        repo: https://github.com/artemisSystem/purescript-canvas-action.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - arrays
+          - canvas
+          - colors
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - maybe
+          - numbers
+          - polymorphic-vectors
+          - prelude
+          - refs
+          - run
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-html
+      cartesian:
+        repo: https://github.com/Ebmtranceboy/purescript-cartesian.git
+        version: v1.0.6
+        dependencies:
+          - console
+          - effect
+          - integers
+          - psci-support
+      catenable-lists:
+        repo: https://github.com/purescript/purescript-catenable-lists.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - lists
+          - maybe
+          - prelude
+          - tuples
+          - unfoldable
+      channel:
+        repo: https://github.com/ConnorDillon/purescript-channel.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - assert
+          - avar
+          - console
+          - contravariant
+          - control
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - lazy
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      checked-exceptions:
+        repo: https://github.com/natefaubion/purescript-checked-exceptions.git
+        version: v3.1.1
+        dependencies:
+          - prelude
+          - transformers
+          - variant
+      codec:
+        repo: https://github.com/garyb/purescript-codec.git
+        version: v5.0.0
+        dependencies:
+          - profunctor
+          - transformers
+      codec-argonaut:
+        repo: https://github.com/garyb/purescript-codec-argonaut.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-core
+          - codec
+          - ordered-collections
+          - type-equality
+          - variant
+      colors:
+        repo: https://github.com/purescript-contrib/purescript-colors.git
+        version: v7.0.1
+        dependencies:
+          - arrays
+          - integers
+          - lists
+          - numbers
+          - partial
+          - strings
+      concurrent-queues:
+        repo: https://github.com/purescript-contrib/purescript-concurrent-queues.git
+        version: v3.0.0
+        dependencies:
+          - aff
+          - avar
+          - effect
+      console:
+        repo: https://github.com/purescript/purescript-console.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - prelude
+      const:
+        repo: https://github.com/purescript/purescript-const.git
+        version: v6.0.0
+        dependencies:
+          - invariant
+          - newtype
+          - prelude
+      contravariant:
+        repo: https://github.com/purescript/purescript-contravariant.git
+        version: v6.0.0
+        dependencies:
+          - const
+          - either
+          - newtype
+          - prelude
+          - tuples
+      control:
+        repo: https://github.com/purescript/purescript-control.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      convertable-options:
+        repo: https://github.com/natefaubion/purescript-convertable-options.git
+        version: v1.0.0
+        dependencies:
+          - console
+          - effect
+          - maybe
+          - record
+      coroutines:
+        repo: https://github.com/purescript-contrib/purescript-coroutines.git
+        version: v7.0.0
+        dependencies:
+          - freet
+          - parallel
+          - profunctor
+      css:
+        repo: https://github.com/purescript-contrib/purescript-css.git
+        version: v6.0.0
+        dependencies:
+          - colors
+          - console
+          - effect
+          - nonempty
+          - profunctor
+          - strings
+          - these
+          - transformers
+      datetime:
+        repo: https://github.com/purescript/purescript-datetime.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - either
+          - enums
+          - foldable-traversable
+          - functions
+          - gen
+          - integers
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - ordered-collections
+          - partial
+          - prelude
+          - tuples
+      datetime-parsing:
+        repo: https://github.com/flounders/purescript-datetime-parsing.git
+        version: v0.2.0
+        dependencies:
+          - arrays
+          - datetime
+          - either
+          - enums
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - numbers
+          - parsing
+          - prelude
+          - strings
+          - unicode
+      debug:
+        repo: https://github.com/garyb/purescript-debug.git
+        version: v6.0.0
+        dependencies:
+          - functions
+          - prelude
+      decimals:
+        repo: https://github.com/sharkdp/purescript-decimals.git
+        version: v7.0.0
+        dependencies:
+          - maybe
+      dissect:
+        repo: https://github.com/PureFunctor/purescript-dissect.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - foreign-object
+          - functors
+          - newtype
+          - partial
+          - prelude
+          - tailrec
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - variant
+      distributive:
+        repo: https://github.com/purescript/purescript-distributive.git
+        version: v6.0.0
+        dependencies:
+          - identity
+          - newtype
+          - prelude
+          - tuples
+          - type-equality
+      dodo-printer:
+        repo: https://github.com/natefaubion/purescript-dodo-printer.git
+        version: v2.2.0
+        dependencies:
+          - aff
+          - ansi
+          - avar
+          - console
+          - effect
+          - foldable-traversable
+          - lists
+          - maybe
+          - minibench
+          - node-child-process
+          - node-fs-aff
+          - node-process
+          - psci-support
+          - strings
+      dom-indexed:
+        repo: https://github.com/purescript-halogen/purescript-dom-indexed.git
+        version: v11.0.0
+        dependencies:
+          - media-types
+          - prelude
+          - web-clipboard
+          - web-pointerevents
+          - web-touchevents
+      droplet:
+        repo: https://github.com/easafe/purescript-droplet.git
+        version: v0.4.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - bigints
+          - datetime
+          - debug
+          - effect
+          - either
+          - enums
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - integers
+          - maybe
+          - newtype
+          - nullable
+          - ordered-collections
+          - partial
+          - prelude
+          - profunctor
+          - record
+          - spec
+          - strings
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+      dynamic-buffer:
+        repo: https://github.com/kritzcreek/purescript-dynamic-buffer.git
+        version: v3.0.1
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - refs
+      effect:
+        repo: https://github.com/purescript/purescript-effect.git
+        version: v4.0.0
+        dependencies:
+          - prelude
+      either:
+        repo: https://github.com/purescript/purescript-either.git
+        version: v6.1.0
+        dependencies:
+          - control
+          - invariant
+          - maybe
+          - prelude
+      elmish:
+        repo: https://github.com/collegevine/purescript-elmish.git
+        version: v0.8.1
+        dependencies:
+          - aff
+          - argonaut-core
+          - arrays
+          - bifunctors
+          - console
+          - debug
+          - effect
+          - either
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - functions
+          - integers
+          - js-date
+          - maybe
+          - nullable
+          - partial
+          - prelude
+          - refs
+          - typelevel-prelude
+          - undefined-is-not-a-problem
+          - unsafe-coerce
+          - web-dom
+          - web-html
+      elmish-enzyme:
+        repo: https://github.com/collegevine/purescript-elmish-enzyme.git
+        version: v0.1.1
+        dependencies:
+          - aff
+          - aff-promise
+          - arrays
+          - console
+          - debug
+          - effect
+          - elmish
+          - foldable-traversable
+          - foreign
+          - functions
+          - prelude
+          - transformers
+          - unsafe-coerce
+      elmish-hooks:
+        repo: https://github.com/collegevine/purescript-elmish-hooks.git
+        version: v0.8.2
+        dependencies:
+          - aff
+          - debug
+          - elmish
+          - maybe
+          - prelude
+          - tuples
+          - undefined-is-not-a-problem
+      elmish-html:
+        repo: https://github.com/collegevine/purescript-elmish-html.git
+        version: v0.7.1
+        dependencies:
+          - effect
+          - elmish
+          - foreign
+          - foreign-object
+          - prelude
+          - record
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-html
+      email-validate:
+        repo: https://github.com/cdepillabout/purescript-email-validate.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - string-parsers
+          - transformers
+      encoding:
+        repo: https://github.com/menelaos/purescript-encoding.git
+        version: v0.0.8
+        dependencies:
+          - arraybuffer-types
+          - either
+          - exceptions
+          - functions
+          - prelude
+      enums:
+        repo: https://github.com/purescript/purescript-enums.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - either
+          - gen
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tuples
+          - unfoldable
+      exceptions:
+        repo: https://github.com/purescript/purescript-exceptions.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - either
+          - maybe
+          - prelude
+      exists:
+        repo: https://github.com/purescript/purescript-exists.git
+        version: v6.0.0
+        dependencies:
+          - unsafe-coerce
+      exitcodes:
+        repo: https://github.com/Risto-Stevcev/purescript-exitcodes.git
+        version: v4.0.0
+        dependencies:
+          - enums
+      expect-inferred:
+        repo: https://github.com/justinwoo/purescript-expect-inferred.git
+        version: v3.0.0
+        dependencies:
+          - prelude
+          - typelevel-prelude
+      fast-vect:
+        repo: https://github.com/sigma-andex/purescript-fast-vect.git
+        version: v0.7.0
+        dependencies:
+          - arrays
+          - filterable
+          - foldable-traversable
+          - lists
+          - maybe
+          - ordered-collections
+          - prelude
+          - profunctor
+          - tuples
+          - unfoldable
+      filterable:
+        repo: https://github.com/purescript/purescript-filterable.git
+        version: v5.0.0
+        dependencies:
+          - arrays
+          - either
+          - foldable-traversable
+          - identity
+          - lists
+          - ordered-collections
+      fixed-points:
+        repo: https://github.com/purescript-contrib/purescript-fixed-points.git
+        version: v7.0.0
+        dependencies:
+          - exists
+          - newtype
+          - prelude
+          - transformers
+      fixed-precision:
+        repo: https://github.com/lumihq/purescript-fixed-precision.git
+        version: v5.0.0
+        dependencies:
+          - arrays
+          - bigints
+          - control
+          - integers
+          - maybe
+          - numbers
+          - partial
+          - prelude
+          - strings
+      flame:
+        repo: https://github.com/easafe/purescript-flame.git
+        version: v1.2.0
+        dependencies:
+          - aff
+          - argonaut-codecs
+          - argonaut-core
+          - argonaut-generic
+          - arrays
+          - bifunctors
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - maybe
+          - newtype
+          - nullable
+          - partial
+          - prelude
+          - random
+          - refs
+          - spec
+          - strings
+          - tuples
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-html
+          - web-uievents
+      float32:
+        repo: https://github.com/purescript-contrib/purescript-float32.git
+        version: v2.0.0
+        dependencies:
+          - gen
+          - maybe
+          - prelude
+      foldable-traversable:
+        repo: https://github.com/purescript/purescript-foldable-traversable.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - const
+          - control
+          - either
+          - functors
+          - identity
+          - maybe
+          - newtype
+          - orders
+          - prelude
+          - tuples
+      foreign:
+        repo: https://github.com/purescript/purescript-foreign.git
+        version: v7.0.0
+        dependencies:
+          - either
+          - functions
+          - identity
+          - integers
+          - lists
+          - maybe
+          - prelude
+          - strings
+          - transformers
+      foreign-object:
+        repo: https://github.com/purescript/purescript-foreign-object.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - functions
+          - gen
+          - lists
+          - maybe
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - typelevel-prelude
+          - unfoldable
+      foreign-readwrite:
+        repo: https://github.com/artemisSystem/purescript-foreign-readwrite.git
+        version: v3.0.0
+        dependencies:
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - record
+          - safe-coerce
+          - transformers
+          - unsafe-coerce
+      fork:
+        repo: https://github.com/purescript-contrib/purescript-fork.git
+        version: v6.0.0
+        dependencies:
+          - aff
+      form-urlencoded:
+        repo: https://github.com/purescript-contrib/purescript-form-urlencoded.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - js-uri
+          - maybe
+          - newtype
+          - prelude
+          - strings
+          - tuples
+      formatters:
+        repo: https://github.com/purescript-contrib/purescript-formatters.git
+        version: v7.0.0
+        dependencies:
+          - datetime
+          - fixed-points
+          - lists
+          - numbers
+          - parsing
+          - prelude
+          - transformers
+      free:
+        repo: https://github.com/purescript/purescript-free.git
+        version: v7.0.0
+        dependencies:
+          - catenable-lists
+          - control
+          - distributive
+          - either
+          - exists
+          - foldable-traversable
+          - invariant
+          - lazy
+          - maybe
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+      freeap:
+        repo: https://github.com/ethul/purescript-freeap.git
+        version: v7.0.0
+        dependencies:
+          - const
+          - exists
+          - gen
+          - lists
+      freet:
+        repo: https://github.com/purescript-contrib/purescript-freet.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - bifunctors
+          - effect
+          - either
+          - exists
+          - free
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      functions:
+        repo: https://github.com/purescript/purescript-functions.git
+        version: v6.0.0
+        dependencies:
+          - prelude
+      functors:
+        repo: https://github.com/purescript/purescript-functors.git
+        version: v5.0.0
+        dependencies:
+          - bifunctors
+          - const
+          - contravariant
+          - control
+          - distributive
+          - either
+          - invariant
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - tuples
+          - unsafe-coerce
+      fuzzy:
+        repo: https://github.com/citizennet/purescript-fuzzy.git
+        version: v0.4.0
+        dependencies:
+          - foldable-traversable
+          - foreign-object
+          - newtype
+          - ordered-collections
+          - prelude
+          - rationals
+          - strings
+          - tuples
+      gen:
+        repo: https://github.com/purescript/purescript-gen.git
+        version: v4.0.0
+        dependencies:
+          - either
+          - foldable-traversable
+          - identity
+          - maybe
+          - newtype
+          - nonempty
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      generate-values:
+        repo: https://github.com/jordanmartinez/purescript-generate-values.git
+        version: v1.0.1
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - enums
+          - foldable-traversable
+          - gen
+          - identity
+          - integers
+          - lcg
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - partial
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      geometry-plane:
+        repo: https://github.com/Ebmtranceboy/purescript-geometry-plane.git
+        version: v1.0.3
+        dependencies:
+          - console
+          - effect
+          - psci-support
+          - sparse-polynomials
+      github-actions-toolkit:
+        repo: https://github.com/purescript-contrib/purescript-github-actions-toolkit.git
+        version: v0.5.0
+        dependencies:
+          - aff
+          - aff-promise
+          - effect
+          - foreign-object
+          - node-buffer
+          - node-path
+          - node-streams
+          - nullable
+          - transformers
+      graphs:
+        repo: https://github.com/purescript/purescript-graphs.git
+        version: v8.0.0
+        dependencies:
+          - catenable-lists
+          - ordered-collections
+      group:
+        repo: https://github.com/morganthomas/purescript-group.git
+        version: v4.1.1
+        dependencies:
+          - lists
+      halogen:
+        repo: https://github.com/purescript-halogen/purescript-halogen.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - avar
+          - console
+          - const
+          - dom-indexed
+          - effect
+          - foreign
+          - fork
+          - free
+          - freeap
+          - halogen-subscriptions
+          - halogen-vdom
+          - media-types
+          - nullable
+          - ordered-collections
+          - parallel
+          - profunctor
+          - transformers
+          - unsafe-coerce
+          - unsafe-reference
+          - web-file
+          - web-uievents
+      halogen-css:
+        repo: https://github.com/purescript-halogen/purescript-halogen-css.git
+        version: v10.0.0
+        dependencies:
+          - css
+          - halogen
+      halogen-formless:
+        repo: https://github.com/thomashoneyman/purescript-halogen-formless.git
+        version: v4.0.0
+        dependencies:
+          - convertable-options
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - halogen
+          - heterogeneous
+          - maybe
+          - prelude
+          - record
+          - safe-coerce
+          - type-equality
+          - unsafe-coerce
+          - unsafe-reference
+          - variant
+          - web-events
+          - web-uievents
+      halogen-hooks:
+        repo: https://github.com/thomashoneyman/purescript-halogen-hooks.git
+        version: v0.6.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - effect
+          - exceptions
+          - foldable-traversable
+          - foreign-object
+          - free
+          - freeap
+          - halogen
+          - halogen-subscriptions
+          - maybe
+          - newtype
+          - ordered-collections
+          - parallel
+          - partial
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+          - unsafe-reference
+          - web-dom
+          - web-html
+      halogen-hooks-extra:
+        repo: https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git
+        version: v0.9.0
+        dependencies:
+          - halogen-hooks
+      halogen-store:
+        repo: https://github.com/thomashoneyman/purescript-halogen-store.git
+        version: v0.5.0
+        dependencies:
+          - aff
+          - distributive
+          - effect
+          - fork
+          - halogen
+          - halogen-hooks
+          - halogen-subscriptions
+          - maybe
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-reference
+      halogen-storybook:
+        repo: https://github.com/rnons/purescript-halogen-storybook.git
+        version: v2.0.0
+        dependencies:
+          - foreign-object
+          - halogen
+          - prelude
+          - routing
+      halogen-subscriptions:
+        repo: https://github.com/purescript-halogen/purescript-halogen-subscriptions.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - effect
+          - foldable-traversable
+          - functors
+          - refs
+          - safe-coerce
+          - unsafe-reference
+      halogen-svg-elems:
+        repo: https://github.com/JordanMartinez/purescript-halogen-svg-elems.git
+        version: v6.0.0
+        dependencies:
+          - halogen
+      halogen-vdom:
+        repo: https://github.com/purescript-halogen/purescript-halogen-vdom.git
+        version: v8.0.0
+        dependencies:
+          - bifunctors
+          - effect
+          - foreign
+          - foreign-object
+          - maybe
+          - prelude
+          - refs
+          - tuples
+          - unsafe-coerce
+          - web-html
+      halogen-vdom-string-renderer:
+        repo: https://github.com/purescript-halogen/purescript-halogen-vdom-string-renderer.git
+        version: v0.5.0
+        dependencies:
+          - foreign
+          - halogen-vdom
+          - ordered-collections
+          - prelude
+      heckin:
+        repo: https://github.com/maxdeviant/purescript-heckin.git
+        version: v2.0.1
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - maybe
+          - prelude
+          - strings
+          - transformers
+          - tuples
+          - unicode
+      heterogeneous:
+        repo: https://github.com/natefaubion/purescript-heterogeneous.git
+        version: v0.6.0
+        dependencies:
+          - either
+          - functors
+          - prelude
+          - record
+          - tuples
+          - variant
+      heterogeneous-extrablatt:
+        repo: https://github.com/sigma-andex/purescript-heterogeneous-extrablatt.git
+        version: v0.2.1
+        dependencies:
+          - heterogeneous
+          - prelude
+          - record
+      http-methods:
+        repo: https://github.com/purescript-contrib/purescript-http-methods.git
+        version: v6.0.0
+        dependencies:
+          - either
+          - prelude
+          - strings
+      httpure:
+        repo: https://github.com/citizennet/purescript-httpure.git
+        version: v0.15.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - js-uri
+          - maybe
+          - newtype
+          - node-buffer
+          - node-fs
+          - node-http
+          - node-streams
+          - options
+          - ordered-collections
+          - prelude
+          - refs
+          - strings
+          - tuples
+          - type-equality
+      httpurple:
+        repo: https://github.com/sigma-andex/purescript-httpurple.git
+        version: v1.3.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - js-uri
+          - justifill
+          - maybe
+          - newtype
+          - node-buffer
+          - node-fs
+          - node-http
+          - node-net
+          - node-process
+          - node-streams
+          - options
+          - ordered-collections
+          - posix-types
+          - prelude
+          - profunctor
+          - record
+          - refs
+          - routing-duplex
+          - strings
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+      httpurple-argonaut:
+        repo: https://github.com/sigma-andex/purescript-httpurple-argonaut.git
+        version: v1.0.1
+        dependencies:
+          - argonaut
+          - console
+          - effect
+          - either
+          - httpurple
+          - prelude
+      httpurple-yoga-json:
+        repo: https://github.com/sigma-andex/purescript-httpurple-yoga-json.git
+        version: v1.0.0
+        dependencies:
+          - console
+          - effect
+          - either
+          - foreign
+          - httpurple
+          - lists
+          - prelude
+          - yoga-json
+      identity:
+        repo: https://github.com/purescript/purescript-identity.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - invariant
+          - newtype
+          - prelude
+      indexed-monad:
+        repo: https://github.com/garyb/purescript-indexed-monad.git
+        version: v2.1.0
+        dependencies:
+          - control
+          - newtype
+      int64:
+        repo: https://github.com/purescript-contrib/purescript-int64.git
+        version: v2.0.0
+        dependencies:
+          - effect
+          - foreign
+          - functions
+          - integers
+          - maybe
+          - nullable
+          - prelude
+          - quickcheck
+      integers:
+        repo: https://github.com/purescript/purescript-integers.git
+        version: v6.0.0
+        dependencies:
+          - maybe
+          - numbers
+          - prelude
+      interpolate:
+        repo: https://github.com/jordanmartinez/purescript-interpolate.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+      invariant:
+        repo: https://github.com/purescript/purescript-invariant.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - prelude
+      js-date:
+        repo: https://github.com/purescript-contrib/purescript-js-date.git
+        version: v8.0.0
+        dependencies:
+          - datetime
+          - effect
+          - exceptions
+          - foreign
+          - integers
+          - now
+      js-fileio:
+        repo: https://github.com/newlandsvalley/purescript-js-fileio.git
+        version: v3.0.0
+        dependencies:
+          - aff
+          - effect
+          - prelude
+      js-timers:
+        repo: https://github.com/purescript-contrib/purescript-js-timers.git
+        version: v6.1.0
+        dependencies:
+          - effect
+      js-uri:
+        repo: https://github.com/purescript-contrib/purescript-js-uri.git
+        version: v3.0.0
+        dependencies:
+          - functions
+          - maybe
+      justifill:
+        repo: https://github.com/i-am-the-slime/purescript-justifill.git
+        version: v0.5.0
+        dependencies:
+          - maybe
+          - prelude
+          - record
+          - typelevel-prelude
+      jwt:
+        repo: https://github.com/menelaos/purescript-jwt.git
+        version: v0.0.9
+        dependencies:
+          - argonaut-core
+          - arrays
+          - b64
+          - either
+          - exceptions
+          - prelude
+          - profunctor-lenses
+          - strings
+      language-cst-parser:
+        repo: https://github.com/natefaubion/purescript-language-cst-parser.git
+        version: v0.12.0
+        dependencies:
+          - arrays
+          - const
+          - control
+          - either
+          - foldable-traversable
+          - free
+          - functions
+          - functors
+          - identity
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - ordered-collections
+          - partial
+          - prelude
+          - st
+          - strings
+          - transformers
+          - tuples
+          - typelevel-prelude
+          - unfoldable
+          - unsafe-coerce
+      lazy:
+        repo: https://github.com/purescript/purescript-lazy.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - invariant
+          - prelude
+      lcg:
+        repo: https://github.com/purescript/purescript-lcg.git
+        version: v4.0.0
+        dependencies:
+          - effect
+          - integers
+          - maybe
+          - partial
+          - prelude
+          - random
+      leibniz:
+        repo: https://github.com/paf31/purescript-leibniz.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+          - unsafe-coerce
+      linalg:
+        repo: https://github.com/gbagan/purescript-linalg.git
+        version: v5.1.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - functions
+          - maybe
+          - prelude
+          - tuples
+      lists:
+        repo: https://github.com/purescript/purescript-lists.git
+        version: v7.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - foldable-traversable
+          - lazy
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      logging:
+        repo: https://github.com/rightfold/purescript-logging.git
+        version: v3.0.0
+        dependencies:
+          - console
+          - contravariant
+          - effect
+          - either
+          - prelude
+          - transformers
+          - tuples
+      machines:
+        repo: https://github.com/purescript-contrib/purescript-machines.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - lists
+          - maybe
+          - prelude
+          - profunctor
+          - tuples
+          - unfoldable
+      matrices:
+        repo: https://github.com/kRITZCREEK/purescript-matrices.git
+        version: v5.0.1
+        dependencies:
+          - arrays
+          - strings
+      matryoshka:
+        repo: https://github.com/purescript-contrib/purescript-matryoshka.git
+        version: v1.0.0
+        dependencies:
+          - fixed-points
+          - free
+          - prelude
+          - profunctor
+          - transformers
+      maybe:
+        repo: https://github.com/purescript/purescript-maybe.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - invariant
+          - newtype
+          - prelude
+      media-types:
+        repo: https://github.com/purescript-contrib/purescript-media-types.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      metadata:
+        repo: https://github.com/purescript/purescript-metadata.git
+        version: v0.15.0
+        dependencies: []
+      midi:
+        repo: https://github.com/newlandsvalley/purescript-midi.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - ordered-collections
+          - prelude
+          - signal
+          - string-parsers
+          - strings
+          - tuples
+          - unfoldable
+      minibench:
+        repo: https://github.com/purescript/purescript-minibench.git
+        version: v4.0.0
+        dependencies:
+          - console
+          - effect
+          - integers
+          - numbers
+          - partial
+          - prelude
+          - refs
+      mmorph:
+        repo: https://github.com/Thimoteus/purescript-mmorph.git
+        version: v7.0.0
+        dependencies:
+          - free
+          - functors
+          - transformers
+      monad-control:
+        repo: https://github.com/athanclark/purescript-monad-control.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - freet
+          - identity
+          - lists
+      monad-logger:
+        repo: https://github.com/cprussin/purescript-monad-logger.git
+        version: v1.3.1
+        dependencies:
+          - aff
+          - ansi
+          - argonaut
+          - arrays
+          - console
+          - control
+          - effect
+          - foldable-traversable
+          - foreign-object
+          - integers
+          - js-date
+          - maybe
+          - newtype
+          - ordered-collections
+          - prelude
+          - strings
+          - transformers
+          - tuples
+      monad-loops:
+        repo: https://github.com/mlang/purescript-monad-loops.git
+        version: v0.5.0
+        dependencies:
+          - lists
+          - maybe
+          - prelude
+          - tailrec
+          - tuples
+      monad-unlift:
+        repo: https://github.com/athanclark/purescript-monad-unlift.git
+        version: v1.0.1
+        dependencies:
+          - monad-control
+      monoidal:
+        repo: https://github.com/mcneissue/purescript-monoidal.git
+        version: v0.16.0
+        dependencies:
+          - either
+          - profunctor
+          - these
+          - tuples
+      morello:
+        repo: https://github.com/sigma-andex/purescript-morello.git
+        version: v0.3.2
+        dependencies:
+          - arrays
+          - barlow-lens
+          - foldable-traversable
+          - heterogeneous
+          - heterogeneous-extrablatt
+          - newtype
+          - prelude
+          - profunctor
+          - profunctor-lenses
+          - record
+          - tuples
+          - typelevel-prelude
+          - validation
+      motsunabe:
+        repo: https://github.com/justinwoo/purescript-motsunabe.git
+        version: v2.0.0
+        dependencies:
+          - lists
+          - strings
+      nano-id:
+        repo: https://github.com/eikooc/nano-id.git
+        version: v1.1.0
+        dependencies:
+          - aff
+          - effect
+          - lists
+          - maybe
+          - prelude
+          - random
+          - spec
+          - strings
+          - stringutils
+      naturals:
+        repo: https://github.com/LiamGoodacre/purescript-naturals.git
+        version: v3.0.0
+        dependencies:
+          - enums
+          - maybe
+          - prelude
+      nested-functor:
+        repo: https://github.com/acple/purescript-nested-functor.git
+        version: v0.2.1
+        dependencies:
+          - prelude
+          - type-equality
+      newtype:
+        repo: https://github.com/purescript/purescript-newtype.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+          - safe-coerce
+      node-buffer:
+        repo: https://github.com/purescript-node/purescript-node-buffer.git
+        version: v8.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - maybe
+          - st
+          - unsafe-coerce
+      node-buffer-blob:
+        repo: https://github.com/purescript-node/purescript-node-buffer-blob.git
+        version: v1.0.0
+        dependencies:
+          - aff-promise
+          - arraybuffer-types
+          - arrays
+          - console
+          - effect
+          - maybe
+          - media-types
+          - newtype
+          - node-buffer
+          - nullable
+          - prelude
+          - web-streams
+      node-child-process:
+        repo: https://github.com/purescript-node/purescript-node-child-process.git
+        version: v9.0.0
+        dependencies:
+          - exceptions
+          - foreign
+          - foreign-object
+          - functions
+          - node-fs
+          - node-streams
+          - nullable
+          - posix-types
+          - unsafe-coerce
+      node-fs:
+        repo: https://github.com/purescript-node/purescript-node-fs.git
+        version: v8.0.0
+        dependencies:
+          - datetime
+          - effect
+          - either
+          - enums
+          - exceptions
+          - functions
+          - integers
+          - js-date
+          - maybe
+          - node-buffer
+          - node-path
+          - node-streams
+          - nullable
+          - partial
+          - prelude
+          - strings
+          - unsafe-coerce
+      node-fs-aff:
+        repo: https://github.com/purescript-node/purescript-node-fs-aff.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - either
+          - node-fs
+          - node-path
+      node-http:
+        repo: https://github.com/purescript-node/purescript-node-http.git
+        version: v8.0.0
+        dependencies:
+          - arraybuffer-types
+          - contravariant
+          - effect
+          - foreign
+          - foreign-object
+          - maybe
+          - node-buffer
+          - node-net
+          - node-streams
+          - node-url
+          - nullable
+          - options
+          - prelude
+          - unsafe-coerce
+      node-net:
+        repo: https://github.com/purescript-node/purescript-node-net.git
+        version: v4.0.0
+        dependencies:
+          - effect
+          - either
+          - exceptions
+          - foreign
+          - maybe
+          - node-buffer
+          - node-fs
+          - nullable
+          - options
+          - prelude
+          - transformers
+      node-path:
+        repo: https://github.com/purescript-node/purescript-node-path.git
+        version: v5.0.0
+        dependencies:
+          - effect
+      node-process:
+        repo: https://github.com/purescript-node/purescript-node-process.git
+        version: v10.0.0
+        dependencies:
+          - effect
+          - foreign-object
+          - maybe
+          - node-streams
+          - posix-types
+          - prelude
+          - unsafe-coerce
+      node-readline:
+        repo: https://github.com/purescript-node/purescript-node-readline.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - foreign
+          - node-process
+          - node-streams
+          - options
+          - prelude
+      node-streams:
+        repo: https://github.com/purescript-node/purescript-node-streams.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - either
+          - exceptions
+          - node-buffer
+          - nullable
+          - prelude
+      node-streams-aff:
+        repo: https://github.com/jamesdbrock/purescript-node-streams-aff.git
+        version: v2.0.0
+        dependencies:
+          - aff
+          - arrays
+          - effect
+          - either
+          - exceptions
+          - maybe
+          - node-buffer
+          - node-streams
+          - prelude
+          - st
+          - tuples
+      node-url:
+        repo: https://github.com/purescript-node/purescript-node-url.git
+        version: v6.0.0
+        dependencies:
+          - nullable
+      nonempty:
+        repo: https://github.com/purescript/purescript-nonempty.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - maybe
+          - prelude
+          - tuples
+          - unfoldable
+      now:
+        repo: https://github.com/purescript-contrib/purescript-now.git
+        version: v6.0.0
+        dependencies:
+          - datetime
+          - effect
+      npm-package-json:
+        repo: https://github.com/maxdeviant/purescript-npm-package-json.git
+        version: v2.0.0
+        dependencies:
+          - argonaut
+          - control
+          - either
+          - foreign-object
+          - maybe
+          - ordered-collections
+          - prelude
+      nullable:
+        repo: https://github.com/purescript-contrib/purescript-nullable.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - functions
+          - maybe
+      numbers:
+        repo: https://github.com/purescript/purescript-numbers.git
+        version: v9.0.0
+        dependencies:
+          - functions
+          - maybe
+      open-folds:
+        repo: https://github.com/purescript-open-community/purescript-open-folds.git
+        version: v6.3.0
+        dependencies:
+          - bifunctors
+          - console
+          - control
+          - distributive
+          - effect
+          - either
+          - foldable-traversable
+          - identity
+          - invariant
+          - maybe
+          - newtype
+          - ordered-collections
+          - prelude
+          - profunctor
+          - psci-support
+          - tuples
+      open-memoize:
+        repo: https://github.com/purescript-open-community/purescript-open-memoize.git
+        version: v6.1.0
+        dependencies:
+          - console
+          - effect
+          - either
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - psci-support
+          - strings
+          - tuples
+      open-pairing:
+        repo: https://github.com/purescript-open-community/purescript-open-pairing.git
+        version: v6.1.0
+        dependencies:
+          - console
+          - control
+          - effect
+          - either
+          - free
+          - functors
+          - identity
+          - newtype
+          - prelude
+          - psci-support
+          - transformers
+          - tuples
+      options:
+        repo: https://github.com/purescript-contrib/purescript-options.git
+        version: v7.0.0
+        dependencies:
+          - contravariant
+          - foreign
+          - foreign-object
+          - maybe
+          - tuples
+      optparse:
+        repo: https://github.com/f-o-a-m/purescript-optparse.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - control
+          - effect
+          - either
+          - enums
+          - exists
+          - exitcodes
+          - foldable-traversable
+          - free
+          - gen
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - newtype
+          - node-buffer
+          - node-process
+          - node-streams
+          - nonempty
+          - numbers
+          - open-memoize
+          - partial
+          - prelude
+          - quickcheck
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+      ordered-collections:
+        repo: https://github.com/purescript/purescript-ordered-collections.git
+        version: v3.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - gen
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - unfoldable
+      ordered-set:
+        repo: https://github.com/flip111/purescript-ordered-set.git
+        version: v0.4.0
+        dependencies:
+          - argonaut-codecs
+          - arrays
+          - partial
+          - prelude
+          - unfoldable
+      orders:
+        repo: https://github.com/purescript/purescript-orders.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      pairs:
+        repo: https://github.com/sharkdp/purescript-pairs.git
+        version: v9.0.0
+        dependencies:
+          - console
+          - distributive
+          - foldable-traversable
+          - quickcheck
+      parallel:
+        repo: https://github.com/purescript/purescript-parallel.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - functors
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - refs
+          - transformers
+      parsing:
+        repo: https://github.com/purescript-contrib/purescript-parsing.git
+        version: v9.1.0
+        dependencies:
+          - arrays
+          - either
+          - foldable-traversable
+          - identity
+          - integers
+          - lists
+          - maybe
+          - nullable
+          - prelude
+          - strings
+          - transformers
+          - unicode
+      parsing-dataview:
+        repo: https://github.com/jamesdbrock/purescript-parsing-dataview.git
+        version: v3.1.0
+        dependencies:
+          - arraybuffer
+          - arraybuffer-types
+          - effect
+          - float32
+          - maybe
+          - parsing
+          - prelude
+          - transformers
+          - tuples
+          - uint
+      partial:
+        repo: https://github.com/purescript/purescript-partial.git
+        version: v4.0.0
+        dependencies: []
+      pathy:
+        repo: https://github.com/purescript-contrib/purescript-pathy.git
+        version: v9.0.0
+        dependencies:
+          - console
+          - exceptions
+          - lists
+          - partial
+          - profunctor
+          - strings
+          - transformers
+          - typelevel-prelude
+          - unsafe-coerce
+      pha:
+        repo: https://github.com/gbagan/purescript-pha.git
+        version: v0.9.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - datetime
+          - effect
+          - foldable-traversable
+          - free
+          - integers
+          - maybe
+          - prelude
+          - profunctor-lenses
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+          - unsafe-reference
+          - web-dom
+          - web-events
+          - web-html
+          - web-pointerevents
+          - web-uievents
+      phaser:
+        repo: https://github.com/lfarroco/purescript-phaser.git
+        version: v0.6.0
+        dependencies:
+          - canvas
+          - console
+          - effect
+          - maybe
+          - nullable
+          - options
+          - prelude
+          - web-html
+      pipes:
+        repo: https://github.com/felixschl/purescript-pipes.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - lists
+          - mmorph
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      point-free:
+        repo: https://github.com/ursi/purescript-point-free.git
+        version: v1.0.0
+        dependencies:
+          - prelude
+      polymorphic-vectors:
+        repo: https://github.com/artemisSystem/purescript-polymorphic-vectors.git
+        version: v4.0.0
+        dependencies:
+          - distributive
+          - foldable-traversable
+          - numbers
+          - prelude
+          - record
+          - safe-coerce
+          - type-equality
+          - typelevel-prelude
+      posix-types:
+        repo: https://github.com/purescript-node/purescript-posix-types.git
+        version: v6.0.0
+        dependencies:
+          - maybe
+          - prelude
+      precise:
+        repo: https://github.com/purescript-contrib/purescript-precise.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - exceptions
+          - gen
+          - integers
+          - lists
+          - numbers
+          - prelude
+          - strings
+      precise-datetime:
+        repo: https://github.com/awakesecurity/purescript-precise-datetime.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - datetime
+          - decimals
+          - either
+          - enums
+          - foldable-traversable
+          - formatters
+          - integers
+          - js-date
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - strings
+          - tuples
+          - unicode
+      prelude:
+        repo: https://github.com/purescript/purescript-prelude.git
+        version: v6.0.0
+        dependencies: []
+      prettier-printer:
+        repo: https://github.com/paulyoung/purescript-prettier-printer.git
+        version: v3.0.0
+        dependencies:
+          - console
+          - lists
+          - prelude
+          - strings
+          - tuples
+      profunctor:
+        repo: https://github.com/purescript/purescript-profunctor.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - distributive
+          - either
+          - exists
+          - invariant
+          - newtype
+          - prelude
+          - tuples
+      profunctor-lenses:
+        repo: https://github.com/purescript-contrib/purescript-profunctor-lenses.git
+        version: v8.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - const
+          - control
+          - distributive
+          - either
+          - foldable-traversable
+          - foreign-object
+          - functors
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - ordered-collections
+          - partial
+          - prelude
+          - profunctor
+          - record
+          - transformers
+          - tuples
+      protobuf:
+        repo: https://github.com/xc-jp/purescript-protobuf.git
+        version: v4.0.0
+        dependencies:
+          - arraybuffer
+          - arraybuffer-builder
+          - arraybuffer-types
+          - arrays
+          - control
+          - effect
+          - either
+          - enums
+          - exceptions
+          - float32
+          - foldable-traversable
+          - functions
+          - int64
+          - maybe
+          - newtype
+          - parsing
+          - parsing-dataview
+          - prelude
+          - record
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+          - uint
+          - web-encoding
+      ps-cst:
+        repo: https://github.com/purescript-codegen/purescript-ps-cst.git
+        version: v1.2.0
+        dependencies:
+          - ansi
+          - console
+          - dodo-printer
+          - effect
+          - node-fs-aff
+          - node-path
+          - psci-support
+          - record
+          - strings
+      psa-utils:
+        repo: https://github.com/natefaubion/purescript-psa-utils.git
+        version: v8.0.0
+        dependencies:
+          - ansi
+          - argonaut-codecs
+          - argonaut-core
+          - arrays
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - maybe
+          - node-path
+          - ordered-collections
+          - prelude
+          - strings
+          - tuples
+          - unsafe-coerce
+      psc-ide:
+        repo: https://github.com/kRITZCREEK/purescript-psc-ide.git
+        version: v19.0.0
+        dependencies:
+          - aff
+          - argonaut
+          - arrays
+          - console
+          - maybe
+          - node-child-process
+          - node-fs
+          - parallel
+          - random
+      psci-support:
+        repo: https://github.com/purescript/purescript-psci-support.git
+        version: v6.0.0
+        dependencies:
+          - console
+          - effect
+          - prelude
+      qualified-do:
+        repo: https://github.com/artemisSystem/purescript-qualified-do.git
+        version: v2.2.0
+        dependencies:
+          - arrays
+          - control
+          - foldable-traversable
+          - parallel
+          - prelude
+          - unfoldable
+      quantities:
+        repo: https://github.com/sharkdp/purescript-quantities.git
+        version: v12.0.1
+        dependencies:
+          - decimals
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - newtype
+          - nonempty
+          - numbers
+          - pairs
+          - prelude
+          - tuples
+      quickcheck:
+        repo: https://github.com/purescript/purescript-quickcheck.git
+        version: v8.0.1
+        dependencies:
+          - arrays
+          - console
+          - control
+          - effect
+          - either
+          - enums
+          - exceptions
+          - foldable-traversable
+          - gen
+          - identity
+          - integers
+          - lazy
+          - lcg
+          - lists
+          - maybe
+          - newtype
+          - nonempty
+          - numbers
+          - partial
+          - prelude
+          - record
+          - st
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+          - unfoldable
+      quickcheck-combinators:
+        repo: https://github.com/athanclark/purescript-quickcheck-combinators.git
+        version: v0.1.3
+        dependencies:
+          - quickcheck
+          - typelevel
+      quickcheck-laws:
+        repo: https://github.com/purescript-contrib/purescript-quickcheck-laws.git
+        version: v7.0.0
+        dependencies:
+          - enums
+          - quickcheck
+      quickcheck-utf8:
+        repo: https://github.com/openchronology/purescript-quickcheck-utf8.git
+        version: v0.0.0
+        dependencies:
+          - quickcheck
+      quotient:
+        repo: https://github.com/rightfold/purescript-quotient.git
+        version: v3.0.0
+        dependencies:
+          - prelude
+          - quickcheck
+      random:
+        repo: https://github.com/purescript/purescript-random.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - integers
+      rationals:
+        repo: https://github.com/anttih/purescript-rationals.git
+        version: v5.0.0
+        dependencies:
+          - integers
+          - prelude
+      react:
+        repo: https://github.com/purescript-contrib/purescript-react.git
+        version: v10.0.1
+        dependencies:
+          - effect
+          - exceptions
+          - maybe
+          - nullable
+          - prelude
+          - typelevel-prelude
+          - unsafe-coerce
+      react-basic:
+        repo: https://github.com/lumihq/purescript-react-basic.git
+        version: v17.0.0
+        dependencies:
+          - effect
+          - prelude
+          - record
+      react-basic-dom:
+        repo: https://github.com/lumihq/purescript-react-basic-dom.git
+        version: v5.0.0
+        dependencies:
+          - effect
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - nullable
+          - prelude
+          - react-basic
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-file
+          - web-html
+      react-basic-hooks:
+        repo: https://github.com/megamaddu/purescript-react-basic-hooks.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - aff-promise
+          - bifunctors
+          - console
+          - control
+          - datetime
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - functions
+          - indexed-monad
+          - integers
+          - maybe
+          - newtype
+          - now
+          - nullable
+          - ordered-collections
+          - prelude
+          - react-basic
+          - refs
+          - tuples
+          - type-equality
+          - unsafe-coerce
+          - unsafe-reference
+          - web-html
+      react-dom:
+        repo: https://github.com/purescript-contrib/purescript-react-dom.git
+        version: v8.0.0
+        dependencies:
+          - effect
+          - react
+          - web-dom
+      read:
+        repo: https://github.com/truqu/purescript-read.git
+        version: v1.0.1
+        dependencies:
+          - maybe
+          - prelude
+          - strings
+      record:
+        repo: https://github.com/purescript/purescript-record.git
+        version: v4.0.0
+        dependencies:
+          - functions
+          - prelude
+          - unsafe-coerce
+      refined:
+        repo: https://github.com/danieljharvey/purescript-refined.git
+        version: v1.0.0
+        dependencies:
+          - argonaut
+          - effect
+          - prelude
+          - quickcheck
+          - typelevel
+      refs:
+        repo: https://github.com/purescript/purescript-refs.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - prelude
+      remotedata:
+        repo: https://github.com/krisajenkins/purescript-remotedata.git
+        version: v5.0.0
+        dependencies:
+          - bifunctors
+          - either
+          - profunctor-lenses
+      resource:
+        repo: https://github.com/joneshf/purescript-resource.git
+        version: v2.0.1
+        dependencies:
+          - aff
+          - console
+          - control
+          - effect
+          - newtype
+          - prelude
+          - psci-support
+          - refs
+      resourcet:
+        repo: https://github.com/robertdp/purescript-resourcet.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - effect
+          - foldable-traversable
+          - maybe
+          - ordered-collections
+          - parallel
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+      result:
+        repo: https://github.com/ad-si/purescript-result.git
+        version: v1.0.3
+        dependencies:
+          - either
+          - foldable-traversable
+          - prelude
+      return:
+        repo: https://github.com/ursi/purescript-return.git
+        version: v0.2.0
+        dependencies:
+          - foldable-traversable
+          - point-free
+          - prelude
+      ring-modules:
+        repo: https://github.com/f-o-a-m/purescript-ring-modules.git
+        version: v5.0.1
+        dependencies:
+          - prelude
+      routing:
+        repo: https://github.com/purescript-contrib/purescript-routing.git
+        version: v11.0.0
+        dependencies:
+          - aff
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - integers
+          - js-uri
+          - lists
+          - maybe
+          - numbers
+          - partial
+          - prelude
+          - semirings
+          - tuples
+          - validation
+          - web-html
+      routing-duplex:
+        repo: https://github.com/natefaubion/purescript-routing-duplex.git
+        version: v0.6.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - js-uri
+          - lazy
+          - numbers
+          - prelude
+          - profunctor
+          - record
+          - strings
+          - typelevel-prelude
+      run:
+        repo: https://github.com/natefaubion/purescript-run.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - free
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - tailrec
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - variant
+      safe-coerce:
+        repo: https://github.com/purescript/purescript-safe-coerce.git
+        version: v2.0.0
+        dependencies:
+          - unsafe-coerce
+      safely:
+        repo: https://github.com/paf31/purescript-safely.git
+        version: v4.0.1
+        dependencies:
+          - freet
+          - lists
+      selection-foldable:
+        repo: https://github.com/jamieyung/purescript-selection-foldable.git
+        version: v0.2.0
+        dependencies:
+          - filterable
+          - foldable-traversable
+          - maybe
+          - prelude
+      semirings:
+        repo: https://github.com/purescript/purescript-semirings.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - lists
+          - newtype
+          - prelude
+      signal:
+        repo: https://github.com/bodil/purescript-signal.git
+        version: v13.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - foldable-traversable
+          - maybe
+          - prelude
+      simple-emitter:
+        repo: https://github.com/oreshinya/purescript-simple-emitter.git
+        version: v2.0.0
+        dependencies:
+          - ordered-collections
+          - refs
+      sized-matrices:
+        repo: https://github.com/csicar/purescript-sized-matrices.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - distributive
+          - foldable-traversable
+          - maybe
+          - prelude
+          - sized-vectors
+          - strings
+          - typelevel
+          - unfoldable
+          - vectorfield
+      sized-vectors:
+        repo: https://github.com/bodil/purescript-sized-vectors.git
+        version: v5.0.2
+        dependencies:
+          - argonaut
+          - arrays
+          - distributive
+          - foldable-traversable
+          - maybe
+          - prelude
+          - quickcheck
+          - typelevel
+          - unfoldable
+      slug:
+        repo: https://github.com/thomashoneyman/purescript-slug.git
+        version: v3.0.1
+        dependencies:
+          - argonaut-codecs
+          - maybe
+          - prelude
+          - strings
+          - unicode
+      soundfonts:
+        repo: https://github.com/newlandsvalley/purescript-soundfonts.git
+        version: v4.1.0
+        dependencies:
+          - aff
+          - affjax
+          - affjax-web
+          - argonaut-core
+          - arraybuffer-types
+          - arrays
+          - b64
+          - bifunctors
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign-object
+          - http-methods
+          - integers
+          - lists
+          - maybe
+          - midi
+          - ordered-collections
+          - parallel
+          - partial
+          - prelude
+          - strings
+          - transformers
+          - tuples
+      sparse-matrices:
+        repo: https://github.com/Ebmtranceboy/purescript-sparse-matrices.git
+        version: v1.2.1
+        dependencies:
+          - console
+          - effect
+          - prelude
+          - sparse-polynomials
+      sparse-polynomials:
+        repo: https://github.com/Ebmtranceboy/purescript-sparse-polynomials.git
+        version: v1.0.5
+        dependencies:
+          - cartesian
+          - console
+          - effect
+          - ordered-collections
+          - prelude
+          - rationals
+          - tuples
+      spec:
+        repo: https://github.com/purescript-spec/purescript-spec.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - ansi
+          - avar
+          - console
+          - exceptions
+          - foldable-traversable
+          - fork
+          - now
+          - pipes
+          - prelude
+          - strings
+          - transformers
+      spec-discovery:
+        repo: https://github.com/purescript-spec/purescript-spec-discovery.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - aff-promise
+          - arrays
+          - console
+          - effect
+          - foldable-traversable
+          - node-fs
+          - prelude
+          - spec
+      spec-quickcheck:
+        repo: https://github.com/purescript-spec/purescript-spec-quickcheck.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - prelude
+          - quickcheck
+          - random
+          - spec
+      ssrs:
+        repo: https://github.com/PureFunctor/purescript-ssrs.git
+        version: v1.0.0
+        dependencies:
+          - dissect
+          - either
+          - fixed-points
+          - free
+          - lists
+          - prelude
+          - safe-coerce
+          - tailrec
+          - tuples
+          - variant
+      st:
+        repo: https://github.com/purescript/purescript-st.git
+        version: v6.0.0
+        dependencies:
+          - partial
+          - prelude
+          - tailrec
+          - unsafe-coerce
+      strictlypositiveint:
+        repo: https://github.com/jamieyung/purescript-strictlypositiveint.git
+        version: v1.0.1
+        dependencies:
+          - prelude
+      string-parsers:
+        repo: https://github.com/purescript-contrib/purescript-string-parsers.git
+        version: v8.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - prelude
+          - strings
+          - tailrec
+      strings:
+        repo: https://github.com/purescript/purescript-strings.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - enums
+          - foldable-traversable
+          - gen
+          - integers
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+          - unsafe-coerce
+      strings-extra:
+        repo: https://github.com/purescript-contrib/purescript-strings-extra.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - maybe
+          - prelude
+          - strings
+          - unicode
+      stringutils:
+        repo: https://github.com/menelaos/purescript-stringutils.git
+        version: v0.0.12
+        dependencies:
+          - arrays
+          - integers
+          - maybe
+          - partial
+          - prelude
+          - strings
+      substitute:
+        repo: https://github.com/ursi/purescript-substitute.git
+        version: v0.2.3
+        dependencies:
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - prelude
+          - return
+          - strings
+      supply:
+        repo: https://github.com/ajnsit/purescript-supply.git
+        version: v0.2.0
+        dependencies:
+          - console
+          - control
+          - effect
+          - lazy
+          - prelude
+          - refs
+          - tuples
+      tailrec:
+        repo: https://github.com/purescript/purescript-tailrec.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - effect
+          - either
+          - identity
+          - maybe
+          - partial
+          - prelude
+          - refs
+      test-unit:
+        repo: https://github.com/bodil/purescript-test-unit.git
+        version: v17.0.0
+        dependencies:
+          - aff
+          - avar
+          - effect
+          - either
+          - free
+          - js-timers
+          - lists
+          - prelude
+          - quickcheck
+          - strings
+      thermite:
+        repo: https://github.com/paf31/purescript-thermite.git
+        version: v6.3.1
+        dependencies:
+          - aff
+          - coroutines
+          - freet
+          - profunctor-lenses
+          - react
+      thermite-dom:
+        repo: https://github.com/athanclark/purescript-thermite-dom.git
+        version: v0.3.1
+        dependencies:
+          - react
+          - react-dom
+          - thermite
+          - web-html
+      these:
+        repo: https://github.com/purescript-contrib/purescript-these.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - gen
+          - lists
+          - quickcheck
+          - quickcheck-laws
+          - tuples
+      transformers:
+        repo: https://github.com/purescript/purescript-transformers.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - distributive
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - identity
+          - lazy
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      tree-rose:
+        repo: https://github.com/jordanmartinez/purescript-tree-rose.git
+        version: v4.0.2
+        dependencies:
+          - control
+          - foldable-traversable
+          - free
+          - lists
+          - maybe
+          - prelude
+          - tailrec
+      tuples:
+        repo: https://github.com/purescript/purescript-tuples.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - invariant
+          - prelude
+      two-or-more:
+        repo: https://github.com/i-am-the-slime/purescript-two-or-more.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - foldable-traversable
+          - maybe
+          - partial
+          - prelude
+          - psci-support
+          - tuples
+      type-equality:
+        repo: https://github.com/purescript/purescript-type-equality.git
+        version: v4.0.1
+        dependencies: []
+      typelevel:
+        repo: https://github.com/bodil/purescript-typelevel.git
+        version: v6.0.0
+        dependencies:
+          - partial
+          - prelude
+          - tuples
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-lists:
+        repo: https://github.com/PureFunctor/purescript-typelevel-lists.git
+        version: v2.1.0
+        dependencies:
+          - prelude
+          - tuples
+          - typelevel-peano
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-peano:
+        repo: https://github.com/csicar/purescript-typelevel-peano.git
+        version: v1.0.1
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - prelude
+          - psci-support
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-prelude:
+        repo: https://github.com/purescript/purescript-typelevel-prelude.git
+        version: v7.0.0
+        dependencies:
+          - prelude
+          - type-equality
+      typelevel-rows:
+        repo: https://github.com/jordanmartinez/purescript-typelevel-rows.git
+        version: v0.1.0
+        dependencies:
+          - prelude
+      uint:
+        repo: https://github.com/purescript-contrib/purescript-uint.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - enums
+          - gen
+          - maybe
+          - numbers
+          - prelude
+      uncurried-transformers:
+        repo: https://github.com/PureFunctor/purescript-uncurried-transformers.git
+        version: v1.1.0
+        dependencies:
+          - control
+          - effect
+          - either
+          - functions
+          - identity
+          - prelude
+          - safe-coerce
+          - tailrec
+          - transformers
+          - tuples
+      undefined-is-not-a-problem:
+        repo: https://github.com/paluh/purescript-undefined-is-not-a-problem.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - assert
+          - effect
+          - either
+          - foreign
+          - maybe
+          - newtype
+          - prelude
+          - random
+          - tuples
+          - type-equality
+          - unsafe-coerce
+      unfoldable:
+        repo: https://github.com/purescript/purescript-unfoldable.git
+        version: v6.0.0
+        dependencies:
+          - foldable-traversable
+          - maybe
+          - partial
+          - prelude
+          - tuples
+      unicode:
+        repo: https://github.com/purescript-contrib/purescript-unicode.git
+        version: v6.0.0
+        dependencies:
+          - foldable-traversable
+          - maybe
+          - strings
+      unlift:
+        repo: https://github.com/tweag/purescript-unlift.git
+        version: v1.0.1
+        dependencies:
+          - aff
+          - effect
+          - either
+          - freet
+          - identity
+          - lists
+          - maybe
+          - monad-control
+          - prelude
+          - st
+          - transformers
+          - tuples
+      unsafe-coerce:
+        repo: https://github.com/purescript/purescript-unsafe-coerce.git
+        version: v6.0.0
+        dependencies: []
+      unsafe-reference:
+        repo: https://github.com/purescript-contrib/purescript-unsafe-reference.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+      uri:
+        repo: https://github.com/purescript-contrib/purescript-uri.git
+        version: v9.0.0
+        dependencies:
+          - arrays
+          - integers
+          - js-uri
+          - numbers
+          - parsing
+          - prelude
+          - profunctor-lenses
+          - these
+          - transformers
+          - unfoldable
+      validation:
+        repo: https://github.com/purescript/purescript-validation.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - newtype
+          - prelude
+      variant:
+        repo: https://github.com/natefaubion/purescript-variant.git
+        version: v8.0.0
+        dependencies:
+          - enums
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - record
+          - tuples
+          - unsafe-coerce
+      vectorfield:
+        repo: https://github.com/csicar/purescript-vectorfield.git
+        version: v1.0.1
+        dependencies:
+          - console
+          - effect
+          - group
+          - prelude
+          - psci-support
+      versions:
+        repo: https://github.com/hdgarrood/purescript-versions.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - either
+          - foldable-traversable
+          - functions
+          - integers
+          - lists
+          - maybe
+          - orders
+          - parsing
+          - partial
+          - strings
+      web-clipboard:
+        repo: https://github.com/purescript-web/purescript-web-clipboard.git
+        version: v4.0.0
+        dependencies:
+          - web-html
+      web-cssom:
+        repo: https://github.com/purescript-web/purescript-web-cssom.git
+        version: v2.0.0
+        dependencies:
+          - web-dom
+          - web-html
+          - web-uievents
+      web-dom:
+        repo: https://github.com/purescript-web/purescript-web-dom.git
+        version: v6.0.0
+        dependencies:
+          - web-events
+      web-dom-parser:
+        repo: https://github.com/purescript-web/purescript-web-dom-parser.git
+        version: v8.0.0
+        dependencies:
+          - effect
+          - partial
+          - prelude
+          - web-dom
+      web-dom-xpath:
+        repo: https://github.com/purescript-web/purescript-web-dom-xpath.git
+        version: v3.0.0
+        dependencies:
+          - web-dom
+      web-encoding:
+        repo: https://github.com/purescript-web/purescript-web-encoding.git
+        version: v3.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - newtype
+          - prelude
+      web-events:
+        repo: https://github.com/purescript-web/purescript-web-events.git
+        version: v4.0.0
+        dependencies:
+          - datetime
+          - enums
+          - foreign
+          - nullable
+      web-fetch:
+        repo: https://github.com/purescript-web/purescript-web-fetch.git
+        version: v3.0.0
+        dependencies:
+          - effect
+          - foreign-object
+          - http-methods
+          - prelude
+          - record
+          - typelevel-prelude
+          - web-file
+          - web-promise
+          - web-streams
+      web-file:
+        repo: https://github.com/purescript-web/purescript-web-file.git
+        version: v4.0.0
+        dependencies:
+          - foreign
+          - media-types
+          - web-dom
+      web-html:
+        repo: https://github.com/purescript-web/purescript-web-html.git
+        version: v4.0.0
+        dependencies:
+          - js-date
+          - web-dom
+          - web-file
+          - web-storage
+      web-page-visibility:
+        repo: https://git.sr.ht/~toastal/purescript-web-page-visibility
+        version: v2.0.0
+        dependencies:
+          - effect
+          - enums
+          - exceptions
+          - maybe
+          - prelude
+          - strings
+          - web-events
+          - web-html
+      web-pointerevents:
+        repo: https://github.com/purescript-web/purescript-web-pointerevents.git
+        version: v1.0.0
+        dependencies:
+          - effect
+          - maybe
+          - prelude
+          - web-dom
+          - web-uievents
+      web-promise:
+        repo: https://github.com/purescript-web/purescript-web-promise.git
+        version: v3.0.0
+        dependencies:
+          - effect
+          - exceptions
+          - foldable-traversable
+          - functions
+          - maybe
+          - prelude
+      web-socket:
+        repo: https://github.com/purescript-web/purescript-web-socket.git
+        version: v4.0.0
+        dependencies:
+          - arraybuffer-types
+          - web-file
+      web-storage:
+        repo: https://github.com/purescript-web/purescript-web-storage.git
+        version: v5.0.0
+        dependencies:
+          - nullable
+          - web-events
+      web-streams:
+        repo: https://github.com/purescript-web/purescript-web-streams.git
+        version: v3.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - exceptions
+          - nullable
+          - prelude
+          - tuples
+          - web-promise
+      web-touchevents:
+        repo: https://github.com/purescript-web/purescript-web-touchevents.git
+        version: v4.0.0
+        dependencies:
+          - web-uievents
+      web-uievents:
+        repo: https://github.com/purescript-web/purescript-web-uievents.git
+        version: v4.0.0
+        dependencies:
+          - web-html
+      web-workers:
+        repo: https://github.com/gbagan/purescript-web-workers.git
+        version: v1.1.0
+        dependencies:
+          - effect
+          - foreign
+          - maybe
+          - prelude
+          - unsafe-coerce
+          - web-events
+      web-xhr:
+        repo: https://github.com/purescript-web/purescript-web-xhr.git
+        version: v5.0.0
+        dependencies:
+          - arraybuffer-types
+          - datetime
+          - http-methods
+          - web-dom
+          - web-file
+          - web-html
+      yoga-fetch:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-fetch.git
+        version: v1.0.1
+        dependencies:
+          - aff
+          - aff-promise
+          - arraybuffer-types
+          - effect
+          - foreign
+          - foreign-object
+          - newtype
+          - prelude
+          - typelevel-prelude
+          - unsafe-coerce
+      yoga-json:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-json.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - identity
+          - lists
+          - maybe
+          - nullable
+          - partial
+          - prelude
+          - record
+          - transformers
+          - typelevel-prelude
+          - variant
+      yoga-postgres:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-postgres.git
+        version: v6.0.0
+        dependencies:
+          - aff
+          - arrays
+          - datetime
+          - effect
+          - either
+          - enums
+          - foldable-traversable
+          - foreign
+          - integers
+          - maybe
+          - nullable
+          - prelude
+          - transformers
+          - unsafe-coerce
+  extra_packages: {}
+packages:
+  aff:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-aff.git
+    rev: 2d44d9f9d0d6a416a4103fba2fb39e5160f80e36
+    dependencies:
+      - datetime
+      - effect
+      - exceptions
+      - functions
+      - parallel
+      - transformers
+      - unsafe-coerce
+  arrays:
+    type: git
+    url: https://github.com/purescript/purescript-arrays.git
+    rev: d20bae2f76db6cf29b7b75e26e82b8a54c32295e
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - maybe
+      - nonempty
+      - partial
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  avar:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-avar.git
+    rev: d00f5784d9cc8f079babd62740f5c52b87e5caa5
+    dependencies:
+      - aff
+      - effect
+      - either
+      - exceptions
+      - functions
+      - maybe
+  bifunctors:
+    type: git
+    url: https://github.com/purescript/purescript-bifunctors.git
+    rev: 16ba2fb6dd7f05528ebd9e2f9ca3a068b325e5b3
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  catenable-lists:
+    type: git
+    url: https://github.com/purescript/purescript-catenable-lists.git
+    rev: 09abe1f4888bc00841ad2b59e56a9e7ce7ebd4ab
+    dependencies:
+      - control
+      - foldable-traversable
+      - lists
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  console:
+    type: git
+    url: https://github.com/purescript/purescript-console.git
+    rev: 3b83d7b792d03872afeea5e62b4f686ab0f09842
+    dependencies:
+      - effect
+      - prelude
+  const:
+    type: git
+    url: https://github.com/purescript/purescript-const.git
+    rev: ab9570cf2b6e67f7e441178211db1231cfd75c37
+    dependencies:
+      - invariant
+      - newtype
+      - prelude
+  contravariant:
+    type: git
+    url: https://github.com/purescript/purescript-contravariant.git
+    rev: 9ad3e105b8855bcc25f4e0893c784789d05a58de
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  control:
+    type: git
+    url: https://github.com/purescript/purescript-control.git
+    rev: a6033808790879a17b2729e73747a9ed3fb2264e
+    dependencies:
+      - newtype
+      - prelude
+  datetime:
+    type: git
+    url: https://github.com/purescript/purescript-datetime.git
+    rev: a6a0cf1b0324964ad1854bc3377ed8766ba90e6f
+    dependencies:
+      - bifunctors
+      - control
+      - either
+      - enums
+      - foldable-traversable
+      - functions
+      - gen
+      - integers
+      - lists
+      - maybe
+      - newtype
+      - numbers
+      - ordered-collections
+      - partial
+      - prelude
+      - tuples
+  distributive:
+    type: git
+    url: https://github.com/purescript/purescript-distributive.git
+    rev: 6005e513642e855ebf6f884d24a35c2803ca252a
+    dependencies:
+      - identity
+      - newtype
+      - prelude
+      - tuples
+      - type-equality
+  effect:
+    type: git
+    url: https://github.com/purescript/purescript-effect.git
+    rev: a192ddb923027d426d6ea3d8deb030c9aa7c7dda
+    dependencies:
+      - prelude
+  either:
+    type: git
+    url: https://github.com/purescript/purescript-either.git
+    rev: af655a04ed2fd694b6688af39ee20d7907ad0763
+    dependencies:
+      - control
+      - invariant
+      - maybe
+      - prelude
+  enums:
+    type: git
+    url: https://github.com/purescript/purescript-enums.git
+    rev: bae47961d401f9acf88da38f32e87403e5f0cf2f
+    dependencies:
+      - control
+      - either
+      - gen
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tuples
+      - unfoldable
+  exceptions:
+    type: git
+    url: https://github.com/purescript/purescript-exceptions.git
+    rev: afab3c07c820bb49b6c5be50049db46a964a6161
+    dependencies:
+      - effect
+      - either
+      - maybe
+      - prelude
+  exists:
+    type: git
+    url: https://github.com/purescript/purescript-exists.git
+    rev: f765b4ace7869c27b9c05949e18c843881f9173b
+    dependencies:
+      - unsafe-coerce
+  foldable-traversable:
+    type: git
+    url: https://github.com/purescript/purescript-foldable-traversable.git
+    rev: b3926f870532d287ea59e2d5cd3873b81ef2a93a
+    dependencies:
+      - bifunctors
+      - const
+      - control
+      - either
+      - functors
+      - identity
+      - maybe
+      - newtype
+      - orders
+      - prelude
+      - tuples
+  free:
+    type: git
+    url: https://github.com/purescript/purescript-free.git
+    rev: e2d8fa8023a864363857834e11393483bced5e38
+    dependencies:
+      - catenable-lists
+      - control
+      - distributive
+      - either
+      - exists
+      - foldable-traversable
+      - invariant
+      - lazy
+      - maybe
+      - prelude
+      - tailrec
+      - transformers
+      - tuples
+      - unsafe-coerce
+  functions:
+    type: git
+    url: https://github.com/purescript/purescript-functions.git
+    rev: f626f20580483977c5b27a01aac6471e28aff367
+    dependencies:
+      - prelude
+  functors:
+    type: git
+    url: https://github.com/purescript/purescript-functors.git
+    rev: 022ffd7a2a7ec12080314f3d217b400674a247b4
+    dependencies:
+      - bifunctors
+      - const
+      - contravariant
+      - control
+      - distributive
+      - either
+      - invariant
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - tuples
+      - unsafe-coerce
+  gen:
+    type: git
+    url: https://github.com/purescript/purescript-gen.git
+    rev: 9fbcc2a1261c32e30d79c5418edef4d96fe76931
+    dependencies:
+      - either
+      - foldable-traversable
+      - identity
+      - maybe
+      - newtype
+      - nonempty
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  identity:
+    type: git
+    url: https://github.com/purescript/purescript-identity.git
+    rev: ef6768f8a52ab0bc943a85f5761ba07c257f639f
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  integers:
+    type: git
+    url: https://github.com/purescript/purescript-integers.git
+    rev: 54d712b25c594833083d15dc9ff2418eb9c52822
+    dependencies:
+      - maybe
+      - numbers
+      - prelude
+  invariant:
+    type: git
+    url: https://github.com/purescript/purescript-invariant.git
+    rev: 1d2a196d51e90623adb88496c2cfd759c6736894
+    dependencies:
+      - control
+      - prelude
+  js-timers:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-js-timers.git
+    rev: 7cb728b3e6dc29f355143617e6e9ac770ecd9273
+    dependencies:
+      - effect
+  lazy:
+    type: git
+    url: https://github.com/purescript/purescript-lazy.git
+    rev: 48347841226b27af5205a1a8ec71e27a93ce86fd
+    dependencies:
+      - control
+      - foldable-traversable
+      - invariant
+      - prelude
+  lcg:
+    type: git
+    url: https://github.com/purescript/purescript-lcg.git
+    rev: 67c6c6483a563a59ae036d9dca0f1be2835326a5
+    dependencies:
+      - effect
+      - integers
+      - maybe
+      - partial
+      - prelude
+      - random
+  lists:
+    type: git
+    url: https://github.com/purescript/purescript-lists.git
+    rev: b113451e5b41cad87d669a3165f955c71cd863e2
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - lazy
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  maybe:
+    type: git
+    url: https://github.com/purescript/purescript-maybe.git
+    rev: c6f98ac1088766287106c5d9c8e30e7648d36786
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  newtype:
+    type: git
+    url: https://github.com/purescript/purescript-newtype.git
+    rev: 29d8e6dd77aec2c975c948364ec3faf26e14ee7b
+    dependencies:
+      - prelude
+      - safe-coerce
+  nonempty:
+    type: git
+    url: https://github.com/purescript/purescript-nonempty.git
+    rev: 28150ecc7419238b187abd609a92a645273348bb
+    dependencies:
+      - control
+      - foldable-traversable
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  numbers:
+    type: git
+    url: https://github.com/purescript/purescript-numbers.git
+    rev: 2a53528f18f9415334bae28e7bb3cf3be86342c2
+    dependencies:
+      - functions
+      - maybe
+  ordered-collections:
+    type: git
+    url: https://github.com/purescript/purescript-ordered-collections.git
+    rev: 9826b7632d0d0a691173bde308a634195f42a419
+    dependencies:
+      - arrays
+      - foldable-traversable
+      - gen
+      - lists
+      - maybe
+      - partial
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+  orders:
+    type: git
+    url: https://github.com/purescript/purescript-orders.git
+    rev: f86db621ec5eef1274145f8b1fd8ebbfe0ed4a2c
+    dependencies:
+      - newtype
+      - prelude
+  parallel:
+    type: git
+    url: https://github.com/purescript/purescript-parallel.git
+    rev: 85290dca837771ac4870071008c933d315ef678f
+    dependencies:
+      - control
+      - effect
+      - either
+      - foldable-traversable
+      - functors
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - refs
+      - transformers
+  partial:
+    type: git
+    url: https://github.com/purescript/purescript-partial.git
+    rev: 0fa0646f5ea1ec5f0c46dcbd770c705a6c9ad3ec
+    dependencies: []
+  prelude:
+    type: git
+    url: https://github.com/purescript/purescript-prelude.git
+    rev: 32787f4399c92459c41602131a5858559eb868c5
+    dependencies: []
+  profunctor:
+    type: git
+    url: https://github.com/purescript/purescript-profunctor.git
+    rev: 0a966a14e7b0c827d44657dc1710cdc712d2e034
+    dependencies:
+      - control
+      - distributive
+      - either
+      - exists
+      - invariant
+      - newtype
+      - prelude
+      - tuples
+  quickcheck:
+    type: git
+    url: https://github.com/purescript/purescript-quickcheck.git
+    rev: bf5029f97e6c0d7552d3a08d2ab793a19e2c5e3d
+    dependencies:
+      - arrays
+      - console
+      - control
+      - effect
+      - either
+      - enums
+      - exceptions
+      - foldable-traversable
+      - gen
+      - identity
+      - integers
+      - lazy
+      - lcg
+      - lists
+      - maybe
+      - newtype
+      - nonempty
+      - numbers
+      - partial
+      - prelude
+      - record
+      - st
+      - strings
+      - tailrec
+      - transformers
+      - tuples
+      - unfoldable
+  random:
+    type: git
+    url: https://github.com/purescript/purescript-random.git
+    rev: 9540bc965a9596da02fefd9949418bb19c92533a
+    dependencies:
+      - effect
+      - integers
+  record:
+    type: git
+    url: https://github.com/purescript/purescript-record.git
+    rev: c89cd1ada6b636692571fc374196b1c39c4c9f70
+    dependencies:
+      - functions
+      - prelude
+      - unsafe-coerce
+  refs:
+    type: git
+    url: https://github.com/purescript/purescript-refs.git
+    rev: f8e6216da4cb9309fde1f20cd6f69ac3a3b7f9e8
+    dependencies:
+      - effect
+      - prelude
+  safe-coerce:
+    type: git
+    url: https://github.com/purescript/purescript-safe-coerce.git
+    rev: 7fa799ae80a38b8d948efcb52608e58e198b3da7
+    dependencies:
+      - unsafe-coerce
+  st:
+    type: git
+    url: https://github.com/purescript/purescript-st.git
+    rev: 2cc7ae1c3318a303378c4a9f3fa0f10ee7cc3589
+    dependencies:
+      - partial
+      - prelude
+      - tailrec
+      - unsafe-coerce
+  strings:
+    type: git
+    url: https://github.com/purescript/purescript-strings.git
+    rev: 4bc6954448d056f8aa7a659695a6ad60ad4fdf19
+    dependencies:
+      - arrays
+      - control
+      - either
+      - enums
+      - foldable-traversable
+      - gen
+      - integers
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  tailrec:
+    type: git
+    url: https://github.com/purescript/purescript-tailrec.git
+    rev: 5e2104aa734b31a17074cc805bf087d72b65afd1
+    dependencies:
+      - bifunctors
+      - effect
+      - either
+      - identity
+      - maybe
+      - partial
+      - prelude
+      - refs
+  test-unit:
+    type: git
+    url: https://github.com/bodil/purescript-test-unit.git
+    rev: 3112d7ebe06d467238058a6384dc75ffd960d335
+    dependencies:
+      - aff
+      - avar
+      - effect
+      - either
+      - free
+      - js-timers
+      - lists
+      - prelude
+      - quickcheck
+      - strings
+  transformers:
+    type: git
+    url: https://github.com/purescript/purescript-transformers.git
+    rev: be72ab52357d9a665cbf93d73ba1c07c4b0957ee
+    dependencies:
+      - control
+      - distributive
+      - effect
+      - either
+      - exceptions
+      - foldable-traversable
+      - identity
+      - lazy
+      - maybe
+      - newtype
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  tuples:
+    type: git
+    url: https://github.com/purescript/purescript-tuples.git
+    rev: 4f52da2729b448c8564369378f1232d8d2dc1d8b
+    dependencies:
+      - control
+      - invariant
+      - prelude
+  type-equality:
+    type: git
+    url: https://github.com/purescript/purescript-type-equality.git
+    rev: 0525b7d39e0fbd81b4209518139fb8ab02695774
+    dependencies: []
+  unfoldable:
+    type: git
+    url: https://github.com/purescript/purescript-unfoldable.git
+    rev: 493dfe04ed590e20d8f69079df2f58486882748d
+    dependencies:
+      - foldable-traversable
+      - maybe
+      - partial
+      - prelude
+      - tuples
+  unsafe-coerce:
+    type: git
+    url: https://github.com/purescript/purescript-unsafe-coerce.git
+    rev: ab956f82e66e633f647fb3098e8ddd3ec58d689f
+    dependencies: []

--- a/exercises/chapter6/spago.yaml
+++ b/exercises/chapter6/spago.yaml
@@ -1,0 +1,20 @@
+package:
+  dependencies:
+    - arrays
+    - console
+    - effect
+    - either
+    - foldable-traversable
+    - lists
+    - maybe
+    - newtype
+    - partial
+    - prelude
+    - strings
+    - test-unit
+    - tuples
+  name: my-project
+workspace:
+  extraPackages: {}
+  packageSet:
+    url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json

--- a/exercises/chapter6/spago.yaml
+++ b/exercises/chapter6/spago.yaml
@@ -17,4 +17,4 @@ package:
 workspace:
   extraPackages: {}
   packageSet:
-    url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
+    registry: 10.0.0

--- a/exercises/chapter7/spago.lock
+++ b/exercises/chapter7/spago.lock
@@ -74,3452 +74,462 @@ workspace:
         - validation
   package_set:
     address:
-      url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
-    compiler: ">=0.15.0 <0.16.0"
+      registry: 10.0.0
+    compiler: ">=0.15.4 <0.16.0"
     content:
-      ace:
-        repo: https://github.com/purescript-contrib/purescript-ace.git
-        version: v9.0.0
-        dependencies:
-          - arrays
-          - effect
-          - foreign
-          - nullable
-          - prelude
-          - web-html
-          - web-uievents
-      aff:
-        repo: https://github.com/purescript-contrib/purescript-aff.git
-        version: v7.0.0
-        dependencies:
-          - datetime
-          - effect
-          - exceptions
-          - functions
-          - parallel
-          - transformers
-          - unsafe-coerce
-      aff-bus:
-        repo: https://github.com/purescript-contrib/purescript-aff-bus.git
-        version: v6.0.0
-        dependencies:
-          - aff
-          - avar
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - lists
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-      aff-coroutines:
-        repo: https://github.com/purescript-contrib/purescript-aff-coroutines.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - avar
-          - coroutines
-          - effect
-      aff-promise:
-        repo: https://github.com/nwolverson/purescript-aff-promise.git
-        version: v4.0.0
-        dependencies:
-          - aff
-          - foreign
-      aff-retry:
-        repo: https://github.com/Unisay/purescript-aff-retry.git
-        version: v2.0.0
-        dependencies:
-          - aff
-          - arrays
-          - datetime
-          - effect
-          - either
-          - exceptions
-          - integers
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - random
-          - transformers
-      affjax:
-        repo: https://github.com/purescript-contrib/purescript-affjax.git
-        version: v13.0.0
-        dependencies:
-          - aff
-          - argonaut-core
-          - arraybuffer-types
-          - foreign
-          - form-urlencoded
-          - http-methods
-          - integers
-          - media-types
-          - nullable
-          - refs
-          - unsafe-coerce
-          - web-xhr
-      affjax-node:
-        repo: https://github.com/purescript-contrib/purescript-affjax-node.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - affjax
-          - either
-          - maybe
-          - prelude
-      affjax-web:
-        repo: https://github.com/purescript-contrib/purescript-affjax-web.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - affjax
-          - either
-          - maybe
-          - prelude
-      ansi:
-        repo: https://github.com/hdgarrood/purescript-ansi.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - lists
-          - strings
-      argonaut:
-        repo: https://github.com/purescript-contrib/purescript-argonaut.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - argonaut-traversals
-      argonaut-codecs:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-codecs.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-core
-          - arrays
-          - effect
-          - foreign-object
-          - identity
-          - integers
-          - maybe
-          - nonempty
-          - ordered-collections
-          - prelude
-          - record
-      argonaut-core:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-core.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - foreign-object
-          - functions
-          - gen
-          - maybe
-          - nonempty
-          - prelude
-          - strings
-          - tailrec
-      argonaut-generic:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-generic.git
-        version: v8.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - prelude
-          - record
-      argonaut-traversals:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-traversals.git
-        version: v10.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - profunctor-lenses
-      argparse-basic:
-        repo: https://github.com/natefaubion/purescript-argparse-basic.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - record
-          - strings
-          - tuples
-          - unfoldable
-      arraybuffer:
-        repo: https://github.com/purescript-contrib/purescript-arraybuffer.git
-        version: v13.0.0
-        dependencies:
-          - arraybuffer-types
-          - arrays
-          - effect
-          - float32
-          - functions
-          - gen
-          - maybe
-          - nullable
-          - prelude
-          - tailrec
-          - uint
-          - unfoldable
-      arraybuffer-builder:
-        repo: https://github.com/jamesdbrock/purescript-arraybuffer-builder.git
-        version: v3.0.1
-        dependencies:
-          - arraybuffer
-          - arraybuffer-types
-          - effect
-          - float32
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - transformers
-          - uint
-      arraybuffer-types:
-        repo: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
-        version: v3.0.2
-        dependencies: []
-      arrays:
-        repo: https://github.com/purescript/purescript-arrays.git
-        version: v7.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - foldable-traversable
-          - maybe
-          - nonempty
-          - partial
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - unfoldable
-          - unsafe-coerce
-      arrays-zipper:
-        repo: https://github.com/JordanMartinez/purescript-arrays-zipper.git
-        version: v2.0.1
-        dependencies:
-          - arrays
-          - control
-          - quickcheck
-      ask:
-        repo: https://github.com/Mateiadrielrafael/purescript-ask.git
-        version: v1.0.0
-        dependencies:
-          - unsafe-coerce
-      assert:
-        repo: https://github.com/purescript/purescript-assert.git
-        version: v6.0.0
-        dependencies:
-          - console
-          - effect
-          - prelude
-      avar:
-        repo: https://github.com/purescript-contrib/purescript-avar.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - exceptions
-          - functions
-          - maybe
-      b64:
-        repo: https://github.com/menelaos/purescript-b64.git
-        version: v0.0.8
-        dependencies:
-          - arraybuffer-types
-          - either
-          - encoding
-          - enums
-          - exceptions
-          - functions
-          - partial
-          - prelude
-          - strings
-      barlow-lens:
-        repo: https://github.com/sigma-andex/purescript-barlow-lens.git
-        version: v0.9.0
-        dependencies:
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - profunctor-lenses
-          - tuples
-          - typelevel-prelude
-      bifunctors:
-        repo: https://github.com/purescript/purescript-bifunctors.git
-        version: v6.0.0
-        dependencies:
-          - const
-          - either
-          - newtype
-          - prelude
-          - tuples
-      bigints:
-        repo: https://github.com/sharkdp/purescript-bigints.git
-        version: v7.0.1
-        dependencies:
-          - integers
-          - maybe
-          - strings
-      bower-json:
-        repo: https://github.com/klntsky/purescript-bower-json.git
-        version: v3.0.0
-        dependencies:
-          - argonaut-codecs
-          - arrays
-          - either
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - newtype
-          - prelude
-          - tuples
-      call-by-name:
-        repo: https://github.com/natefaubion/purescript-call-by-name.git
-        version: v4.0.1
-        dependencies:
-          - control
-          - either
-          - lazy
-          - maybe
-          - unsafe-coerce
-      canvas:
-        repo: https://github.com/purescript-web/purescript-canvas.git
-        version: v6.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - exceptions
-          - functions
-          - maybe
-      canvas-action:
-        repo: https://github.com/artemisSystem/purescript-canvas-action.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - arrays
-          - canvas
-          - colors
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - maybe
-          - numbers
-          - polymorphic-vectors
-          - prelude
-          - refs
-          - run
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-html
-      cartesian:
-        repo: https://github.com/Ebmtranceboy/purescript-cartesian.git
-        version: v1.0.6
-        dependencies:
-          - console
-          - effect
-          - integers
-          - psci-support
-      catenable-lists:
-        repo: https://github.com/purescript/purescript-catenable-lists.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - lists
-          - maybe
-          - prelude
-          - tuples
-          - unfoldable
-      channel:
-        repo: https://github.com/ConnorDillon/purescript-channel.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - assert
-          - avar
-          - console
-          - contravariant
-          - control
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - lazy
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      checked-exceptions:
-        repo: https://github.com/natefaubion/purescript-checked-exceptions.git
-        version: v3.1.1
-        dependencies:
-          - prelude
-          - transformers
-          - variant
-      codec:
-        repo: https://github.com/garyb/purescript-codec.git
-        version: v5.0.0
-        dependencies:
-          - profunctor
-          - transformers
-      codec-argonaut:
-        repo: https://github.com/garyb/purescript-codec-argonaut.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-core
-          - codec
-          - ordered-collections
-          - type-equality
-          - variant
-      colors:
-        repo: https://github.com/purescript-contrib/purescript-colors.git
-        version: v7.0.1
-        dependencies:
-          - arrays
-          - integers
-          - lists
-          - numbers
-          - partial
-          - strings
-      concurrent-queues:
-        repo: https://github.com/purescript-contrib/purescript-concurrent-queues.git
-        version: v3.0.0
-        dependencies:
-          - aff
-          - avar
-          - effect
-      console:
-        repo: https://github.com/purescript/purescript-console.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - prelude
-      const:
-        repo: https://github.com/purescript/purescript-const.git
-        version: v6.0.0
-        dependencies:
-          - invariant
-          - newtype
-          - prelude
-      contravariant:
-        repo: https://github.com/purescript/purescript-contravariant.git
-        version: v6.0.0
-        dependencies:
-          - const
-          - either
-          - newtype
-          - prelude
-          - tuples
-      control:
-        repo: https://github.com/purescript/purescript-control.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      convertable-options:
-        repo: https://github.com/natefaubion/purescript-convertable-options.git
-        version: v1.0.0
-        dependencies:
-          - console
-          - effect
-          - maybe
-          - record
-      coroutines:
-        repo: https://github.com/purescript-contrib/purescript-coroutines.git
-        version: v7.0.0
-        dependencies:
-          - freet
-          - parallel
-          - profunctor
-      css:
-        repo: https://github.com/purescript-contrib/purescript-css.git
-        version: v6.0.0
-        dependencies:
-          - colors
-          - console
-          - effect
-          - nonempty
-          - profunctor
-          - strings
-          - these
-          - transformers
-      datetime:
-        repo: https://github.com/purescript/purescript-datetime.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - either
-          - enums
-          - foldable-traversable
-          - functions
-          - gen
-          - integers
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - ordered-collections
-          - partial
-          - prelude
-          - tuples
-      datetime-parsing:
-        repo: https://github.com/flounders/purescript-datetime-parsing.git
-        version: v0.2.0
-        dependencies:
-          - arrays
-          - datetime
-          - either
-          - enums
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - numbers
-          - parsing
-          - prelude
-          - strings
-          - unicode
-      debug:
-        repo: https://github.com/garyb/purescript-debug.git
-        version: v6.0.0
-        dependencies:
-          - functions
-          - prelude
-      decimals:
-        repo: https://github.com/sharkdp/purescript-decimals.git
-        version: v7.0.0
-        dependencies:
-          - maybe
-      dissect:
-        repo: https://github.com/PureFunctor/purescript-dissect.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - foreign-object
-          - functors
-          - newtype
-          - partial
-          - prelude
-          - tailrec
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - variant
-      distributive:
-        repo: https://github.com/purescript/purescript-distributive.git
-        version: v6.0.0
-        dependencies:
-          - identity
-          - newtype
-          - prelude
-          - tuples
-          - type-equality
-      dodo-printer:
-        repo: https://github.com/natefaubion/purescript-dodo-printer.git
-        version: v2.2.0
-        dependencies:
-          - aff
-          - ansi
-          - avar
-          - console
-          - effect
-          - foldable-traversable
-          - lists
-          - maybe
-          - minibench
-          - node-child-process
-          - node-fs-aff
-          - node-process
-          - psci-support
-          - strings
-      dom-indexed:
-        repo: https://github.com/purescript-halogen/purescript-dom-indexed.git
-        version: v11.0.0
-        dependencies:
-          - media-types
-          - prelude
-          - web-clipboard
-          - web-pointerevents
-          - web-touchevents
-      droplet:
-        repo: https://github.com/easafe/purescript-droplet.git
-        version: v0.4.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - bigints
-          - datetime
-          - debug
-          - effect
-          - either
-          - enums
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - integers
-          - maybe
-          - newtype
-          - nullable
-          - ordered-collections
-          - partial
-          - prelude
-          - profunctor
-          - record
-          - spec
-          - strings
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-      dynamic-buffer:
-        repo: https://github.com/kritzcreek/purescript-dynamic-buffer.git
-        version: v3.0.1
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - refs
-      effect:
-        repo: https://github.com/purescript/purescript-effect.git
-        version: v4.0.0
-        dependencies:
-          - prelude
-      either:
-        repo: https://github.com/purescript/purescript-either.git
-        version: v6.1.0
-        dependencies:
-          - control
-          - invariant
-          - maybe
-          - prelude
-      elmish:
-        repo: https://github.com/collegevine/purescript-elmish.git
-        version: v0.8.1
-        dependencies:
-          - aff
-          - argonaut-core
-          - arrays
-          - bifunctors
-          - console
-          - debug
-          - effect
-          - either
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - functions
-          - integers
-          - js-date
-          - maybe
-          - nullable
-          - partial
-          - prelude
-          - refs
-          - typelevel-prelude
-          - undefined-is-not-a-problem
-          - unsafe-coerce
-          - web-dom
-          - web-html
-      elmish-enzyme:
-        repo: https://github.com/collegevine/purescript-elmish-enzyme.git
-        version: v0.1.1
-        dependencies:
-          - aff
-          - aff-promise
-          - arrays
-          - console
-          - debug
-          - effect
-          - elmish
-          - foldable-traversable
-          - foreign
-          - functions
-          - prelude
-          - transformers
-          - unsafe-coerce
-      elmish-hooks:
-        repo: https://github.com/collegevine/purescript-elmish-hooks.git
-        version: v0.8.2
-        dependencies:
-          - aff
-          - debug
-          - elmish
-          - maybe
-          - prelude
-          - tuples
-          - undefined-is-not-a-problem
-      elmish-html:
-        repo: https://github.com/collegevine/purescript-elmish-html.git
-        version: v0.7.1
-        dependencies:
-          - effect
-          - elmish
-          - foreign
-          - foreign-object
-          - prelude
-          - record
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-html
-      email-validate:
-        repo: https://github.com/cdepillabout/purescript-email-validate.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - string-parsers
-          - transformers
-      encoding:
-        repo: https://github.com/menelaos/purescript-encoding.git
-        version: v0.0.8
-        dependencies:
-          - arraybuffer-types
-          - either
-          - exceptions
-          - functions
-          - prelude
-      enums:
-        repo: https://github.com/purescript/purescript-enums.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - either
-          - gen
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tuples
-          - unfoldable
-      exceptions:
-        repo: https://github.com/purescript/purescript-exceptions.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - either
-          - maybe
-          - prelude
-      exists:
-        repo: https://github.com/purescript/purescript-exists.git
-        version: v6.0.0
-        dependencies:
-          - unsafe-coerce
-      exitcodes:
-        repo: https://github.com/Risto-Stevcev/purescript-exitcodes.git
-        version: v4.0.0
-        dependencies:
-          - enums
-      expect-inferred:
-        repo: https://github.com/justinwoo/purescript-expect-inferred.git
-        version: v3.0.0
-        dependencies:
-          - prelude
-          - typelevel-prelude
-      fast-vect:
-        repo: https://github.com/sigma-andex/purescript-fast-vect.git
-        version: v0.7.0
-        dependencies:
-          - arrays
-          - filterable
-          - foldable-traversable
-          - lists
-          - maybe
-          - ordered-collections
-          - prelude
-          - profunctor
-          - tuples
-          - unfoldable
-      filterable:
-        repo: https://github.com/purescript/purescript-filterable.git
-        version: v5.0.0
-        dependencies:
-          - arrays
-          - either
-          - foldable-traversable
-          - identity
-          - lists
-          - ordered-collections
-      fixed-points:
-        repo: https://github.com/purescript-contrib/purescript-fixed-points.git
-        version: v7.0.0
-        dependencies:
-          - exists
-          - newtype
-          - prelude
-          - transformers
-      fixed-precision:
-        repo: https://github.com/lumihq/purescript-fixed-precision.git
-        version: v5.0.0
-        dependencies:
-          - arrays
-          - bigints
-          - control
-          - integers
-          - maybe
-          - numbers
-          - partial
-          - prelude
-          - strings
-      flame:
-        repo: https://github.com/easafe/purescript-flame.git
-        version: v1.2.0
-        dependencies:
-          - aff
-          - argonaut-codecs
-          - argonaut-core
-          - argonaut-generic
-          - arrays
-          - bifunctors
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - maybe
-          - newtype
-          - nullable
-          - partial
-          - prelude
-          - random
-          - refs
-          - spec
-          - strings
-          - tuples
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-html
-          - web-uievents
-      float32:
-        repo: https://github.com/purescript-contrib/purescript-float32.git
-        version: v2.0.0
-        dependencies:
-          - gen
-          - maybe
-          - prelude
-      foldable-traversable:
-        repo: https://github.com/purescript/purescript-foldable-traversable.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - const
-          - control
-          - either
-          - functors
-          - identity
-          - maybe
-          - newtype
-          - orders
-          - prelude
-          - tuples
-      foreign:
-        repo: https://github.com/purescript/purescript-foreign.git
-        version: v7.0.0
-        dependencies:
-          - either
-          - functions
-          - identity
-          - integers
-          - lists
-          - maybe
-          - prelude
-          - strings
-          - transformers
-      foreign-object:
-        repo: https://github.com/purescript/purescript-foreign-object.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - functions
-          - gen
-          - lists
-          - maybe
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - typelevel-prelude
-          - unfoldable
-      foreign-readwrite:
-        repo: https://github.com/artemisSystem/purescript-foreign-readwrite.git
-        version: v3.0.0
-        dependencies:
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - record
-          - safe-coerce
-          - transformers
-          - unsafe-coerce
-      fork:
-        repo: https://github.com/purescript-contrib/purescript-fork.git
-        version: v6.0.0
-        dependencies:
-          - aff
-      form-urlencoded:
-        repo: https://github.com/purescript-contrib/purescript-form-urlencoded.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - js-uri
-          - maybe
-          - newtype
-          - prelude
-          - strings
-          - tuples
-      formatters:
-        repo: https://github.com/purescript-contrib/purescript-formatters.git
-        version: v7.0.0
-        dependencies:
-          - datetime
-          - fixed-points
-          - lists
-          - numbers
-          - parsing
-          - prelude
-          - transformers
-      free:
-        repo: https://github.com/purescript/purescript-free.git
-        version: v7.0.0
-        dependencies:
-          - catenable-lists
-          - control
-          - distributive
-          - either
-          - exists
-          - foldable-traversable
-          - invariant
-          - lazy
-          - maybe
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-      freeap:
-        repo: https://github.com/ethul/purescript-freeap.git
-        version: v7.0.0
-        dependencies:
-          - const
-          - exists
-          - gen
-          - lists
-      freet:
-        repo: https://github.com/purescript-contrib/purescript-freet.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - bifunctors
-          - effect
-          - either
-          - exists
-          - free
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      functions:
-        repo: https://github.com/purescript/purescript-functions.git
-        version: v6.0.0
-        dependencies:
-          - prelude
-      functors:
-        repo: https://github.com/purescript/purescript-functors.git
-        version: v5.0.0
-        dependencies:
-          - bifunctors
-          - const
-          - contravariant
-          - control
-          - distributive
-          - either
-          - invariant
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - tuples
-          - unsafe-coerce
-      fuzzy:
-        repo: https://github.com/citizennet/purescript-fuzzy.git
-        version: v0.4.0
-        dependencies:
-          - foldable-traversable
-          - foreign-object
-          - newtype
-          - ordered-collections
-          - prelude
-          - rationals
-          - strings
-          - tuples
-      gen:
-        repo: https://github.com/purescript/purescript-gen.git
-        version: v4.0.0
-        dependencies:
-          - either
-          - foldable-traversable
-          - identity
-          - maybe
-          - newtype
-          - nonempty
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      generate-values:
-        repo: https://github.com/jordanmartinez/purescript-generate-values.git
-        version: v1.0.1
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - enums
-          - foldable-traversable
-          - gen
-          - identity
-          - integers
-          - lcg
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - partial
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      geometry-plane:
-        repo: https://github.com/Ebmtranceboy/purescript-geometry-plane.git
-        version: v1.0.3
-        dependencies:
-          - console
-          - effect
-          - psci-support
-          - sparse-polynomials
-      github-actions-toolkit:
-        repo: https://github.com/purescript-contrib/purescript-github-actions-toolkit.git
-        version: v0.5.0
-        dependencies:
-          - aff
-          - aff-promise
-          - effect
-          - foreign-object
-          - node-buffer
-          - node-path
-          - node-streams
-          - nullable
-          - transformers
-      graphs:
-        repo: https://github.com/purescript/purescript-graphs.git
-        version: v8.0.0
-        dependencies:
-          - catenable-lists
-          - ordered-collections
-      group:
-        repo: https://github.com/morganthomas/purescript-group.git
-        version: v4.1.1
-        dependencies:
-          - lists
-      halogen:
-        repo: https://github.com/purescript-halogen/purescript-halogen.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - avar
-          - console
-          - const
-          - dom-indexed
-          - effect
-          - foreign
-          - fork
-          - free
-          - freeap
-          - halogen-subscriptions
-          - halogen-vdom
-          - media-types
-          - nullable
-          - ordered-collections
-          - parallel
-          - profunctor
-          - transformers
-          - unsafe-coerce
-          - unsafe-reference
-          - web-file
-          - web-uievents
-      halogen-css:
-        repo: https://github.com/purescript-halogen/purescript-halogen-css.git
-        version: v10.0.0
-        dependencies:
-          - css
-          - halogen
-      halogen-formless:
-        repo: https://github.com/thomashoneyman/purescript-halogen-formless.git
-        version: v4.0.0
-        dependencies:
-          - convertable-options
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - halogen
-          - heterogeneous
-          - maybe
-          - prelude
-          - record
-          - safe-coerce
-          - type-equality
-          - unsafe-coerce
-          - unsafe-reference
-          - variant
-          - web-events
-          - web-uievents
-      halogen-hooks:
-        repo: https://github.com/thomashoneyman/purescript-halogen-hooks.git
-        version: v0.6.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - effect
-          - exceptions
-          - foldable-traversable
-          - foreign-object
-          - free
-          - freeap
-          - halogen
-          - halogen-subscriptions
-          - maybe
-          - newtype
-          - ordered-collections
-          - parallel
-          - partial
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-          - unsafe-reference
-          - web-dom
-          - web-html
-      halogen-hooks-extra:
-        repo: https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git
-        version: v0.9.0
-        dependencies:
-          - halogen-hooks
-      halogen-store:
-        repo: https://github.com/thomashoneyman/purescript-halogen-store.git
-        version: v0.5.0
-        dependencies:
-          - aff
-          - distributive
-          - effect
-          - fork
-          - halogen
-          - halogen-hooks
-          - halogen-subscriptions
-          - maybe
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-reference
-      halogen-storybook:
-        repo: https://github.com/rnons/purescript-halogen-storybook.git
-        version: v2.0.0
-        dependencies:
-          - foreign-object
-          - halogen
-          - prelude
-          - routing
-      halogen-subscriptions:
-        repo: https://github.com/purescript-halogen/purescript-halogen-subscriptions.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - effect
-          - foldable-traversable
-          - functors
-          - refs
-          - safe-coerce
-          - unsafe-reference
-      halogen-svg-elems:
-        repo: https://github.com/JordanMartinez/purescript-halogen-svg-elems.git
-        version: v6.0.0
-        dependencies:
-          - halogen
-      halogen-vdom:
-        repo: https://github.com/purescript-halogen/purescript-halogen-vdom.git
-        version: v8.0.0
-        dependencies:
-          - bifunctors
-          - effect
-          - foreign
-          - foreign-object
-          - maybe
-          - prelude
-          - refs
-          - tuples
-          - unsafe-coerce
-          - web-html
-      halogen-vdom-string-renderer:
-        repo: https://github.com/purescript-halogen/purescript-halogen-vdom-string-renderer.git
-        version: v0.5.0
-        dependencies:
-          - foreign
-          - halogen-vdom
-          - ordered-collections
-          - prelude
-      heckin:
-        repo: https://github.com/maxdeviant/purescript-heckin.git
-        version: v2.0.1
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - maybe
-          - prelude
-          - strings
-          - transformers
-          - tuples
-          - unicode
-      heterogeneous:
-        repo: https://github.com/natefaubion/purescript-heterogeneous.git
-        version: v0.6.0
-        dependencies:
-          - either
-          - functors
-          - prelude
-          - record
-          - tuples
-          - variant
-      heterogeneous-extrablatt:
-        repo: https://github.com/sigma-andex/purescript-heterogeneous-extrablatt.git
-        version: v0.2.1
-        dependencies:
-          - heterogeneous
-          - prelude
-          - record
-      http-methods:
-        repo: https://github.com/purescript-contrib/purescript-http-methods.git
-        version: v6.0.0
-        dependencies:
-          - either
-          - prelude
-          - strings
-      httpure:
-        repo: https://github.com/citizennet/purescript-httpure.git
-        version: v0.15.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - js-uri
-          - maybe
-          - newtype
-          - node-buffer
-          - node-fs
-          - node-http
-          - node-streams
-          - options
-          - ordered-collections
-          - prelude
-          - refs
-          - strings
-          - tuples
-          - type-equality
-      httpurple:
-        repo: https://github.com/sigma-andex/purescript-httpurple.git
-        version: v1.3.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - js-uri
-          - justifill
-          - maybe
-          - newtype
-          - node-buffer
-          - node-fs
-          - node-http
-          - node-net
-          - node-process
-          - node-streams
-          - options
-          - ordered-collections
-          - posix-types
-          - prelude
-          - profunctor
-          - record
-          - refs
-          - routing-duplex
-          - strings
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-      httpurple-argonaut:
-        repo: https://github.com/sigma-andex/purescript-httpurple-argonaut.git
-        version: v1.0.1
-        dependencies:
-          - argonaut
-          - console
-          - effect
-          - either
-          - httpurple
-          - prelude
-      httpurple-yoga-json:
-        repo: https://github.com/sigma-andex/purescript-httpurple-yoga-json.git
-        version: v1.0.0
-        dependencies:
-          - console
-          - effect
-          - either
-          - foreign
-          - httpurple
-          - lists
-          - prelude
-          - yoga-json
-      identity:
-        repo: https://github.com/purescript/purescript-identity.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - invariant
-          - newtype
-          - prelude
-      indexed-monad:
-        repo: https://github.com/garyb/purescript-indexed-monad.git
-        version: v2.1.0
-        dependencies:
-          - control
-          - newtype
-      int64:
-        repo: https://github.com/purescript-contrib/purescript-int64.git
-        version: v2.0.0
-        dependencies:
-          - effect
-          - foreign
-          - functions
-          - integers
-          - maybe
-          - nullable
-          - prelude
-          - quickcheck
-      integers:
-        repo: https://github.com/purescript/purescript-integers.git
-        version: v6.0.0
-        dependencies:
-          - maybe
-          - numbers
-          - prelude
-      interpolate:
-        repo: https://github.com/jordanmartinez/purescript-interpolate.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-      invariant:
-        repo: https://github.com/purescript/purescript-invariant.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - prelude
-      js-date:
-        repo: https://github.com/purescript-contrib/purescript-js-date.git
-        version: v8.0.0
-        dependencies:
-          - datetime
-          - effect
-          - exceptions
-          - foreign
-          - integers
-          - now
-      js-fileio:
-        repo: https://github.com/newlandsvalley/purescript-js-fileio.git
-        version: v3.0.0
-        dependencies:
-          - aff
-          - effect
-          - prelude
-      js-timers:
-        repo: https://github.com/purescript-contrib/purescript-js-timers.git
-        version: v6.1.0
-        dependencies:
-          - effect
-      js-uri:
-        repo: https://github.com/purescript-contrib/purescript-js-uri.git
-        version: v3.0.0
-        dependencies:
-          - functions
-          - maybe
-      justifill:
-        repo: https://github.com/i-am-the-slime/purescript-justifill.git
-        version: v0.5.0
-        dependencies:
-          - maybe
-          - prelude
-          - record
-          - typelevel-prelude
-      jwt:
-        repo: https://github.com/menelaos/purescript-jwt.git
-        version: v0.0.9
-        dependencies:
-          - argonaut-core
-          - arrays
-          - b64
-          - either
-          - exceptions
-          - prelude
-          - profunctor-lenses
-          - strings
-      language-cst-parser:
-        repo: https://github.com/natefaubion/purescript-language-cst-parser.git
-        version: v0.12.0
-        dependencies:
-          - arrays
-          - const
-          - control
-          - either
-          - foldable-traversable
-          - free
-          - functions
-          - functors
-          - identity
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - ordered-collections
-          - partial
-          - prelude
-          - st
-          - strings
-          - transformers
-          - tuples
-          - typelevel-prelude
-          - unfoldable
-          - unsafe-coerce
-      lazy:
-        repo: https://github.com/purescript/purescript-lazy.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - invariant
-          - prelude
-      lcg:
-        repo: https://github.com/purescript/purescript-lcg.git
-        version: v4.0.0
-        dependencies:
-          - effect
-          - integers
-          - maybe
-          - partial
-          - prelude
-          - random
-      leibniz:
-        repo: https://github.com/paf31/purescript-leibniz.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-          - unsafe-coerce
-      linalg:
-        repo: https://github.com/gbagan/purescript-linalg.git
-        version: v5.1.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - functions
-          - maybe
-          - prelude
-          - tuples
-      lists:
-        repo: https://github.com/purescript/purescript-lists.git
-        version: v7.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - foldable-traversable
-          - lazy
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      logging:
-        repo: https://github.com/rightfold/purescript-logging.git
-        version: v3.0.0
-        dependencies:
-          - console
-          - contravariant
-          - effect
-          - either
-          - prelude
-          - transformers
-          - tuples
-      machines:
-        repo: https://github.com/purescript-contrib/purescript-machines.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - lists
-          - maybe
-          - prelude
-          - profunctor
-          - tuples
-          - unfoldable
-      matrices:
-        repo: https://github.com/kRITZCREEK/purescript-matrices.git
-        version: v5.0.1
-        dependencies:
-          - arrays
-          - strings
-      matryoshka:
-        repo: https://github.com/purescript-contrib/purescript-matryoshka.git
-        version: v1.0.0
-        dependencies:
-          - fixed-points
-          - free
-          - prelude
-          - profunctor
-          - transformers
-      maybe:
-        repo: https://github.com/purescript/purescript-maybe.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - invariant
-          - newtype
-          - prelude
-      media-types:
-        repo: https://github.com/purescript-contrib/purescript-media-types.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      metadata:
-        repo: https://github.com/purescript/purescript-metadata.git
-        version: v0.15.0
-        dependencies: []
-      midi:
-        repo: https://github.com/newlandsvalley/purescript-midi.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - ordered-collections
-          - prelude
-          - signal
-          - string-parsers
-          - strings
-          - tuples
-          - unfoldable
-      minibench:
-        repo: https://github.com/purescript/purescript-minibench.git
-        version: v4.0.0
-        dependencies:
-          - console
-          - effect
-          - integers
-          - numbers
-          - partial
-          - prelude
-          - refs
-      mmorph:
-        repo: https://github.com/Thimoteus/purescript-mmorph.git
-        version: v7.0.0
-        dependencies:
-          - free
-          - functors
-          - transformers
-      monad-control:
-        repo: https://github.com/athanclark/purescript-monad-control.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - freet
-          - identity
-          - lists
-      monad-logger:
-        repo: https://github.com/cprussin/purescript-monad-logger.git
-        version: v1.3.1
-        dependencies:
-          - aff
-          - ansi
-          - argonaut
-          - arrays
-          - console
-          - control
-          - effect
-          - foldable-traversable
-          - foreign-object
-          - integers
-          - js-date
-          - maybe
-          - newtype
-          - ordered-collections
-          - prelude
-          - strings
-          - transformers
-          - tuples
-      monad-loops:
-        repo: https://github.com/mlang/purescript-monad-loops.git
-        version: v0.5.0
-        dependencies:
-          - lists
-          - maybe
-          - prelude
-          - tailrec
-          - tuples
-      monad-unlift:
-        repo: https://github.com/athanclark/purescript-monad-unlift.git
-        version: v1.0.1
-        dependencies:
-          - monad-control
-      monoidal:
-        repo: https://github.com/mcneissue/purescript-monoidal.git
-        version: v0.16.0
-        dependencies:
-          - either
-          - profunctor
-          - these
-          - tuples
-      morello:
-        repo: https://github.com/sigma-andex/purescript-morello.git
-        version: v0.3.2
-        dependencies:
-          - arrays
-          - barlow-lens
-          - foldable-traversable
-          - heterogeneous
-          - heterogeneous-extrablatt
-          - newtype
-          - prelude
-          - profunctor
-          - profunctor-lenses
-          - record
-          - tuples
-          - typelevel-prelude
-          - validation
-      motsunabe:
-        repo: https://github.com/justinwoo/purescript-motsunabe.git
-        version: v2.0.0
-        dependencies:
-          - lists
-          - strings
-      nano-id:
-        repo: https://github.com/eikooc/nano-id.git
-        version: v1.1.0
-        dependencies:
-          - aff
-          - effect
-          - lists
-          - maybe
-          - prelude
-          - random
-          - spec
-          - strings
-          - stringutils
-      naturals:
-        repo: https://github.com/LiamGoodacre/purescript-naturals.git
-        version: v3.0.0
-        dependencies:
-          - enums
-          - maybe
-          - prelude
-      nested-functor:
-        repo: https://github.com/acple/purescript-nested-functor.git
-        version: v0.2.1
-        dependencies:
-          - prelude
-          - type-equality
-      newtype:
-        repo: https://github.com/purescript/purescript-newtype.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-          - safe-coerce
-      node-buffer:
-        repo: https://github.com/purescript-node/purescript-node-buffer.git
-        version: v8.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - maybe
-          - st
-          - unsafe-coerce
-      node-buffer-blob:
-        repo: https://github.com/purescript-node/purescript-node-buffer-blob.git
-        version: v1.0.0
-        dependencies:
-          - aff-promise
-          - arraybuffer-types
-          - arrays
-          - console
-          - effect
-          - maybe
-          - media-types
-          - newtype
-          - node-buffer
-          - nullable
-          - prelude
-          - web-streams
-      node-child-process:
-        repo: https://github.com/purescript-node/purescript-node-child-process.git
-        version: v9.0.0
-        dependencies:
-          - exceptions
-          - foreign
-          - foreign-object
-          - functions
-          - node-fs
-          - node-streams
-          - nullable
-          - posix-types
-          - unsafe-coerce
-      node-fs:
-        repo: https://github.com/purescript-node/purescript-node-fs.git
-        version: v8.0.0
-        dependencies:
-          - datetime
-          - effect
-          - either
-          - enums
-          - exceptions
-          - functions
-          - integers
-          - js-date
-          - maybe
-          - node-buffer
-          - node-path
-          - node-streams
-          - nullable
-          - partial
-          - prelude
-          - strings
-          - unsafe-coerce
-      node-fs-aff:
-        repo: https://github.com/purescript-node/purescript-node-fs-aff.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - either
-          - node-fs
-          - node-path
-      node-http:
-        repo: https://github.com/purescript-node/purescript-node-http.git
-        version: v8.0.0
-        dependencies:
-          - arraybuffer-types
-          - contravariant
-          - effect
-          - foreign
-          - foreign-object
-          - maybe
-          - node-buffer
-          - node-net
-          - node-streams
-          - node-url
-          - nullable
-          - options
-          - prelude
-          - unsafe-coerce
-      node-net:
-        repo: https://github.com/purescript-node/purescript-node-net.git
-        version: v4.0.0
-        dependencies:
-          - effect
-          - either
-          - exceptions
-          - foreign
-          - maybe
-          - node-buffer
-          - node-fs
-          - nullable
-          - options
-          - prelude
-          - transformers
-      node-path:
-        repo: https://github.com/purescript-node/purescript-node-path.git
-        version: v5.0.0
-        dependencies:
-          - effect
-      node-process:
-        repo: https://github.com/purescript-node/purescript-node-process.git
-        version: v10.0.0
-        dependencies:
-          - effect
-          - foreign-object
-          - maybe
-          - node-streams
-          - posix-types
-          - prelude
-          - unsafe-coerce
-      node-readline:
-        repo: https://github.com/purescript-node/purescript-node-readline.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - foreign
-          - node-process
-          - node-streams
-          - options
-          - prelude
-      node-streams:
-        repo: https://github.com/purescript-node/purescript-node-streams.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - either
-          - exceptions
-          - node-buffer
-          - nullable
-          - prelude
-      node-streams-aff:
-        repo: https://github.com/jamesdbrock/purescript-node-streams-aff.git
-        version: v2.0.0
-        dependencies:
-          - aff
-          - arrays
-          - effect
-          - either
-          - exceptions
-          - maybe
-          - node-buffer
-          - node-streams
-          - prelude
-          - st
-          - tuples
-      node-url:
-        repo: https://github.com/purescript-node/purescript-node-url.git
-        version: v6.0.0
-        dependencies:
-          - nullable
-      nonempty:
-        repo: https://github.com/purescript/purescript-nonempty.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - maybe
-          - prelude
-          - tuples
-          - unfoldable
-      now:
-        repo: https://github.com/purescript-contrib/purescript-now.git
-        version: v6.0.0
-        dependencies:
-          - datetime
-          - effect
-      npm-package-json:
-        repo: https://github.com/maxdeviant/purescript-npm-package-json.git
-        version: v2.0.0
-        dependencies:
-          - argonaut
-          - control
-          - either
-          - foreign-object
-          - maybe
-          - ordered-collections
-          - prelude
-      nullable:
-        repo: https://github.com/purescript-contrib/purescript-nullable.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - functions
-          - maybe
-      numbers:
-        repo: https://github.com/purescript/purescript-numbers.git
-        version: v9.0.0
-        dependencies:
-          - functions
-          - maybe
-      open-folds:
-        repo: https://github.com/purescript-open-community/purescript-open-folds.git
-        version: v6.3.0
-        dependencies:
-          - bifunctors
-          - console
-          - control
-          - distributive
-          - effect
-          - either
-          - foldable-traversable
-          - identity
-          - invariant
-          - maybe
-          - newtype
-          - ordered-collections
-          - prelude
-          - profunctor
-          - psci-support
-          - tuples
-      open-memoize:
-        repo: https://github.com/purescript-open-community/purescript-open-memoize.git
-        version: v6.1.0
-        dependencies:
-          - console
-          - effect
-          - either
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - psci-support
-          - strings
-          - tuples
-      open-pairing:
-        repo: https://github.com/purescript-open-community/purescript-open-pairing.git
-        version: v6.1.0
-        dependencies:
-          - console
-          - control
-          - effect
-          - either
-          - free
-          - functors
-          - identity
-          - newtype
-          - prelude
-          - psci-support
-          - transformers
-          - tuples
-      options:
-        repo: https://github.com/purescript-contrib/purescript-options.git
-        version: v7.0.0
-        dependencies:
-          - contravariant
-          - foreign
-          - foreign-object
-          - maybe
-          - tuples
-      optparse:
-        repo: https://github.com/f-o-a-m/purescript-optparse.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - control
-          - effect
-          - either
-          - enums
-          - exists
-          - exitcodes
-          - foldable-traversable
-          - free
-          - gen
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - newtype
-          - node-buffer
-          - node-process
-          - node-streams
-          - nonempty
-          - numbers
-          - open-memoize
-          - partial
-          - prelude
-          - quickcheck
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-      ordered-collections:
-        repo: https://github.com/purescript/purescript-ordered-collections.git
-        version: v3.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - gen
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - unfoldable
-      ordered-set:
-        repo: https://github.com/flip111/purescript-ordered-set.git
-        version: v0.4.0
-        dependencies:
-          - argonaut-codecs
-          - arrays
-          - partial
-          - prelude
-          - unfoldable
-      orders:
-        repo: https://github.com/purescript/purescript-orders.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      pairs:
-        repo: https://github.com/sharkdp/purescript-pairs.git
-        version: v9.0.0
-        dependencies:
-          - console
-          - distributive
-          - foldable-traversable
-          - quickcheck
-      parallel:
-        repo: https://github.com/purescript/purescript-parallel.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - functors
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - refs
-          - transformers
-      parsing:
-        repo: https://github.com/purescript-contrib/purescript-parsing.git
-        version: v9.1.0
-        dependencies:
-          - arrays
-          - either
-          - foldable-traversable
-          - identity
-          - integers
-          - lists
-          - maybe
-          - nullable
-          - prelude
-          - strings
-          - transformers
-          - unicode
-      parsing-dataview:
-        repo: https://github.com/jamesdbrock/purescript-parsing-dataview.git
-        version: v3.1.0
-        dependencies:
-          - arraybuffer
-          - arraybuffer-types
-          - effect
-          - float32
-          - maybe
-          - parsing
-          - prelude
-          - transformers
-          - tuples
-          - uint
-      partial:
-        repo: https://github.com/purescript/purescript-partial.git
-        version: v4.0.0
-        dependencies: []
-      pathy:
-        repo: https://github.com/purescript-contrib/purescript-pathy.git
-        version: v9.0.0
-        dependencies:
-          - console
-          - exceptions
-          - lists
-          - partial
-          - profunctor
-          - strings
-          - transformers
-          - typelevel-prelude
-          - unsafe-coerce
-      pha:
-        repo: https://github.com/gbagan/purescript-pha.git
-        version: v0.9.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - datetime
-          - effect
-          - foldable-traversable
-          - free
-          - integers
-          - maybe
-          - prelude
-          - profunctor-lenses
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-          - unsafe-reference
-          - web-dom
-          - web-events
-          - web-html
-          - web-pointerevents
-          - web-uievents
-      phaser:
-        repo: https://github.com/lfarroco/purescript-phaser.git
-        version: v0.6.0
-        dependencies:
-          - canvas
-          - console
-          - effect
-          - maybe
-          - nullable
-          - options
-          - prelude
-          - web-html
-      pipes:
-        repo: https://github.com/felixschl/purescript-pipes.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - lists
-          - mmorph
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      point-free:
-        repo: https://github.com/ursi/purescript-point-free.git
-        version: v1.0.0
-        dependencies:
-          - prelude
-      polymorphic-vectors:
-        repo: https://github.com/artemisSystem/purescript-polymorphic-vectors.git
-        version: v4.0.0
-        dependencies:
-          - distributive
-          - foldable-traversable
-          - numbers
-          - prelude
-          - record
-          - safe-coerce
-          - type-equality
-          - typelevel-prelude
-      posix-types:
-        repo: https://github.com/purescript-node/purescript-posix-types.git
-        version: v6.0.0
-        dependencies:
-          - maybe
-          - prelude
-      precise:
-        repo: https://github.com/purescript-contrib/purescript-precise.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - exceptions
-          - gen
-          - integers
-          - lists
-          - numbers
-          - prelude
-          - strings
-      precise-datetime:
-        repo: https://github.com/awakesecurity/purescript-precise-datetime.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - datetime
-          - decimals
-          - either
-          - enums
-          - foldable-traversable
-          - formatters
-          - integers
-          - js-date
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - strings
-          - tuples
-          - unicode
-      prelude:
-        repo: https://github.com/purescript/purescript-prelude.git
-        version: v6.0.0
-        dependencies: []
-      prettier-printer:
-        repo: https://github.com/paulyoung/purescript-prettier-printer.git
-        version: v3.0.0
-        dependencies:
-          - console
-          - lists
-          - prelude
-          - strings
-          - tuples
-      profunctor:
-        repo: https://github.com/purescript/purescript-profunctor.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - distributive
-          - either
-          - exists
-          - invariant
-          - newtype
-          - prelude
-          - tuples
-      profunctor-lenses:
-        repo: https://github.com/purescript-contrib/purescript-profunctor-lenses.git
-        version: v8.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - const
-          - control
-          - distributive
-          - either
-          - foldable-traversable
-          - foreign-object
-          - functors
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - ordered-collections
-          - partial
-          - prelude
-          - profunctor
-          - record
-          - transformers
-          - tuples
-      protobuf:
-        repo: https://github.com/xc-jp/purescript-protobuf.git
-        version: v4.0.0
-        dependencies:
-          - arraybuffer
-          - arraybuffer-builder
-          - arraybuffer-types
-          - arrays
-          - control
-          - effect
-          - either
-          - enums
-          - exceptions
-          - float32
-          - foldable-traversable
-          - functions
-          - int64
-          - maybe
-          - newtype
-          - parsing
-          - parsing-dataview
-          - prelude
-          - record
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-          - uint
-          - web-encoding
-      ps-cst:
-        repo: https://github.com/purescript-codegen/purescript-ps-cst.git
-        version: v1.2.0
-        dependencies:
-          - ansi
-          - console
-          - dodo-printer
-          - effect
-          - node-fs-aff
-          - node-path
-          - psci-support
-          - record
-          - strings
-      psa-utils:
-        repo: https://github.com/natefaubion/purescript-psa-utils.git
-        version: v8.0.0
-        dependencies:
-          - ansi
-          - argonaut-codecs
-          - argonaut-core
-          - arrays
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - maybe
-          - node-path
-          - ordered-collections
-          - prelude
-          - strings
-          - tuples
-          - unsafe-coerce
-      psc-ide:
-        repo: https://github.com/kRITZCREEK/purescript-psc-ide.git
-        version: v19.0.0
-        dependencies:
-          - aff
-          - argonaut
-          - arrays
-          - console
-          - maybe
-          - node-child-process
-          - node-fs
-          - parallel
-          - random
-      psci-support:
-        repo: https://github.com/purescript/purescript-psci-support.git
-        version: v6.0.0
-        dependencies:
-          - console
-          - effect
-          - prelude
-      qualified-do:
-        repo: https://github.com/artemisSystem/purescript-qualified-do.git
-        version: v2.2.0
-        dependencies:
-          - arrays
-          - control
-          - foldable-traversable
-          - parallel
-          - prelude
-          - unfoldable
-      quantities:
-        repo: https://github.com/sharkdp/purescript-quantities.git
-        version: v12.0.1
-        dependencies:
-          - decimals
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - newtype
-          - nonempty
-          - numbers
-          - pairs
-          - prelude
-          - tuples
-      quickcheck:
-        repo: https://github.com/purescript/purescript-quickcheck.git
-        version: v8.0.1
-        dependencies:
-          - arrays
-          - console
-          - control
-          - effect
-          - either
-          - enums
-          - exceptions
-          - foldable-traversable
-          - gen
-          - identity
-          - integers
-          - lazy
-          - lcg
-          - lists
-          - maybe
-          - newtype
-          - nonempty
-          - numbers
-          - partial
-          - prelude
-          - record
-          - st
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-          - unfoldable
-      quickcheck-combinators:
-        repo: https://github.com/athanclark/purescript-quickcheck-combinators.git
-        version: v0.1.3
-        dependencies:
-          - quickcheck
-          - typelevel
-      quickcheck-laws:
-        repo: https://github.com/purescript-contrib/purescript-quickcheck-laws.git
-        version: v7.0.0
-        dependencies:
-          - enums
-          - quickcheck
-      quickcheck-utf8:
-        repo: https://github.com/openchronology/purescript-quickcheck-utf8.git
-        version: v0.0.0
-        dependencies:
-          - quickcheck
-      quotient:
-        repo: https://github.com/rightfold/purescript-quotient.git
-        version: v3.0.0
-        dependencies:
-          - prelude
-          - quickcheck
-      random:
-        repo: https://github.com/purescript/purescript-random.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - integers
-      rationals:
-        repo: https://github.com/anttih/purescript-rationals.git
-        version: v5.0.0
-        dependencies:
-          - integers
-          - prelude
-      react:
-        repo: https://github.com/purescript-contrib/purescript-react.git
-        version: v10.0.1
-        dependencies:
-          - effect
-          - exceptions
-          - maybe
-          - nullable
-          - prelude
-          - typelevel-prelude
-          - unsafe-coerce
-      react-basic:
-        repo: https://github.com/lumihq/purescript-react-basic.git
-        version: v17.0.0
-        dependencies:
-          - effect
-          - prelude
-          - record
-      react-basic-dom:
-        repo: https://github.com/lumihq/purescript-react-basic-dom.git
-        version: v5.0.0
-        dependencies:
-          - effect
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - nullable
-          - prelude
-          - react-basic
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-file
-          - web-html
-      react-basic-hooks:
-        repo: https://github.com/megamaddu/purescript-react-basic-hooks.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - aff-promise
-          - bifunctors
-          - console
-          - control
-          - datetime
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - functions
-          - indexed-monad
-          - integers
-          - maybe
-          - newtype
-          - now
-          - nullable
-          - ordered-collections
-          - prelude
-          - react-basic
-          - refs
-          - tuples
-          - type-equality
-          - unsafe-coerce
-          - unsafe-reference
-          - web-html
-      react-dom:
-        repo: https://github.com/purescript-contrib/purescript-react-dom.git
-        version: v8.0.0
-        dependencies:
-          - effect
-          - react
-          - web-dom
-      read:
-        repo: https://github.com/truqu/purescript-read.git
-        version: v1.0.1
-        dependencies:
-          - maybe
-          - prelude
-          - strings
-      record:
-        repo: https://github.com/purescript/purescript-record.git
-        version: v4.0.0
-        dependencies:
-          - functions
-          - prelude
-          - unsafe-coerce
-      refined:
-        repo: https://github.com/danieljharvey/purescript-refined.git
-        version: v1.0.0
-        dependencies:
-          - argonaut
-          - effect
-          - prelude
-          - quickcheck
-          - typelevel
-      refs:
-        repo: https://github.com/purescript/purescript-refs.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - prelude
-      remotedata:
-        repo: https://github.com/krisajenkins/purescript-remotedata.git
-        version: v5.0.0
-        dependencies:
-          - bifunctors
-          - either
-          - profunctor-lenses
-      resource:
-        repo: https://github.com/joneshf/purescript-resource.git
-        version: v2.0.1
-        dependencies:
-          - aff
-          - console
-          - control
-          - effect
-          - newtype
-          - prelude
-          - psci-support
-          - refs
-      resourcet:
-        repo: https://github.com/robertdp/purescript-resourcet.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - effect
-          - foldable-traversable
-          - maybe
-          - ordered-collections
-          - parallel
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-      result:
-        repo: https://github.com/ad-si/purescript-result.git
-        version: v1.0.3
-        dependencies:
-          - either
-          - foldable-traversable
-          - prelude
-      return:
-        repo: https://github.com/ursi/purescript-return.git
-        version: v0.2.0
-        dependencies:
-          - foldable-traversable
-          - point-free
-          - prelude
-      ring-modules:
-        repo: https://github.com/f-o-a-m/purescript-ring-modules.git
-        version: v5.0.1
-        dependencies:
-          - prelude
-      routing:
-        repo: https://github.com/purescript-contrib/purescript-routing.git
-        version: v11.0.0
-        dependencies:
-          - aff
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - integers
-          - js-uri
-          - lists
-          - maybe
-          - numbers
-          - partial
-          - prelude
-          - semirings
-          - tuples
-          - validation
-          - web-html
-      routing-duplex:
-        repo: https://github.com/natefaubion/purescript-routing-duplex.git
-        version: v0.6.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - js-uri
-          - lazy
-          - numbers
-          - prelude
-          - profunctor
-          - record
-          - strings
-          - typelevel-prelude
-      run:
-        repo: https://github.com/natefaubion/purescript-run.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - free
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - tailrec
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - variant
-      safe-coerce:
-        repo: https://github.com/purescript/purescript-safe-coerce.git
-        version: v2.0.0
-        dependencies:
-          - unsafe-coerce
-      safely:
-        repo: https://github.com/paf31/purescript-safely.git
-        version: v4.0.1
-        dependencies:
-          - freet
-          - lists
-      selection-foldable:
-        repo: https://github.com/jamieyung/purescript-selection-foldable.git
-        version: v0.2.0
-        dependencies:
-          - filterable
-          - foldable-traversable
-          - maybe
-          - prelude
-      semirings:
-        repo: https://github.com/purescript/purescript-semirings.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - lists
-          - newtype
-          - prelude
-      signal:
-        repo: https://github.com/bodil/purescript-signal.git
-        version: v13.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - foldable-traversable
-          - maybe
-          - prelude
-      simple-emitter:
-        repo: https://github.com/oreshinya/purescript-simple-emitter.git
-        version: v2.0.0
-        dependencies:
-          - ordered-collections
-          - refs
-      sized-matrices:
-        repo: https://github.com/csicar/purescript-sized-matrices.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - distributive
-          - foldable-traversable
-          - maybe
-          - prelude
-          - sized-vectors
-          - strings
-          - typelevel
-          - unfoldable
-          - vectorfield
-      sized-vectors:
-        repo: https://github.com/bodil/purescript-sized-vectors.git
-        version: v5.0.2
-        dependencies:
-          - argonaut
-          - arrays
-          - distributive
-          - foldable-traversable
-          - maybe
-          - prelude
-          - quickcheck
-          - typelevel
-          - unfoldable
-      slug:
-        repo: https://github.com/thomashoneyman/purescript-slug.git
-        version: v3.0.1
-        dependencies:
-          - argonaut-codecs
-          - maybe
-          - prelude
-          - strings
-          - unicode
-      soundfonts:
-        repo: https://github.com/newlandsvalley/purescript-soundfonts.git
-        version: v4.1.0
-        dependencies:
-          - aff
-          - affjax
-          - affjax-web
-          - argonaut-core
-          - arraybuffer-types
-          - arrays
-          - b64
-          - bifunctors
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign-object
-          - http-methods
-          - integers
-          - lists
-          - maybe
-          - midi
-          - ordered-collections
-          - parallel
-          - partial
-          - prelude
-          - strings
-          - transformers
-          - tuples
-      sparse-matrices:
-        repo: https://github.com/Ebmtranceboy/purescript-sparse-matrices.git
-        version: v1.2.1
-        dependencies:
-          - console
-          - effect
-          - prelude
-          - sparse-polynomials
-      sparse-polynomials:
-        repo: https://github.com/Ebmtranceboy/purescript-sparse-polynomials.git
-        version: v1.0.5
-        dependencies:
-          - cartesian
-          - console
-          - effect
-          - ordered-collections
-          - prelude
-          - rationals
-          - tuples
-      spec:
-        repo: https://github.com/purescript-spec/purescript-spec.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - ansi
-          - avar
-          - console
-          - exceptions
-          - foldable-traversable
-          - fork
-          - now
-          - pipes
-          - prelude
-          - strings
-          - transformers
-      spec-discovery:
-        repo: https://github.com/purescript-spec/purescript-spec-discovery.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - aff-promise
-          - arrays
-          - console
-          - effect
-          - foldable-traversable
-          - node-fs
-          - prelude
-          - spec
-      spec-quickcheck:
-        repo: https://github.com/purescript-spec/purescript-spec-quickcheck.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - prelude
-          - quickcheck
-          - random
-          - spec
-      ssrs:
-        repo: https://github.com/PureFunctor/purescript-ssrs.git
-        version: v1.0.0
-        dependencies:
-          - dissect
-          - either
-          - fixed-points
-          - free
-          - lists
-          - prelude
-          - safe-coerce
-          - tailrec
-          - tuples
-          - variant
-      st:
-        repo: https://github.com/purescript/purescript-st.git
-        version: v6.0.0
-        dependencies:
-          - partial
-          - prelude
-          - tailrec
-          - unsafe-coerce
-      strictlypositiveint:
-        repo: https://github.com/jamieyung/purescript-strictlypositiveint.git
-        version: v1.0.1
-        dependencies:
-          - prelude
-      string-parsers:
-        repo: https://github.com/purescript-contrib/purescript-string-parsers.git
-        version: v8.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - prelude
-          - strings
-          - tailrec
-      strings:
-        repo: https://github.com/purescript/purescript-strings.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - enums
-          - foldable-traversable
-          - gen
-          - integers
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-          - unsafe-coerce
-      strings-extra:
-        repo: https://github.com/purescript-contrib/purescript-strings-extra.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - maybe
-          - prelude
-          - strings
-          - unicode
-      stringutils:
-        repo: https://github.com/menelaos/purescript-stringutils.git
-        version: v0.0.12
-        dependencies:
-          - arrays
-          - integers
-          - maybe
-          - partial
-          - prelude
-          - strings
-      substitute:
-        repo: https://github.com/ursi/purescript-substitute.git
-        version: v0.2.3
-        dependencies:
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - prelude
-          - return
-          - strings
-      supply:
-        repo: https://github.com/ajnsit/purescript-supply.git
-        version: v0.2.0
-        dependencies:
-          - console
-          - control
-          - effect
-          - lazy
-          - prelude
-          - refs
-          - tuples
-      tailrec:
-        repo: https://github.com/purescript/purescript-tailrec.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - effect
-          - either
-          - identity
-          - maybe
-          - partial
-          - prelude
-          - refs
-      test-unit:
-        repo: https://github.com/bodil/purescript-test-unit.git
-        version: v17.0.0
-        dependencies:
-          - aff
-          - avar
-          - effect
-          - either
-          - free
-          - js-timers
-          - lists
-          - prelude
-          - quickcheck
-          - strings
-      thermite:
-        repo: https://github.com/paf31/purescript-thermite.git
-        version: v6.3.1
-        dependencies:
-          - aff
-          - coroutines
-          - freet
-          - profunctor-lenses
-          - react
-      thermite-dom:
-        repo: https://github.com/athanclark/purescript-thermite-dom.git
-        version: v0.3.1
-        dependencies:
-          - react
-          - react-dom
-          - thermite
-          - web-html
-      these:
-        repo: https://github.com/purescript-contrib/purescript-these.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - gen
-          - lists
-          - quickcheck
-          - quickcheck-laws
-          - tuples
-      transformers:
-        repo: https://github.com/purescript/purescript-transformers.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - distributive
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - identity
-          - lazy
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      tree-rose:
-        repo: https://github.com/jordanmartinez/purescript-tree-rose.git
-        version: v4.0.2
-        dependencies:
-          - control
-          - foldable-traversable
-          - free
-          - lists
-          - maybe
-          - prelude
-          - tailrec
-      tuples:
-        repo: https://github.com/purescript/purescript-tuples.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - invariant
-          - prelude
-      two-or-more:
-        repo: https://github.com/i-am-the-slime/purescript-two-or-more.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - foldable-traversable
-          - maybe
-          - partial
-          - prelude
-          - psci-support
-          - tuples
-      type-equality:
-        repo: https://github.com/purescript/purescript-type-equality.git
-        version: v4.0.1
-        dependencies: []
-      typelevel:
-        repo: https://github.com/bodil/purescript-typelevel.git
-        version: v6.0.0
-        dependencies:
-          - partial
-          - prelude
-          - tuples
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-lists:
-        repo: https://github.com/PureFunctor/purescript-typelevel-lists.git
-        version: v2.1.0
-        dependencies:
-          - prelude
-          - tuples
-          - typelevel-peano
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-peano:
-        repo: https://github.com/csicar/purescript-typelevel-peano.git
-        version: v1.0.1
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - prelude
-          - psci-support
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-prelude:
-        repo: https://github.com/purescript/purescript-typelevel-prelude.git
-        version: v7.0.0
-        dependencies:
-          - prelude
-          - type-equality
-      typelevel-rows:
-        repo: https://github.com/jordanmartinez/purescript-typelevel-rows.git
-        version: v0.1.0
-        dependencies:
-          - prelude
-      uint:
-        repo: https://github.com/purescript-contrib/purescript-uint.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - enums
-          - gen
-          - maybe
-          - numbers
-          - prelude
-      uncurried-transformers:
-        repo: https://github.com/PureFunctor/purescript-uncurried-transformers.git
-        version: v1.1.0
-        dependencies:
-          - control
-          - effect
-          - either
-          - functions
-          - identity
-          - prelude
-          - safe-coerce
-          - tailrec
-          - transformers
-          - tuples
-      undefined-is-not-a-problem:
-        repo: https://github.com/paluh/purescript-undefined-is-not-a-problem.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - assert
-          - effect
-          - either
-          - foreign
-          - maybe
-          - newtype
-          - prelude
-          - random
-          - tuples
-          - type-equality
-          - unsafe-coerce
-      unfoldable:
-        repo: https://github.com/purescript/purescript-unfoldable.git
-        version: v6.0.0
-        dependencies:
-          - foldable-traversable
-          - maybe
-          - partial
-          - prelude
-          - tuples
-      unicode:
-        repo: https://github.com/purescript-contrib/purescript-unicode.git
-        version: v6.0.0
-        dependencies:
-          - foldable-traversable
-          - maybe
-          - strings
-      unlift:
-        repo: https://github.com/tweag/purescript-unlift.git
-        version: v1.0.1
-        dependencies:
-          - aff
-          - effect
-          - either
-          - freet
-          - identity
-          - lists
-          - maybe
-          - monad-control
-          - prelude
-          - st
-          - transformers
-          - tuples
-      unsafe-coerce:
-        repo: https://github.com/purescript/purescript-unsafe-coerce.git
-        version: v6.0.0
-        dependencies: []
-      unsafe-reference:
-        repo: https://github.com/purescript-contrib/purescript-unsafe-reference.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-      uri:
-        repo: https://github.com/purescript-contrib/purescript-uri.git
-        version: v9.0.0
-        dependencies:
-          - arrays
-          - integers
-          - js-uri
-          - numbers
-          - parsing
-          - prelude
-          - profunctor-lenses
-          - these
-          - transformers
-          - unfoldable
-      validation:
-        repo: https://github.com/purescript/purescript-validation.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - newtype
-          - prelude
-      variant:
-        repo: https://github.com/natefaubion/purescript-variant.git
-        version: v8.0.0
-        dependencies:
-          - enums
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - record
-          - tuples
-          - unsafe-coerce
-      vectorfield:
-        repo: https://github.com/csicar/purescript-vectorfield.git
-        version: v1.0.1
-        dependencies:
-          - console
-          - effect
-          - group
-          - prelude
-          - psci-support
-      versions:
-        repo: https://github.com/hdgarrood/purescript-versions.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - either
-          - foldable-traversable
-          - functions
-          - integers
-          - lists
-          - maybe
-          - orders
-          - parsing
-          - partial
-          - strings
-      web-clipboard:
-        repo: https://github.com/purescript-web/purescript-web-clipboard.git
-        version: v4.0.0
-        dependencies:
-          - web-html
-      web-cssom:
-        repo: https://github.com/purescript-web/purescript-web-cssom.git
-        version: v2.0.0
-        dependencies:
-          - web-dom
-          - web-html
-          - web-uievents
-      web-dom:
-        repo: https://github.com/purescript-web/purescript-web-dom.git
-        version: v6.0.0
-        dependencies:
-          - web-events
-      web-dom-parser:
-        repo: https://github.com/purescript-web/purescript-web-dom-parser.git
-        version: v8.0.0
-        dependencies:
-          - effect
-          - partial
-          - prelude
-          - web-dom
-      web-dom-xpath:
-        repo: https://github.com/purescript-web/purescript-web-dom-xpath.git
-        version: v3.0.0
-        dependencies:
-          - web-dom
-      web-encoding:
-        repo: https://github.com/purescript-web/purescript-web-encoding.git
-        version: v3.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - newtype
-          - prelude
-      web-events:
-        repo: https://github.com/purescript-web/purescript-web-events.git
-        version: v4.0.0
-        dependencies:
-          - datetime
-          - enums
-          - foreign
-          - nullable
-      web-fetch:
-        repo: https://github.com/purescript-web/purescript-web-fetch.git
-        version: v3.0.0
-        dependencies:
-          - effect
-          - foreign-object
-          - http-methods
-          - prelude
-          - record
-          - typelevel-prelude
-          - web-file
-          - web-promise
-          - web-streams
-      web-file:
-        repo: https://github.com/purescript-web/purescript-web-file.git
-        version: v4.0.0
-        dependencies:
-          - foreign
-          - media-types
-          - web-dom
-      web-html:
-        repo: https://github.com/purescript-web/purescript-web-html.git
-        version: v4.0.0
-        dependencies:
-          - js-date
-          - web-dom
-          - web-file
-          - web-storage
-      web-page-visibility:
-        repo: https://git.sr.ht/~toastal/purescript-web-page-visibility
-        version: v2.0.0
-        dependencies:
-          - effect
-          - enums
-          - exceptions
-          - maybe
-          - prelude
-          - strings
-          - web-events
-          - web-html
-      web-pointerevents:
-        repo: https://github.com/purescript-web/purescript-web-pointerevents.git
-        version: v1.0.0
-        dependencies:
-          - effect
-          - maybe
-          - prelude
-          - web-dom
-          - web-uievents
-      web-promise:
-        repo: https://github.com/purescript-web/purescript-web-promise.git
-        version: v3.0.0
-        dependencies:
-          - effect
-          - exceptions
-          - foldable-traversable
-          - functions
-          - maybe
-          - prelude
-      web-socket:
-        repo: https://github.com/purescript-web/purescript-web-socket.git
-        version: v4.0.0
-        dependencies:
-          - arraybuffer-types
-          - web-file
-      web-storage:
-        repo: https://github.com/purescript-web/purescript-web-storage.git
-        version: v5.0.0
-        dependencies:
-          - nullable
-          - web-events
-      web-streams:
-        repo: https://github.com/purescript-web/purescript-web-streams.git
-        version: v3.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - exceptions
-          - nullable
-          - prelude
-          - tuples
-          - web-promise
-      web-touchevents:
-        repo: https://github.com/purescript-web/purescript-web-touchevents.git
-        version: v4.0.0
-        dependencies:
-          - web-uievents
-      web-uievents:
-        repo: https://github.com/purescript-web/purescript-web-uievents.git
-        version: v4.0.0
-        dependencies:
-          - web-html
-      web-workers:
-        repo: https://github.com/gbagan/purescript-web-workers.git
-        version: v1.1.0
-        dependencies:
-          - effect
-          - foreign
-          - maybe
-          - prelude
-          - unsafe-coerce
-          - web-events
-      web-xhr:
-        repo: https://github.com/purescript-web/purescript-web-xhr.git
-        version: v5.0.0
-        dependencies:
-          - arraybuffer-types
-          - datetime
-          - http-methods
-          - web-dom
-          - web-file
-          - web-html
-      yoga-fetch:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-fetch.git
-        version: v1.0.1
-        dependencies:
-          - aff
-          - aff-promise
-          - arraybuffer-types
-          - effect
-          - foreign
-          - foreign-object
-          - newtype
-          - prelude
-          - typelevel-prelude
-          - unsafe-coerce
-      yoga-json:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-json.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - identity
-          - lists
-          - maybe
-          - nullable
-          - partial
-          - prelude
-          - record
-          - transformers
-          - typelevel-prelude
-          - variant
-      yoga-postgres:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-postgres.git
-        version: v6.0.0
-        dependencies:
-          - aff
-          - arrays
-          - datetime
-          - effect
-          - either
-          - enums
-          - foldable-traversable
-          - foreign
-          - integers
-          - maybe
-          - nullable
-          - prelude
-          - transformers
-          - unsafe-coerce
+      abc-parser: 2.0.0
+      ace: 9.0.0
+      aff: 7.1.0
+      aff-bus: 6.0.0
+      aff-coroutines: 9.0.0
+      aff-promise: 4.0.0
+      aff-retry: 2.0.0
+      affjax: 13.0.0
+      affjax-node: 1.0.0
+      affjax-web: 1.0.0
+      ansi: 7.0.0
+      argonaut: 9.0.0
+      argonaut-aeson-generic: 0.4.1
+      argonaut-codecs: 9.1.0
+      argonaut-core: 7.0.0
+      argonaut-generic: 8.0.0
+      argonaut-traversals: 10.0.0
+      argparse-basic: 2.0.0
+      array-builder: 0.1.2
+      arraybuffer: 13.1.1
+      arraybuffer-builder: 3.1.0
+      arraybuffer-types: 3.0.2
+      arrays: 7.1.0
+      arrays-zipper: 2.0.1
+      ask: 1.0.0
+      assert: 6.0.0
+      avar: 5.0.0
+      b64: 0.0.8
+      barbies: 1.0.1
+      barlow-lens: 0.9.0
+      basic-auth: 3.0.1
+      bifunctors: 6.0.0
+      bigints: 7.0.1
+      bolson: 0.3.1
+      bower-json: 3.0.0
+      bucketchain: 1.0.1
+      bucketchain-basic-auth: 1.0.1
+      bucketchain-conditional: 1.0.1
+      bucketchain-cors: 1.0.1
+      bucketchain-csrf: 1.0.1
+      bucketchain-header-utils: 1.0.1
+      bucketchain-health: 1.0.1
+      bucketchain-history-api-fallback: 1.0.1
+      bucketchain-logger: 1.0.1
+      bucketchain-secure: 1.0.1
+      bucketchain-simple-api: 5.0.1
+      bucketchain-sslify: 1.0.1
+      bucketchain-static: 1.0.1
+      call-by-name: 4.0.1
+      canvas: 6.0.0
+      canvas-action: 9.0.0
+      cartesian: 1.0.6
+      catenable-lists: 7.0.0
+      channel: 1.0.0
+      checked-exceptions: 3.1.1
+      classless: 0.1.1
+      classless-arbitrary: 0.1.1
+      classless-decode-json: 0.1.1
+      classless-encode-json: 0.1.3
+      classnames: 2.0.0
+      codec: 6.0.0
+      codec-argonaut: 10.0.0
+      colors: 7.0.1
+      concur-core: 0.5.0
+      concur-react: 0.5.0
+      concurrent-queues: 3.0.0
+      console: 6.0.0
+      const: 6.0.0
+      contravariant: 6.0.0
+      control: 6.0.0
+      convertable-options: 1.0.0
+      coroutines: 7.0.0
+      crypto: 5.0.1
+      css: 6.0.0
+      datetime: 6.1.0
+      datetime-parsing: 0.2.0
+      debug: 6.0.2
+      decimals: 7.1.0
+      default-values: 1.0.1
+      deku: 0.9.9
+      deno: 0.0.5
+      dissect: 1.0.0
+      distributive: 6.0.0
+      dodo-printer: 2.2.1
+      dom-filereader: 7.0.0
+      dom-indexed: 11.0.0
+      dotenv: 3.0.0
+      droplet: 0.5.0
+      dynamic-buffer: 3.0.1
+      echarts-simple: 0.0.1
+      effect: 4.0.0
+      either: 6.1.0
+      elmish: 0.8.3
+      elmish-enzyme: 0.1.1
+      elmish-hooks: 0.9.1
+      elmish-html: 0.7.2
+      elmish-testing-library: 0.3.1
+      email-validate: 7.0.0
+      encoding: 0.0.8
+      enums: 6.0.1
+      error: 2.0.0
+      exceptions: 6.0.0
+      exists: 6.0.0
+      exitcodes: 4.0.0
+      expect-inferred: 3.0.0
+      fahrtwind: 2.0.0
+      fallback: 0.1.0
+      fast-vect: 1.1.0
+      fetch: 1.1.4
+      fetch-argonaut: 1.0.0
+      fetch-core: 4.0.4
+      fetch-yoga-json: 1.1.0
+      filterable: 5.0.0
+      fixed-points: 7.0.0
+      fixed-precision: 5.0.0
+      flame: 1.2.0
+      float32: 2.0.0
+      foldable-traversable: 6.0.0
+      foreign: 7.0.0
+      foreign-object: 4.1.0
+      foreign-readwrite: 3.4.0
+      fork: 6.0.0
+      form-urlencoded: 7.0.0
+      formatters: 7.0.0
+      framer-motion: 1.0.1
+      free: 7.0.0
+      freeap: 7.0.0
+      freer-free: 0.0.1
+      freet: 7.0.0
+      functions: 6.0.0
+      functor1: 3.0.0
+      functors: 5.0.0
+      fuzzy: 0.4.0
+      gen: 4.0.0
+      generate-values: 1.0.1
+      generic-router: 0.0.1
+      geometry-plane: 1.0.3
+      github-actions-toolkit: 0.5.0
+      grain: 3.0.0
+      grain-router: 3.0.0
+      grain-virtualized: 3.0.0
+      graphql-client: 9.3.2
+      graphs: 8.1.0
+      group: 4.1.1
+      halogen: 7.0.0
+      halogen-bootstrap5: 2.1.0
+      halogen-css: 10.0.0
+      halogen-echarts-simple: 0.0.4
+      halogen-formless: 4.0.2
+      halogen-hooks: 0.6.3
+      halogen-hooks-extra: 0.9.0
+      halogen-store: 0.5.4
+      halogen-storybook: 2.0.0
+      halogen-subscriptions: 2.0.0
+      halogen-svg-elems: 7.0.0
+      halogen-vdom: 8.0.0
+      halogen-vdom-string-renderer: 0.5.0
+      heckin: 2.0.1
+      heterogeneous: 0.6.0
+      homogeneous: 0.4.0
+      http-methods: 6.0.0
+      httpure: 0.16.0
+      httpurple: 3.0.1
+      httpurple-argonaut: 1.0.1
+      httpurple-yoga-json: 1.0.0
+      humdrum: 0.0.1
+      hyrule: 2.3.5
+      identity: 6.0.0
+      identy: 4.0.1
+      indexed-monad: 2.1.0
+      int64: 3.0.0
+      integers: 6.0.0
+      interpolate: 5.0.2
+      invariant: 6.0.0
+      jarilo: 1.0.1
+      jelly: 0.9.1
+      jelly-hooks: 0.3.1
+      jelly-router: 0.2.2
+      jelly-signal: 0.3.0
+      jest: 1.0.0
+      js-bigints: 1.2.0
+      js-date: 8.0.0
+      js-fileio: 3.0.0
+      js-promise: 1.0.0
+      js-promise-aff: 1.0.0
+      js-timers: 6.1.0
+      js-uri: 3.1.0
+      justifill: 0.5.0
+      jwt: 0.0.9
+      language-cst-parser: 0.12.1
+      lazy: 6.0.0
+      lazy-joe: 1.0.0
+      lcg: 4.0.0
+      leibniz: 5.0.0
+      linalg: 5.1.0
+      lists: 7.0.0
+      literals: 1.0.2
+      logging: 3.0.0
+      logging-journald: 0.4.0
+      machines: 7.0.0
+      marionette: 1.0.0
+      marionette-commander: 0.1.1
+      marionette-react-basic-hooks: 0.1.1
+      matrices: 5.0.1
+      matryoshka: 1.0.0
+      maybe: 6.0.0
+      mdast-util-from-markdown: 0.2.1
+      media-types: 6.0.0
+      midi: 4.0.0
+      milkis: 9.0.0
+      minibench: 4.0.1
+      mmorph: 7.0.0
+      monad-control: 5.0.0
+      monad-logger: 1.3.1
+      monad-loops: 0.5.0
+      monad-unlift: 1.0.1
+      monoid-extras: 0.0.1
+      monoidal: 0.16.0
+      morello: 0.4.0
+      mote: 3.0.0
+      motsunabe: 2.0.0
+      mysql: 6.0.1
+      n3: 0.1.0
+      nano-id: 1.1.0
+      naturals: 3.0.0
+      nested-functor: 0.2.1
+      newtype: 5.0.0
+      nextui: 0.1.0
+      node-buffer: 8.0.0
+      node-buffer-blob: 1.0.0
+      node-child-process: 9.0.0
+      node-fs: 8.1.1
+      node-fs-aff: 9.1.0
+      node-http: 8.0.0
+      node-net: 4.0.0
+      node-path: 5.0.0
+      node-process: 10.0.0
+      node-readline: 7.0.0
+      node-sqlite3: 8.0.0
+      node-streams: 7.0.0
+      node-streams-aff: 4.0.1
+      node-url: 6.0.0
+      nodemailer: 4.0.1
+      nonempty: 7.0.0
+      now: 6.0.0
+      npm-package-json: 2.0.0
+      nullable: 6.0.0
+      numbers: 9.0.0
+      object-maps: 0.1.1
+      ocarina: 1.5.2
+      open-folds: 6.3.0
+      open-memoize: 6.1.0
+      open-pairing: 6.1.0
+      options: 7.0.0
+      optparse: 5.0.0
+      ordered-collections: 3.0.0
+      ordered-set: 0.4.0
+      orders: 6.0.0
+      pairs: 9.0.0
+      parallel: 6.0.0
+      parsing: 10.2.0
+      parsing-dataview: 3.2.4
+      partial: 4.0.0
+      pathy: 9.0.0
+      pha: 0.9.0
+      phaser: 0.6.0
+      pipes: 8.0.0
+      pirates-charm: 0.0.1
+      point-free: 1.0.0
+      pointed-list: 0.5.1
+      polymorphic-vectors: 4.0.0
+      posix-types: 6.0.0
+      precise: 6.0.0
+      precise-datetime: 7.0.0
+      prelude: 6.0.1
+      prettier-printer: 3.0.0
+      profunctor: 6.0.0
+      profunctor-lenses: 8.0.0
+      protobuf: 4.2.0
+      ps-cst: 1.2.0
+      psa-utils: 8.0.0
+      psc-ide: 19.0.0
+      psci-support: 6.0.0
+      qualified-do: 2.2.0
+      quantities: 12.1.0
+      quickcheck: 8.0.1
+      quickcheck-combinators: 0.1.3
+      quickcheck-laws: 7.0.0
+      quickcheck-utf8: 0.0.0
+      random: 6.0.0
+      rationals: 5.0.1
+      rdf: 0.1.0
+      react: 10.0.1
+      react-aria: 0.2.0
+      react-basic: 17.0.0
+      react-basic-classic: 3.0.0
+      react-basic-dnd: 10.1.0
+      react-basic-dom: 6.0.0
+      react-basic-emotion: 7.1.0
+      react-basic-hooks: 8.1.2
+      react-basic-storybook: 2.0.0
+      react-dom: 8.0.0
+      react-halo: 3.0.0
+      react-icons: 1.0.8
+      react-testing-library: 4.0.1
+      react-virtuoso: 1.0.0
+      read: 1.0.1
+      record: 4.0.0
+      record-extra: 5.0.1
+      record-studio: 1.0.4
+      refs: 6.0.0
+      remotedata: 5.0.0
+      resource: 2.0.1
+      resourcet: 1.0.0
+      result: 1.0.3
+      return: 0.2.0
+      ring-modules: 5.0.1
+      rito: 0.3.2
+      routing: 11.0.0
+      routing-duplex: 0.7.0
+      run: 5.0.0
+      safe-coerce: 2.0.0
+      safely: 4.0.1
+      school-of-music: 1.3.0
+      selection-foldable: 0.2.0
+      semirings: 7.0.0
+      signal: 13.0.0
+      simple-emitter: 3.0.1
+      simple-i18n: 2.0.1
+      simple-json: 9.0.0
+      simple-jwt: 4.0.1
+      simple-ulid: 3.0.0
+      sized-matrices: 1.0.0
+      sized-vectors: 5.0.2
+      slug: 3.0.8
+      small-ffi: 4.0.1
+      soundfonts: 4.1.0
+      sparse-matrices: 1.2.1
+      sparse-polynomials: 1.0.5
+      spec: 7.2.0
+      spec-discovery: 8.0.1
+      spec-quickcheck: 5.0.0
+      splitmix: 2.1.0
+      ssrs: 1.0.0
+      st: 6.2.0
+      strictlypositiveint: 1.0.1
+      string-parsers: 8.0.0
+      strings: 6.0.1
+      strings-extra: 4.0.0
+      stringutils: 0.0.12
+      substitute: 0.2.3
+      sunde: 3.0.0
+      supply: 0.2.0
+      svg-parser: 3.0.0
+      systemd-journald: 0.3.0
+      tagged: 4.0.2
+      tailrec: 6.1.0
+      tecton: 0.1.6
+      tecton-halogen: 0.1.3
+      test-unit: 17.0.0
+      thermite: 6.3.1
+      thermite-dom: 0.3.1
+      these: 6.0.0
+      toppokki: 4.0.0
+      transformers: 6.0.0
+      tree-rose: 4.0.2
+      tuples: 7.0.0
+      two-or-more: 1.0.0
+      type-equality: 4.0.1
+      typelevel: 6.0.0
+      typelevel-lists: 2.1.0
+      typelevel-peano: 1.0.1
+      typelevel-prelude: 7.0.0
+      typelevel-rows: 0.1.0
+      uint: 7.0.0
+      ulid: 3.0.1
+      uncurried-transformers: 1.1.0
+      undefined: 2.0.0
+      undefined-is-not-a-problem: 1.1.0
+      unfoldable: 6.0.0
+      unicode: 6.0.0
+      unlift: 1.0.1
+      unordered-collections: 3.0.1
+      unsafe-coerce: 6.0.0
+      unsafe-reference: 5.0.0
+      untagged-to-tagged: 0.1.4
+      untagged-union: 1.0.0
+      uri: 9.0.0
+      uuid: 9.0.0
+      uuidv4: 1.0.0
+      validation: 6.0.0
+      variant: 8.0.0
+      vectorfield: 1.0.1
+      vectors: 2.1.0
+      versions: 7.0.0
+      visx: 0.0.2
+      web-clipboard: 5.0.0
+      web-cssom: 2.0.0
+      web-dom: 6.0.0
+      web-dom-parser: 8.0.0
+      web-dom-xpath: 3.0.0
+      web-encoding: 3.0.0
+      web-events: 4.0.0
+      web-fetch: 3.0.0
+      web-file: 4.0.0
+      web-html: 4.1.0
+      web-pointerevents: 1.0.0
+      web-proletarian: 1.0.0
+      web-promise: 3.1.0
+      web-resize-observer: 2.0.0
+      web-router: 1.0.0
+      web-socket: 4.0.0
+      web-storage: 5.0.0
+      web-streams: 3.0.0
+      web-touchevents: 4.0.0
+      web-uievents: 4.0.0
+      web-url: 2.0.0
+      web-workers: 1.1.0
+      web-xhr: 5.0.0
+      which: 2.0.0
+      yoga-fetch: 1.0.1
+      yoga-json: 4.0.1
+      yoga-om: 0.1.0
+      yoga-postgres: 6.0.0
+      yoga-tree: 1.0.0
   extra_packages: {}
 packages:
   aff:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-aff.git
-    rev: 2d44d9f9d0d6a416a4103fba2fb39e5160f80e36
+    type: registry
+    version: 7.1.0
+    integrity: sha256-7hOC6uQO9XBAI5FD8F33ChLjFAiZVfd4BJMqlMh7TNU=
     dependencies:
+      - arrays
+      - bifunctors
+      - control
       - datetime
       - effect
+      - either
       - exceptions
+      - foldable-traversable
       - functions
+      - maybe
+      - newtype
       - parallel
+      - prelude
+      - refs
+      - tailrec
       - transformers
       - unsafe-coerce
   arrays:
-    type: git
-    url: https://github.com/purescript/purescript-arrays.git
-    rev: d20bae2f76db6cf29b7b75e26e82b8a54c32295e
+    type: registry
+    version: 7.1.0
+    integrity: sha256-Rvb3AVLal0ZLpmpABgOPIUeYHa4M+c5GwcUP5rQ2trA=
     dependencies:
       - bifunctors
       - control
@@ -3528,15 +538,16 @@ packages:
       - nonempty
       - partial
       - prelude
+      - safe-coerce
       - st
       - tailrec
       - tuples
       - unfoldable
       - unsafe-coerce
   avar:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-avar.git
-    rev: d00f5784d9cc8f079babd62740f5c52b87e5caa5
+    type: registry
+    version: 5.0.0
+    integrity: sha256-e7hf0x4hEpcygXP0LtvfvAQ49Bbj2aWtZT3gqM///0A=
     dependencies:
       - aff
       - effect
@@ -3545,9 +556,9 @@ packages:
       - functions
       - maybe
   bifunctors:
-    type: git
-    url: https://github.com/purescript/purescript-bifunctors.git
-    rev: 16ba2fb6dd7f05528ebd9e2f9ca3a068b325e5b3
+    type: registry
+    version: 6.0.0
+    integrity: sha256-/gZwC9YhNxZNQpnHa5BIYerCGM2jeX9ukZiEvYxm5Nw=
     dependencies:
       - const
       - either
@@ -3555,9 +566,9 @@ packages:
       - prelude
       - tuples
   catenable-lists:
-    type: git
-    url: https://github.com/purescript/purescript-catenable-lists.git
-    rev: 09abe1f4888bc00841ad2b59e56a9e7ce7ebd4ab
+    type: registry
+    version: 7.0.0
+    integrity: sha256-76vYENhwF4BWTBsjeLuErCH2jqVT4M3R1HX+4RwSftA=
     dependencies:
       - control
       - foldable-traversable
@@ -3567,24 +578,24 @@ packages:
       - tuples
       - unfoldable
   console:
-    type: git
-    url: https://github.com/purescript/purescript-console.git
-    rev: 3b83d7b792d03872afeea5e62b4f686ab0f09842
+    type: registry
+    version: 6.0.0
+    integrity: sha256-gJpJ53fCDAL8BiCiJXH0HNAJ9K3gJtLo8GDaCK6hA5U=
     dependencies:
       - effect
       - prelude
   const:
-    type: git
-    url: https://github.com/purescript/purescript-const.git
-    rev: ab9570cf2b6e67f7e441178211db1231cfd75c37
+    type: registry
+    version: 6.0.0
+    integrity: sha256-tNrxDW8D8H4jdHE2HiPzpLy08zkzJMmGHdRqt5BQuTc=
     dependencies:
       - invariant
       - newtype
       - prelude
   contravariant:
-    type: git
-    url: https://github.com/purescript/purescript-contravariant.git
-    rev: 9ad3e105b8855bcc25f4e0893c784789d05a58de
+    type: registry
+    version: 6.0.0
+    integrity: sha256-TP+ooAp3vvmdjfQsQJSichF5B4BPDHp3wAJoWchip6c=
     dependencies:
       - const
       - either
@@ -3592,16 +603,16 @@ packages:
       - prelude
       - tuples
   control:
-    type: git
-    url: https://github.com/purescript/purescript-control.git
-    rev: a6033808790879a17b2729e73747a9ed3fb2264e
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sH7Pg9E96JCPF9PIA6oQ8+BjTyO/BH1ZuE/bOcyj4Jk=
     dependencies:
       - newtype
       - prelude
   datetime:
-    type: git
-    url: https://github.com/purescript/purescript-datetime.git
-    rev: a6a0cf1b0324964ad1854bc3377ed8766ba90e6f
+    type: registry
+    version: 6.1.0
+    integrity: sha256-g/5X5BBegQWLpI9IWD+sY6mcaYpzzlW5lz5NBzaMtyI=
     dependencies:
       - bifunctors
       - control
@@ -3620,9 +631,9 @@ packages:
       - prelude
       - tuples
   distributive:
-    type: git
-    url: https://github.com/purescript/purescript-distributive.git
-    rev: 6005e513642e855ebf6f884d24a35c2803ca252a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-HTDdmEnzigMl+02SJB88j+gAXDx9VKsbvR4MJGDPbOQ=
     dependencies:
       - identity
       - newtype
@@ -3630,24 +641,24 @@ packages:
       - tuples
       - type-equality
   effect:
-    type: git
-    url: https://github.com/purescript/purescript-effect.git
-    rev: a192ddb923027d426d6ea3d8deb030c9aa7c7dda
+    type: registry
+    version: 4.0.0
+    integrity: sha256-eBtZu+HZcMa5HilvI6kaDyVX3ji8p0W9MGKy2K4T6+M=
     dependencies:
       - prelude
   either:
-    type: git
-    url: https://github.com/purescript/purescript-either.git
-    rev: af655a04ed2fd694b6688af39ee20d7907ad0763
+    type: registry
+    version: 6.1.0
+    integrity: sha256-6hgTPisnMWVwQivOu2PKYcH8uqjEOOqDyaDQVUchTpY=
     dependencies:
       - control
       - invariant
       - maybe
       - prelude
   enums:
-    type: git
-    url: https://github.com/purescript/purescript-enums.git
-    rev: bae47961d401f9acf88da38f32e87403e5f0cf2f
+    type: registry
+    version: 6.0.1
+    integrity: sha256-HWaD73JFLorc4A6trKIRUeDMdzE+GpkJaEOM1nTNkC8=
     dependencies:
       - control
       - either
@@ -3660,24 +671,24 @@ packages:
       - tuples
       - unfoldable
   exceptions:
-    type: git
-    url: https://github.com/purescript/purescript-exceptions.git
-    rev: afab3c07c820bb49b6c5be50049db46a964a6161
+    type: registry
+    version: 6.0.0
+    integrity: sha256-y/xTAEIZIARCE+50/u1di0ncebJ+CIwNOLswyOWzMTw=
     dependencies:
       - effect
       - either
       - maybe
       - prelude
   exists:
-    type: git
-    url: https://github.com/purescript/purescript-exists.git
-    rev: f765b4ace7869c27b9c05949e18c843881f9173b
+    type: registry
+    version: 6.0.0
+    integrity: sha256-A0JQHpTfo1dNOj9U5/Fd3xndlRSE0g2IQWOGor2yXn8=
     dependencies:
       - unsafe-coerce
   foldable-traversable:
-    type: git
-    url: https://github.com/purescript/purescript-foldable-traversable.git
-    rev: b3926f870532d287ea59e2d5cd3873b81ef2a93a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-fLeqRYM4jUrZD5H4WqcwUgzU7XfYkzO4zhgtNc3jcWM=
     dependencies:
       - bifunctors
       - const
@@ -3691,9 +702,9 @@ packages:
       - prelude
       - tuples
   free:
-    type: git
-    url: https://github.com/purescript/purescript-free.git
-    rev: e2d8fa8023a864363857834e11393483bced5e38
+    type: registry
+    version: 7.0.0
+    integrity: sha256-72auTIZAG6fhz4F94rxyDwgfnHwp+/89rujZpZWrV0w=
     dependencies:
       - catenable-lists
       - control
@@ -3710,15 +721,15 @@ packages:
       - tuples
       - unsafe-coerce
   functions:
-    type: git
-    url: https://github.com/purescript/purescript-functions.git
-    rev: f626f20580483977c5b27a01aac6471e28aff367
+    type: registry
+    version: 6.0.0
+    integrity: sha256-adMyJNEnhGde2unHHAP79gPtlNjNqzgLB8arEOn9hLI=
     dependencies:
       - prelude
   functors:
-    type: git
-    url: https://github.com/purescript/purescript-functors.git
-    rev: 022ffd7a2a7ec12080314f3d217b400674a247b4
+    type: registry
+    version: 5.0.0
+    integrity: sha256-zfPWWYisbD84MqwpJSZFlvM6v86McM68ob8p9s27ywU=
     dependencies:
       - bifunctors
       - const
@@ -3734,9 +745,9 @@ packages:
       - tuples
       - unsafe-coerce
   gen:
-    type: git
-    url: https://github.com/purescript/purescript-gen.git
-    rev: 9fbcc2a1261c32e30d79c5418edef4d96fe76931
+    type: registry
+    version: 4.0.0
+    integrity: sha256-f7yzAXWwr+xnaqEOcvyO3ezKdoes8+WXWdXIHDBCAPI=
     dependencies:
       - either
       - foldable-traversable
@@ -3749,48 +760,48 @@ packages:
       - tuples
       - unfoldable
   identity:
-    type: git
-    url: https://github.com/purescript/purescript-identity.git
-    rev: ef6768f8a52ab0bc943a85f5761ba07c257f639f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-4wY0XZbAksjY6UAg99WkuKyJlQlWAfTi2ssadH0wVMY=
     dependencies:
       - control
       - invariant
       - newtype
       - prelude
   integers:
-    type: git
-    url: https://github.com/purescript/purescript-integers.git
-    rev: 54d712b25c594833083d15dc9ff2418eb9c52822
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sf+sK26R1hzwl3NhXR7WAu9zCDjQnfoXwcyGoseX158=
     dependencies:
       - maybe
       - numbers
       - prelude
   invariant:
-    type: git
-    url: https://github.com/purescript/purescript-invariant.git
-    rev: 1d2a196d51e90623adb88496c2cfd759c6736894
+    type: registry
+    version: 6.0.0
+    integrity: sha256-RGWWyYrz0Hs1KjPDA+87Kia67ZFBhfJ5lMGOMCEFoLo=
     dependencies:
       - control
       - prelude
   js-timers:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-js-timers.git
-    rev: 7cb728b3e6dc29f355143617e6e9ac770ecd9273
+    type: registry
+    version: 6.1.0
+    integrity: sha256-znHWLSSOYw15P5DTcsAdal2lf7nGA2yayLdOZ2t5r7o=
     dependencies:
       - effect
   lazy:
-    type: git
-    url: https://github.com/purescript/purescript-lazy.git
-    rev: 48347841226b27af5205a1a8ec71e27a93ce86fd
+    type: registry
+    version: 6.0.0
+    integrity: sha256-lMsfFOnlqfe4KzRRiW8ot5ge6HtcU3Eyh2XkXcP5IgU=
     dependencies:
       - control
       - foldable-traversable
       - invariant
       - prelude
   lcg:
-    type: git
-    url: https://github.com/purescript/purescript-lcg.git
-    rev: 67c6c6483a563a59ae036d9dca0f1be2835326a5
+    type: registry
+    version: 4.0.0
+    integrity: sha256-h7ME5cthLfbgJOJdsZcSfFpwXsx4rf8YmhebU+3iSYg=
     dependencies:
       - effect
       - integers
@@ -3799,9 +810,9 @@ packages:
       - prelude
       - random
   lists:
-    type: git
-    url: https://github.com/purescript/purescript-lists.git
-    rev: b113451e5b41cad87d669a3165f955c71cd863e2
+    type: registry
+    version: 7.0.0
+    integrity: sha256-EKF15qYqucuXP2lT/xPxhqy58f0FFT6KHdIB/yBOayI=
     dependencies:
       - bifunctors
       - control
@@ -3816,25 +827,25 @@ packages:
       - tuples
       - unfoldable
   maybe:
-    type: git
-    url: https://github.com/purescript/purescript-maybe.git
-    rev: c6f98ac1088766287106c5d9c8e30e7648d36786
+    type: registry
+    version: 6.0.0
+    integrity: sha256-5cCIb0wPwbat2PRkQhUeZO0jcAmf8jCt2qE0wbC3v2Q=
     dependencies:
       - control
       - invariant
       - newtype
       - prelude
   newtype:
-    type: git
-    url: https://github.com/purescript/purescript-newtype.git
-    rev: 29d8e6dd77aec2c975c948364ec3faf26e14ee7b
+    type: registry
+    version: 5.0.0
+    integrity: sha256-gdrQu8oGe9eZE6L3wOI8ql/igOg+zEGB5ITh2g+uttw=
     dependencies:
       - prelude
       - safe-coerce
   nonempty:
-    type: git
-    url: https://github.com/purescript/purescript-nonempty.git
-    rev: 28150ecc7419238b187abd609a92a645273348bb
+    type: registry
+    version: 7.0.0
+    integrity: sha256-54ablJZUHGvvlTJzi3oXyPCuvY6zsrWJuH/dMJ/MFLs=
     dependencies:
       - control
       - foldable-traversable
@@ -3843,16 +854,16 @@ packages:
       - tuples
       - unfoldable
   numbers:
-    type: git
-    url: https://github.com/purescript/purescript-numbers.git
-    rev: 2a53528f18f9415334bae28e7bb3cf3be86342c2
+    type: registry
+    version: 9.0.0
+    integrity: sha256-fDKXExFxMRFgy+v+kbjVbGBIOOQkWGnmm0vtnE3zWRE=
     dependencies:
       - functions
       - maybe
   ordered-collections:
-    type: git
-    url: https://github.com/purescript/purescript-ordered-collections.git
-    rev: 9826b7632d0d0a691173bde308a634195f42a419
+    type: registry
+    version: 3.0.0
+    integrity: sha256-R9WddNBRPkY37gw8XkDCLX2vJ5eI9qdaWDdCp61r2+M=
     dependencies:
       - arrays
       - foldable-traversable
@@ -3866,16 +877,16 @@ packages:
       - tuples
       - unfoldable
   orders:
-    type: git
-    url: https://github.com/purescript/purescript-orders.git
-    rev: f86db621ec5eef1274145f8b1fd8ebbfe0ed4a2c
+    type: registry
+    version: 6.0.0
+    integrity: sha256-nBA0g3/ai0euH8q9pSbGqk53W2q6agm/dECZTHcoink=
     dependencies:
       - newtype
       - prelude
   parallel:
-    type: git
-    url: https://github.com/purescript/purescript-parallel.git
-    rev: 85290dca837771ac4870071008c933d315ef678f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-VJbkGD0rAKX+NUEeBJbYJ78bEKaZbgow+QwQEfPB6ko=
     dependencies:
       - control
       - effect
@@ -3889,19 +900,19 @@ packages:
       - refs
       - transformers
   partial:
-    type: git
-    url: https://github.com/purescript/purescript-partial.git
-    rev: 0fa0646f5ea1ec5f0c46dcbd770c705a6c9ad3ec
+    type: registry
+    version: 4.0.0
+    integrity: sha256-fwXerld6Xw1VkReh8yeQsdtLVrjfGiVuC5bA1Wyo/J4=
     dependencies: []
   prelude:
-    type: git
-    url: https://github.com/purescript/purescript-prelude.git
-    rev: 32787f4399c92459c41602131a5858559eb868c5
+    type: registry
+    version: 6.0.1
+    integrity: sha256-o8p6SLYmVPqzXZhQFd2hGAWEwBoXl1swxLG/scpJ0V0=
     dependencies: []
   profunctor:
-    type: git
-    url: https://github.com/purescript/purescript-profunctor.git
-    rev: 0a966a14e7b0c827d44657dc1710cdc712d2e034
+    type: registry
+    version: 6.0.0
+    integrity: sha256-99NzxFgTr4CGlCSRYG1kShL+JhYbihhHtbOk1/0R5zI=
     dependencies:
       - control
       - distributive
@@ -3912,9 +923,9 @@ packages:
       - prelude
       - tuples
   quickcheck:
-    type: git
-    url: https://github.com/purescript/purescript-quickcheck.git
-    rev: bf5029f97e6c0d7552d3a08d2ab793a19e2c5e3d
+    type: registry
+    version: 8.0.1
+    integrity: sha256-ZvpccKQCvgslTXZCNmpYW4bUsFzhZd/kQUr2WmxFTGY=
     dependencies:
       - arrays
       - console
@@ -3944,46 +955,46 @@ packages:
       - tuples
       - unfoldable
   random:
-    type: git
-    url: https://github.com/purescript/purescript-random.git
-    rev: 9540bc965a9596da02fefd9949418bb19c92533a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-CJ611a35MPCE7XQMp0rdC6MCn76znlhisiCRgboAG+Q=
     dependencies:
       - effect
       - integers
   record:
-    type: git
-    url: https://github.com/purescript/purescript-record.git
-    rev: c89cd1ada6b636692571fc374196b1c39c4c9f70
+    type: registry
+    version: 4.0.0
+    integrity: sha256-Za5U85bTRJEfGK5Sk4hM41oXy84YQI0I8TL3WUn1Qzg=
     dependencies:
       - functions
       - prelude
       - unsafe-coerce
   refs:
-    type: git
-    url: https://github.com/purescript/purescript-refs.git
-    rev: f8e6216da4cb9309fde1f20cd6f69ac3a3b7f9e8
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Vgwne7jIbD3ZMoLNNETLT8Litw6lIYo3MfYNdtYWj9s=
     dependencies:
       - effect
       - prelude
   safe-coerce:
-    type: git
-    url: https://github.com/purescript/purescript-safe-coerce.git
-    rev: 7fa799ae80a38b8d948efcb52608e58e198b3da7
+    type: registry
+    version: 2.0.0
+    integrity: sha256-a1ibQkiUcbODbLE/WAq7Ttbbh9ex+x33VCQ7GngKudU=
     dependencies:
       - unsafe-coerce
   st:
-    type: git
-    url: https://github.com/purescript/purescript-st.git
-    rev: 2cc7ae1c3318a303378c4a9f3fa0f10ee7cc3589
+    type: registry
+    version: 6.2.0
+    integrity: sha256-z9X0WsOUlPwNx9GlCC+YccCyz8MejC8Wb0C4+9fiBRY=
     dependencies:
       - partial
       - prelude
       - tailrec
       - unsafe-coerce
   strings:
-    type: git
-    url: https://github.com/purescript/purescript-strings.git
-    rev: 4bc6954448d056f8aa7a659695a6ad60ad4fdf19
+    type: registry
+    version: 6.0.1
+    integrity: sha256-WssD3DbX4OPzxSdjvRMX0yvc9+pS7n5gyPv5I2Trb7k=
     dependencies:
       - arrays
       - control
@@ -4002,9 +1013,9 @@ packages:
       - unfoldable
       - unsafe-coerce
   tailrec:
-    type: git
-    url: https://github.com/purescript/purescript-tailrec.git
-    rev: 5e2104aa734b31a17074cc805bf087d72b65afd1
+    type: registry
+    version: 6.1.0
+    integrity: sha256-Xx19ECVDRrDWpz9D2GxQHHV89vd61dnXxQm0IcYQHGk=
     dependencies:
       - bifunctors
       - effect
@@ -4015,9 +1026,9 @@ packages:
       - prelude
       - refs
   test-unit:
-    type: git
-    url: https://github.com/bodil/purescript-test-unit.git
-    rev: 3112d7ebe06d467238058a6384dc75ffd960d335
+    type: registry
+    version: 17.0.0
+    integrity: sha256-aITJ2KngFFjASmG0JjnjybaKWl9dn7Hf2B3Wk4engNs=
     dependencies:
       - aff
       - avar
@@ -4030,9 +1041,9 @@ packages:
       - quickcheck
       - strings
   transformers:
-    type: git
-    url: https://github.com/purescript/purescript-transformers.git
-    rev: be72ab52357d9a665cbf93d73ba1c07c4b0957ee
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Pzw40HjthX77tdPAYzjx43LK3X5Bb7ZspYAp27wksFA=
     dependencies:
       - control
       - distributive
@@ -4049,22 +1060,22 @@ packages:
       - tuples
       - unfoldable
   tuples:
-    type: git
-    url: https://github.com/purescript/purescript-tuples.git
-    rev: 4f52da2729b448c8564369378f1232d8d2dc1d8b
+    type: registry
+    version: 7.0.0
+    integrity: sha256-1rXgTomes9105BjgXqIw0FL6Fz1lqqUTLWOumhWec1M=
     dependencies:
       - control
       - invariant
       - prelude
   type-equality:
-    type: git
-    url: https://github.com/purescript/purescript-type-equality.git
-    rev: 0525b7d39e0fbd81b4209518139fb8ab02695774
+    type: registry
+    version: 4.0.1
+    integrity: sha256-Hs9D6Y71zFi/b+qu5NSbuadUQXe5iv5iWx0226vOHUw=
     dependencies: []
   unfoldable:
-    type: git
-    url: https://github.com/purescript/purescript-unfoldable.git
-    rev: 493dfe04ed590e20d8f69079df2f58486882748d
+    type: registry
+    version: 6.0.0
+    integrity: sha256-JtikvJdktRap7vr/K4ITlxUX1QexpnqBq0G/InLr6eg=
     dependencies:
       - foldable-traversable
       - maybe
@@ -4072,14 +1083,14 @@ packages:
       - prelude
       - tuples
   unsafe-coerce:
-    type: git
-    url: https://github.com/purescript/purescript-unsafe-coerce.git
-    rev: ab956f82e66e633f647fb3098e8ddd3ec58d689f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-IqIYW4Vkevn8sI+6aUwRGvd87tVL36BBeOr0cGAE7t0=
     dependencies: []
   validation:
-    type: git
-    url: https://github.com/purescript/purescript-validation.git
-    rev: a3d9ec2176a7a808d70a01fa7e6f16d10e05429a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-kfFailaIW4spGxbRk4261z/RGT0Sb7Dx5f3qihy0MTw=
     dependencies:
       - bifunctors
       - control

--- a/exercises/chapter7/spago.lock
+++ b/exercises/chapter7/spago.lock
@@ -1,0 +1,4089 @@
+workspace:
+  packages:
+    my-project:
+      path: ./
+      dependencies:
+        - arrays
+        - console
+        - effect
+        - either
+        - foldable-traversable
+        - integers
+        - lists
+        - maybe
+        - prelude
+        - strings
+        - test-unit
+        - transformers
+        - tuples
+        - validation
+      test_dependencies: []
+      build_plan:
+        - aff
+        - arrays
+        - avar
+        - bifunctors
+        - catenable-lists
+        - console
+        - const
+        - contravariant
+        - control
+        - datetime
+        - distributive
+        - effect
+        - either
+        - enums
+        - exceptions
+        - exists
+        - foldable-traversable
+        - free
+        - functions
+        - functors
+        - gen
+        - identity
+        - integers
+        - invariant
+        - js-timers
+        - lazy
+        - lcg
+        - lists
+        - maybe
+        - newtype
+        - nonempty
+        - numbers
+        - ordered-collections
+        - orders
+        - parallel
+        - partial
+        - prelude
+        - profunctor
+        - quickcheck
+        - random
+        - record
+        - refs
+        - safe-coerce
+        - st
+        - strings
+        - tailrec
+        - test-unit
+        - transformers
+        - tuples
+        - type-equality
+        - unfoldable
+        - unsafe-coerce
+        - validation
+  package_set:
+    address:
+      url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
+    compiler: ">=0.15.0 <0.16.0"
+    content:
+      ace:
+        repo: https://github.com/purescript-contrib/purescript-ace.git
+        version: v9.0.0
+        dependencies:
+          - arrays
+          - effect
+          - foreign
+          - nullable
+          - prelude
+          - web-html
+          - web-uievents
+      aff:
+        repo: https://github.com/purescript-contrib/purescript-aff.git
+        version: v7.0.0
+        dependencies:
+          - datetime
+          - effect
+          - exceptions
+          - functions
+          - parallel
+          - transformers
+          - unsafe-coerce
+      aff-bus:
+        repo: https://github.com/purescript-contrib/purescript-aff-bus.git
+        version: v6.0.0
+        dependencies:
+          - aff
+          - avar
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - lists
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+      aff-coroutines:
+        repo: https://github.com/purescript-contrib/purescript-aff-coroutines.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - avar
+          - coroutines
+          - effect
+      aff-promise:
+        repo: https://github.com/nwolverson/purescript-aff-promise.git
+        version: v4.0.0
+        dependencies:
+          - aff
+          - foreign
+      aff-retry:
+        repo: https://github.com/Unisay/purescript-aff-retry.git
+        version: v2.0.0
+        dependencies:
+          - aff
+          - arrays
+          - datetime
+          - effect
+          - either
+          - exceptions
+          - integers
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - random
+          - transformers
+      affjax:
+        repo: https://github.com/purescript-contrib/purescript-affjax.git
+        version: v13.0.0
+        dependencies:
+          - aff
+          - argonaut-core
+          - arraybuffer-types
+          - foreign
+          - form-urlencoded
+          - http-methods
+          - integers
+          - media-types
+          - nullable
+          - refs
+          - unsafe-coerce
+          - web-xhr
+      affjax-node:
+        repo: https://github.com/purescript-contrib/purescript-affjax-node.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - affjax
+          - either
+          - maybe
+          - prelude
+      affjax-web:
+        repo: https://github.com/purescript-contrib/purescript-affjax-web.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - affjax
+          - either
+          - maybe
+          - prelude
+      ansi:
+        repo: https://github.com/hdgarrood/purescript-ansi.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - lists
+          - strings
+      argonaut:
+        repo: https://github.com/purescript-contrib/purescript-argonaut.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - argonaut-traversals
+      argonaut-codecs:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-codecs.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-core
+          - arrays
+          - effect
+          - foreign-object
+          - identity
+          - integers
+          - maybe
+          - nonempty
+          - ordered-collections
+          - prelude
+          - record
+      argonaut-core:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-core.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - foreign-object
+          - functions
+          - gen
+          - maybe
+          - nonempty
+          - prelude
+          - strings
+          - tailrec
+      argonaut-generic:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-generic.git
+        version: v8.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - prelude
+          - record
+      argonaut-traversals:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-traversals.git
+        version: v10.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - profunctor-lenses
+      argparse-basic:
+        repo: https://github.com/natefaubion/purescript-argparse-basic.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - record
+          - strings
+          - tuples
+          - unfoldable
+      arraybuffer:
+        repo: https://github.com/purescript-contrib/purescript-arraybuffer.git
+        version: v13.0.0
+        dependencies:
+          - arraybuffer-types
+          - arrays
+          - effect
+          - float32
+          - functions
+          - gen
+          - maybe
+          - nullable
+          - prelude
+          - tailrec
+          - uint
+          - unfoldable
+      arraybuffer-builder:
+        repo: https://github.com/jamesdbrock/purescript-arraybuffer-builder.git
+        version: v3.0.1
+        dependencies:
+          - arraybuffer
+          - arraybuffer-types
+          - effect
+          - float32
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - transformers
+          - uint
+      arraybuffer-types:
+        repo: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
+        version: v3.0.2
+        dependencies: []
+      arrays:
+        repo: https://github.com/purescript/purescript-arrays.git
+        version: v7.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - foldable-traversable
+          - maybe
+          - nonempty
+          - partial
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - unfoldable
+          - unsafe-coerce
+      arrays-zipper:
+        repo: https://github.com/JordanMartinez/purescript-arrays-zipper.git
+        version: v2.0.1
+        dependencies:
+          - arrays
+          - control
+          - quickcheck
+      ask:
+        repo: https://github.com/Mateiadrielrafael/purescript-ask.git
+        version: v1.0.0
+        dependencies:
+          - unsafe-coerce
+      assert:
+        repo: https://github.com/purescript/purescript-assert.git
+        version: v6.0.0
+        dependencies:
+          - console
+          - effect
+          - prelude
+      avar:
+        repo: https://github.com/purescript-contrib/purescript-avar.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - exceptions
+          - functions
+          - maybe
+      b64:
+        repo: https://github.com/menelaos/purescript-b64.git
+        version: v0.0.8
+        dependencies:
+          - arraybuffer-types
+          - either
+          - encoding
+          - enums
+          - exceptions
+          - functions
+          - partial
+          - prelude
+          - strings
+      barlow-lens:
+        repo: https://github.com/sigma-andex/purescript-barlow-lens.git
+        version: v0.9.0
+        dependencies:
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - profunctor-lenses
+          - tuples
+          - typelevel-prelude
+      bifunctors:
+        repo: https://github.com/purescript/purescript-bifunctors.git
+        version: v6.0.0
+        dependencies:
+          - const
+          - either
+          - newtype
+          - prelude
+          - tuples
+      bigints:
+        repo: https://github.com/sharkdp/purescript-bigints.git
+        version: v7.0.1
+        dependencies:
+          - integers
+          - maybe
+          - strings
+      bower-json:
+        repo: https://github.com/klntsky/purescript-bower-json.git
+        version: v3.0.0
+        dependencies:
+          - argonaut-codecs
+          - arrays
+          - either
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - newtype
+          - prelude
+          - tuples
+      call-by-name:
+        repo: https://github.com/natefaubion/purescript-call-by-name.git
+        version: v4.0.1
+        dependencies:
+          - control
+          - either
+          - lazy
+          - maybe
+          - unsafe-coerce
+      canvas:
+        repo: https://github.com/purescript-web/purescript-canvas.git
+        version: v6.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - exceptions
+          - functions
+          - maybe
+      canvas-action:
+        repo: https://github.com/artemisSystem/purescript-canvas-action.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - arrays
+          - canvas
+          - colors
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - maybe
+          - numbers
+          - polymorphic-vectors
+          - prelude
+          - refs
+          - run
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-html
+      cartesian:
+        repo: https://github.com/Ebmtranceboy/purescript-cartesian.git
+        version: v1.0.6
+        dependencies:
+          - console
+          - effect
+          - integers
+          - psci-support
+      catenable-lists:
+        repo: https://github.com/purescript/purescript-catenable-lists.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - lists
+          - maybe
+          - prelude
+          - tuples
+          - unfoldable
+      channel:
+        repo: https://github.com/ConnorDillon/purescript-channel.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - assert
+          - avar
+          - console
+          - contravariant
+          - control
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - lazy
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      checked-exceptions:
+        repo: https://github.com/natefaubion/purescript-checked-exceptions.git
+        version: v3.1.1
+        dependencies:
+          - prelude
+          - transformers
+          - variant
+      codec:
+        repo: https://github.com/garyb/purescript-codec.git
+        version: v5.0.0
+        dependencies:
+          - profunctor
+          - transformers
+      codec-argonaut:
+        repo: https://github.com/garyb/purescript-codec-argonaut.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-core
+          - codec
+          - ordered-collections
+          - type-equality
+          - variant
+      colors:
+        repo: https://github.com/purescript-contrib/purescript-colors.git
+        version: v7.0.1
+        dependencies:
+          - arrays
+          - integers
+          - lists
+          - numbers
+          - partial
+          - strings
+      concurrent-queues:
+        repo: https://github.com/purescript-contrib/purescript-concurrent-queues.git
+        version: v3.0.0
+        dependencies:
+          - aff
+          - avar
+          - effect
+      console:
+        repo: https://github.com/purescript/purescript-console.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - prelude
+      const:
+        repo: https://github.com/purescript/purescript-const.git
+        version: v6.0.0
+        dependencies:
+          - invariant
+          - newtype
+          - prelude
+      contravariant:
+        repo: https://github.com/purescript/purescript-contravariant.git
+        version: v6.0.0
+        dependencies:
+          - const
+          - either
+          - newtype
+          - prelude
+          - tuples
+      control:
+        repo: https://github.com/purescript/purescript-control.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      convertable-options:
+        repo: https://github.com/natefaubion/purescript-convertable-options.git
+        version: v1.0.0
+        dependencies:
+          - console
+          - effect
+          - maybe
+          - record
+      coroutines:
+        repo: https://github.com/purescript-contrib/purescript-coroutines.git
+        version: v7.0.0
+        dependencies:
+          - freet
+          - parallel
+          - profunctor
+      css:
+        repo: https://github.com/purescript-contrib/purescript-css.git
+        version: v6.0.0
+        dependencies:
+          - colors
+          - console
+          - effect
+          - nonempty
+          - profunctor
+          - strings
+          - these
+          - transformers
+      datetime:
+        repo: https://github.com/purescript/purescript-datetime.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - either
+          - enums
+          - foldable-traversable
+          - functions
+          - gen
+          - integers
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - ordered-collections
+          - partial
+          - prelude
+          - tuples
+      datetime-parsing:
+        repo: https://github.com/flounders/purescript-datetime-parsing.git
+        version: v0.2.0
+        dependencies:
+          - arrays
+          - datetime
+          - either
+          - enums
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - numbers
+          - parsing
+          - prelude
+          - strings
+          - unicode
+      debug:
+        repo: https://github.com/garyb/purescript-debug.git
+        version: v6.0.0
+        dependencies:
+          - functions
+          - prelude
+      decimals:
+        repo: https://github.com/sharkdp/purescript-decimals.git
+        version: v7.0.0
+        dependencies:
+          - maybe
+      dissect:
+        repo: https://github.com/PureFunctor/purescript-dissect.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - foreign-object
+          - functors
+          - newtype
+          - partial
+          - prelude
+          - tailrec
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - variant
+      distributive:
+        repo: https://github.com/purescript/purescript-distributive.git
+        version: v6.0.0
+        dependencies:
+          - identity
+          - newtype
+          - prelude
+          - tuples
+          - type-equality
+      dodo-printer:
+        repo: https://github.com/natefaubion/purescript-dodo-printer.git
+        version: v2.2.0
+        dependencies:
+          - aff
+          - ansi
+          - avar
+          - console
+          - effect
+          - foldable-traversable
+          - lists
+          - maybe
+          - minibench
+          - node-child-process
+          - node-fs-aff
+          - node-process
+          - psci-support
+          - strings
+      dom-indexed:
+        repo: https://github.com/purescript-halogen/purescript-dom-indexed.git
+        version: v11.0.0
+        dependencies:
+          - media-types
+          - prelude
+          - web-clipboard
+          - web-pointerevents
+          - web-touchevents
+      droplet:
+        repo: https://github.com/easafe/purescript-droplet.git
+        version: v0.4.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - bigints
+          - datetime
+          - debug
+          - effect
+          - either
+          - enums
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - integers
+          - maybe
+          - newtype
+          - nullable
+          - ordered-collections
+          - partial
+          - prelude
+          - profunctor
+          - record
+          - spec
+          - strings
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+      dynamic-buffer:
+        repo: https://github.com/kritzcreek/purescript-dynamic-buffer.git
+        version: v3.0.1
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - refs
+      effect:
+        repo: https://github.com/purescript/purescript-effect.git
+        version: v4.0.0
+        dependencies:
+          - prelude
+      either:
+        repo: https://github.com/purescript/purescript-either.git
+        version: v6.1.0
+        dependencies:
+          - control
+          - invariant
+          - maybe
+          - prelude
+      elmish:
+        repo: https://github.com/collegevine/purescript-elmish.git
+        version: v0.8.1
+        dependencies:
+          - aff
+          - argonaut-core
+          - arrays
+          - bifunctors
+          - console
+          - debug
+          - effect
+          - either
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - functions
+          - integers
+          - js-date
+          - maybe
+          - nullable
+          - partial
+          - prelude
+          - refs
+          - typelevel-prelude
+          - undefined-is-not-a-problem
+          - unsafe-coerce
+          - web-dom
+          - web-html
+      elmish-enzyme:
+        repo: https://github.com/collegevine/purescript-elmish-enzyme.git
+        version: v0.1.1
+        dependencies:
+          - aff
+          - aff-promise
+          - arrays
+          - console
+          - debug
+          - effect
+          - elmish
+          - foldable-traversable
+          - foreign
+          - functions
+          - prelude
+          - transformers
+          - unsafe-coerce
+      elmish-hooks:
+        repo: https://github.com/collegevine/purescript-elmish-hooks.git
+        version: v0.8.2
+        dependencies:
+          - aff
+          - debug
+          - elmish
+          - maybe
+          - prelude
+          - tuples
+          - undefined-is-not-a-problem
+      elmish-html:
+        repo: https://github.com/collegevine/purescript-elmish-html.git
+        version: v0.7.1
+        dependencies:
+          - effect
+          - elmish
+          - foreign
+          - foreign-object
+          - prelude
+          - record
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-html
+      email-validate:
+        repo: https://github.com/cdepillabout/purescript-email-validate.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - string-parsers
+          - transformers
+      encoding:
+        repo: https://github.com/menelaos/purescript-encoding.git
+        version: v0.0.8
+        dependencies:
+          - arraybuffer-types
+          - either
+          - exceptions
+          - functions
+          - prelude
+      enums:
+        repo: https://github.com/purescript/purescript-enums.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - either
+          - gen
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tuples
+          - unfoldable
+      exceptions:
+        repo: https://github.com/purescript/purescript-exceptions.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - either
+          - maybe
+          - prelude
+      exists:
+        repo: https://github.com/purescript/purescript-exists.git
+        version: v6.0.0
+        dependencies:
+          - unsafe-coerce
+      exitcodes:
+        repo: https://github.com/Risto-Stevcev/purescript-exitcodes.git
+        version: v4.0.0
+        dependencies:
+          - enums
+      expect-inferred:
+        repo: https://github.com/justinwoo/purescript-expect-inferred.git
+        version: v3.0.0
+        dependencies:
+          - prelude
+          - typelevel-prelude
+      fast-vect:
+        repo: https://github.com/sigma-andex/purescript-fast-vect.git
+        version: v0.7.0
+        dependencies:
+          - arrays
+          - filterable
+          - foldable-traversable
+          - lists
+          - maybe
+          - ordered-collections
+          - prelude
+          - profunctor
+          - tuples
+          - unfoldable
+      filterable:
+        repo: https://github.com/purescript/purescript-filterable.git
+        version: v5.0.0
+        dependencies:
+          - arrays
+          - either
+          - foldable-traversable
+          - identity
+          - lists
+          - ordered-collections
+      fixed-points:
+        repo: https://github.com/purescript-contrib/purescript-fixed-points.git
+        version: v7.0.0
+        dependencies:
+          - exists
+          - newtype
+          - prelude
+          - transformers
+      fixed-precision:
+        repo: https://github.com/lumihq/purescript-fixed-precision.git
+        version: v5.0.0
+        dependencies:
+          - arrays
+          - bigints
+          - control
+          - integers
+          - maybe
+          - numbers
+          - partial
+          - prelude
+          - strings
+      flame:
+        repo: https://github.com/easafe/purescript-flame.git
+        version: v1.2.0
+        dependencies:
+          - aff
+          - argonaut-codecs
+          - argonaut-core
+          - argonaut-generic
+          - arrays
+          - bifunctors
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - maybe
+          - newtype
+          - nullable
+          - partial
+          - prelude
+          - random
+          - refs
+          - spec
+          - strings
+          - tuples
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-html
+          - web-uievents
+      float32:
+        repo: https://github.com/purescript-contrib/purescript-float32.git
+        version: v2.0.0
+        dependencies:
+          - gen
+          - maybe
+          - prelude
+      foldable-traversable:
+        repo: https://github.com/purescript/purescript-foldable-traversable.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - const
+          - control
+          - either
+          - functors
+          - identity
+          - maybe
+          - newtype
+          - orders
+          - prelude
+          - tuples
+      foreign:
+        repo: https://github.com/purescript/purescript-foreign.git
+        version: v7.0.0
+        dependencies:
+          - either
+          - functions
+          - identity
+          - integers
+          - lists
+          - maybe
+          - prelude
+          - strings
+          - transformers
+      foreign-object:
+        repo: https://github.com/purescript/purescript-foreign-object.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - functions
+          - gen
+          - lists
+          - maybe
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - typelevel-prelude
+          - unfoldable
+      foreign-readwrite:
+        repo: https://github.com/artemisSystem/purescript-foreign-readwrite.git
+        version: v3.0.0
+        dependencies:
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - record
+          - safe-coerce
+          - transformers
+          - unsafe-coerce
+      fork:
+        repo: https://github.com/purescript-contrib/purescript-fork.git
+        version: v6.0.0
+        dependencies:
+          - aff
+      form-urlencoded:
+        repo: https://github.com/purescript-contrib/purescript-form-urlencoded.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - js-uri
+          - maybe
+          - newtype
+          - prelude
+          - strings
+          - tuples
+      formatters:
+        repo: https://github.com/purescript-contrib/purescript-formatters.git
+        version: v7.0.0
+        dependencies:
+          - datetime
+          - fixed-points
+          - lists
+          - numbers
+          - parsing
+          - prelude
+          - transformers
+      free:
+        repo: https://github.com/purescript/purescript-free.git
+        version: v7.0.0
+        dependencies:
+          - catenable-lists
+          - control
+          - distributive
+          - either
+          - exists
+          - foldable-traversable
+          - invariant
+          - lazy
+          - maybe
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+      freeap:
+        repo: https://github.com/ethul/purescript-freeap.git
+        version: v7.0.0
+        dependencies:
+          - const
+          - exists
+          - gen
+          - lists
+      freet:
+        repo: https://github.com/purescript-contrib/purescript-freet.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - bifunctors
+          - effect
+          - either
+          - exists
+          - free
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      functions:
+        repo: https://github.com/purescript/purescript-functions.git
+        version: v6.0.0
+        dependencies:
+          - prelude
+      functors:
+        repo: https://github.com/purescript/purescript-functors.git
+        version: v5.0.0
+        dependencies:
+          - bifunctors
+          - const
+          - contravariant
+          - control
+          - distributive
+          - either
+          - invariant
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - tuples
+          - unsafe-coerce
+      fuzzy:
+        repo: https://github.com/citizennet/purescript-fuzzy.git
+        version: v0.4.0
+        dependencies:
+          - foldable-traversable
+          - foreign-object
+          - newtype
+          - ordered-collections
+          - prelude
+          - rationals
+          - strings
+          - tuples
+      gen:
+        repo: https://github.com/purescript/purescript-gen.git
+        version: v4.0.0
+        dependencies:
+          - either
+          - foldable-traversable
+          - identity
+          - maybe
+          - newtype
+          - nonempty
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      generate-values:
+        repo: https://github.com/jordanmartinez/purescript-generate-values.git
+        version: v1.0.1
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - enums
+          - foldable-traversable
+          - gen
+          - identity
+          - integers
+          - lcg
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - partial
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      geometry-plane:
+        repo: https://github.com/Ebmtranceboy/purescript-geometry-plane.git
+        version: v1.0.3
+        dependencies:
+          - console
+          - effect
+          - psci-support
+          - sparse-polynomials
+      github-actions-toolkit:
+        repo: https://github.com/purescript-contrib/purescript-github-actions-toolkit.git
+        version: v0.5.0
+        dependencies:
+          - aff
+          - aff-promise
+          - effect
+          - foreign-object
+          - node-buffer
+          - node-path
+          - node-streams
+          - nullable
+          - transformers
+      graphs:
+        repo: https://github.com/purescript/purescript-graphs.git
+        version: v8.0.0
+        dependencies:
+          - catenable-lists
+          - ordered-collections
+      group:
+        repo: https://github.com/morganthomas/purescript-group.git
+        version: v4.1.1
+        dependencies:
+          - lists
+      halogen:
+        repo: https://github.com/purescript-halogen/purescript-halogen.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - avar
+          - console
+          - const
+          - dom-indexed
+          - effect
+          - foreign
+          - fork
+          - free
+          - freeap
+          - halogen-subscriptions
+          - halogen-vdom
+          - media-types
+          - nullable
+          - ordered-collections
+          - parallel
+          - profunctor
+          - transformers
+          - unsafe-coerce
+          - unsafe-reference
+          - web-file
+          - web-uievents
+      halogen-css:
+        repo: https://github.com/purescript-halogen/purescript-halogen-css.git
+        version: v10.0.0
+        dependencies:
+          - css
+          - halogen
+      halogen-formless:
+        repo: https://github.com/thomashoneyman/purescript-halogen-formless.git
+        version: v4.0.0
+        dependencies:
+          - convertable-options
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - halogen
+          - heterogeneous
+          - maybe
+          - prelude
+          - record
+          - safe-coerce
+          - type-equality
+          - unsafe-coerce
+          - unsafe-reference
+          - variant
+          - web-events
+          - web-uievents
+      halogen-hooks:
+        repo: https://github.com/thomashoneyman/purescript-halogen-hooks.git
+        version: v0.6.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - effect
+          - exceptions
+          - foldable-traversable
+          - foreign-object
+          - free
+          - freeap
+          - halogen
+          - halogen-subscriptions
+          - maybe
+          - newtype
+          - ordered-collections
+          - parallel
+          - partial
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+          - unsafe-reference
+          - web-dom
+          - web-html
+      halogen-hooks-extra:
+        repo: https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git
+        version: v0.9.0
+        dependencies:
+          - halogen-hooks
+      halogen-store:
+        repo: https://github.com/thomashoneyman/purescript-halogen-store.git
+        version: v0.5.0
+        dependencies:
+          - aff
+          - distributive
+          - effect
+          - fork
+          - halogen
+          - halogen-hooks
+          - halogen-subscriptions
+          - maybe
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-reference
+      halogen-storybook:
+        repo: https://github.com/rnons/purescript-halogen-storybook.git
+        version: v2.0.0
+        dependencies:
+          - foreign-object
+          - halogen
+          - prelude
+          - routing
+      halogen-subscriptions:
+        repo: https://github.com/purescript-halogen/purescript-halogen-subscriptions.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - effect
+          - foldable-traversable
+          - functors
+          - refs
+          - safe-coerce
+          - unsafe-reference
+      halogen-svg-elems:
+        repo: https://github.com/JordanMartinez/purescript-halogen-svg-elems.git
+        version: v6.0.0
+        dependencies:
+          - halogen
+      halogen-vdom:
+        repo: https://github.com/purescript-halogen/purescript-halogen-vdom.git
+        version: v8.0.0
+        dependencies:
+          - bifunctors
+          - effect
+          - foreign
+          - foreign-object
+          - maybe
+          - prelude
+          - refs
+          - tuples
+          - unsafe-coerce
+          - web-html
+      halogen-vdom-string-renderer:
+        repo: https://github.com/purescript-halogen/purescript-halogen-vdom-string-renderer.git
+        version: v0.5.0
+        dependencies:
+          - foreign
+          - halogen-vdom
+          - ordered-collections
+          - prelude
+      heckin:
+        repo: https://github.com/maxdeviant/purescript-heckin.git
+        version: v2.0.1
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - maybe
+          - prelude
+          - strings
+          - transformers
+          - tuples
+          - unicode
+      heterogeneous:
+        repo: https://github.com/natefaubion/purescript-heterogeneous.git
+        version: v0.6.0
+        dependencies:
+          - either
+          - functors
+          - prelude
+          - record
+          - tuples
+          - variant
+      heterogeneous-extrablatt:
+        repo: https://github.com/sigma-andex/purescript-heterogeneous-extrablatt.git
+        version: v0.2.1
+        dependencies:
+          - heterogeneous
+          - prelude
+          - record
+      http-methods:
+        repo: https://github.com/purescript-contrib/purescript-http-methods.git
+        version: v6.0.0
+        dependencies:
+          - either
+          - prelude
+          - strings
+      httpure:
+        repo: https://github.com/citizennet/purescript-httpure.git
+        version: v0.15.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - js-uri
+          - maybe
+          - newtype
+          - node-buffer
+          - node-fs
+          - node-http
+          - node-streams
+          - options
+          - ordered-collections
+          - prelude
+          - refs
+          - strings
+          - tuples
+          - type-equality
+      httpurple:
+        repo: https://github.com/sigma-andex/purescript-httpurple.git
+        version: v1.3.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - js-uri
+          - justifill
+          - maybe
+          - newtype
+          - node-buffer
+          - node-fs
+          - node-http
+          - node-net
+          - node-process
+          - node-streams
+          - options
+          - ordered-collections
+          - posix-types
+          - prelude
+          - profunctor
+          - record
+          - refs
+          - routing-duplex
+          - strings
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+      httpurple-argonaut:
+        repo: https://github.com/sigma-andex/purescript-httpurple-argonaut.git
+        version: v1.0.1
+        dependencies:
+          - argonaut
+          - console
+          - effect
+          - either
+          - httpurple
+          - prelude
+      httpurple-yoga-json:
+        repo: https://github.com/sigma-andex/purescript-httpurple-yoga-json.git
+        version: v1.0.0
+        dependencies:
+          - console
+          - effect
+          - either
+          - foreign
+          - httpurple
+          - lists
+          - prelude
+          - yoga-json
+      identity:
+        repo: https://github.com/purescript/purescript-identity.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - invariant
+          - newtype
+          - prelude
+      indexed-monad:
+        repo: https://github.com/garyb/purescript-indexed-monad.git
+        version: v2.1.0
+        dependencies:
+          - control
+          - newtype
+      int64:
+        repo: https://github.com/purescript-contrib/purescript-int64.git
+        version: v2.0.0
+        dependencies:
+          - effect
+          - foreign
+          - functions
+          - integers
+          - maybe
+          - nullable
+          - prelude
+          - quickcheck
+      integers:
+        repo: https://github.com/purescript/purescript-integers.git
+        version: v6.0.0
+        dependencies:
+          - maybe
+          - numbers
+          - prelude
+      interpolate:
+        repo: https://github.com/jordanmartinez/purescript-interpolate.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+      invariant:
+        repo: https://github.com/purescript/purescript-invariant.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - prelude
+      js-date:
+        repo: https://github.com/purescript-contrib/purescript-js-date.git
+        version: v8.0.0
+        dependencies:
+          - datetime
+          - effect
+          - exceptions
+          - foreign
+          - integers
+          - now
+      js-fileio:
+        repo: https://github.com/newlandsvalley/purescript-js-fileio.git
+        version: v3.0.0
+        dependencies:
+          - aff
+          - effect
+          - prelude
+      js-timers:
+        repo: https://github.com/purescript-contrib/purescript-js-timers.git
+        version: v6.1.0
+        dependencies:
+          - effect
+      js-uri:
+        repo: https://github.com/purescript-contrib/purescript-js-uri.git
+        version: v3.0.0
+        dependencies:
+          - functions
+          - maybe
+      justifill:
+        repo: https://github.com/i-am-the-slime/purescript-justifill.git
+        version: v0.5.0
+        dependencies:
+          - maybe
+          - prelude
+          - record
+          - typelevel-prelude
+      jwt:
+        repo: https://github.com/menelaos/purescript-jwt.git
+        version: v0.0.9
+        dependencies:
+          - argonaut-core
+          - arrays
+          - b64
+          - either
+          - exceptions
+          - prelude
+          - profunctor-lenses
+          - strings
+      language-cst-parser:
+        repo: https://github.com/natefaubion/purescript-language-cst-parser.git
+        version: v0.12.0
+        dependencies:
+          - arrays
+          - const
+          - control
+          - either
+          - foldable-traversable
+          - free
+          - functions
+          - functors
+          - identity
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - ordered-collections
+          - partial
+          - prelude
+          - st
+          - strings
+          - transformers
+          - tuples
+          - typelevel-prelude
+          - unfoldable
+          - unsafe-coerce
+      lazy:
+        repo: https://github.com/purescript/purescript-lazy.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - invariant
+          - prelude
+      lcg:
+        repo: https://github.com/purescript/purescript-lcg.git
+        version: v4.0.0
+        dependencies:
+          - effect
+          - integers
+          - maybe
+          - partial
+          - prelude
+          - random
+      leibniz:
+        repo: https://github.com/paf31/purescript-leibniz.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+          - unsafe-coerce
+      linalg:
+        repo: https://github.com/gbagan/purescript-linalg.git
+        version: v5.1.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - functions
+          - maybe
+          - prelude
+          - tuples
+      lists:
+        repo: https://github.com/purescript/purescript-lists.git
+        version: v7.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - foldable-traversable
+          - lazy
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      logging:
+        repo: https://github.com/rightfold/purescript-logging.git
+        version: v3.0.0
+        dependencies:
+          - console
+          - contravariant
+          - effect
+          - either
+          - prelude
+          - transformers
+          - tuples
+      machines:
+        repo: https://github.com/purescript-contrib/purescript-machines.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - lists
+          - maybe
+          - prelude
+          - profunctor
+          - tuples
+          - unfoldable
+      matrices:
+        repo: https://github.com/kRITZCREEK/purescript-matrices.git
+        version: v5.0.1
+        dependencies:
+          - arrays
+          - strings
+      matryoshka:
+        repo: https://github.com/purescript-contrib/purescript-matryoshka.git
+        version: v1.0.0
+        dependencies:
+          - fixed-points
+          - free
+          - prelude
+          - profunctor
+          - transformers
+      maybe:
+        repo: https://github.com/purescript/purescript-maybe.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - invariant
+          - newtype
+          - prelude
+      media-types:
+        repo: https://github.com/purescript-contrib/purescript-media-types.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      metadata:
+        repo: https://github.com/purescript/purescript-metadata.git
+        version: v0.15.0
+        dependencies: []
+      midi:
+        repo: https://github.com/newlandsvalley/purescript-midi.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - ordered-collections
+          - prelude
+          - signal
+          - string-parsers
+          - strings
+          - tuples
+          - unfoldable
+      minibench:
+        repo: https://github.com/purescript/purescript-minibench.git
+        version: v4.0.0
+        dependencies:
+          - console
+          - effect
+          - integers
+          - numbers
+          - partial
+          - prelude
+          - refs
+      mmorph:
+        repo: https://github.com/Thimoteus/purescript-mmorph.git
+        version: v7.0.0
+        dependencies:
+          - free
+          - functors
+          - transformers
+      monad-control:
+        repo: https://github.com/athanclark/purescript-monad-control.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - freet
+          - identity
+          - lists
+      monad-logger:
+        repo: https://github.com/cprussin/purescript-monad-logger.git
+        version: v1.3.1
+        dependencies:
+          - aff
+          - ansi
+          - argonaut
+          - arrays
+          - console
+          - control
+          - effect
+          - foldable-traversable
+          - foreign-object
+          - integers
+          - js-date
+          - maybe
+          - newtype
+          - ordered-collections
+          - prelude
+          - strings
+          - transformers
+          - tuples
+      monad-loops:
+        repo: https://github.com/mlang/purescript-monad-loops.git
+        version: v0.5.0
+        dependencies:
+          - lists
+          - maybe
+          - prelude
+          - tailrec
+          - tuples
+      monad-unlift:
+        repo: https://github.com/athanclark/purescript-monad-unlift.git
+        version: v1.0.1
+        dependencies:
+          - monad-control
+      monoidal:
+        repo: https://github.com/mcneissue/purescript-monoidal.git
+        version: v0.16.0
+        dependencies:
+          - either
+          - profunctor
+          - these
+          - tuples
+      morello:
+        repo: https://github.com/sigma-andex/purescript-morello.git
+        version: v0.3.2
+        dependencies:
+          - arrays
+          - barlow-lens
+          - foldable-traversable
+          - heterogeneous
+          - heterogeneous-extrablatt
+          - newtype
+          - prelude
+          - profunctor
+          - profunctor-lenses
+          - record
+          - tuples
+          - typelevel-prelude
+          - validation
+      motsunabe:
+        repo: https://github.com/justinwoo/purescript-motsunabe.git
+        version: v2.0.0
+        dependencies:
+          - lists
+          - strings
+      nano-id:
+        repo: https://github.com/eikooc/nano-id.git
+        version: v1.1.0
+        dependencies:
+          - aff
+          - effect
+          - lists
+          - maybe
+          - prelude
+          - random
+          - spec
+          - strings
+          - stringutils
+      naturals:
+        repo: https://github.com/LiamGoodacre/purescript-naturals.git
+        version: v3.0.0
+        dependencies:
+          - enums
+          - maybe
+          - prelude
+      nested-functor:
+        repo: https://github.com/acple/purescript-nested-functor.git
+        version: v0.2.1
+        dependencies:
+          - prelude
+          - type-equality
+      newtype:
+        repo: https://github.com/purescript/purescript-newtype.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+          - safe-coerce
+      node-buffer:
+        repo: https://github.com/purescript-node/purescript-node-buffer.git
+        version: v8.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - maybe
+          - st
+          - unsafe-coerce
+      node-buffer-blob:
+        repo: https://github.com/purescript-node/purescript-node-buffer-blob.git
+        version: v1.0.0
+        dependencies:
+          - aff-promise
+          - arraybuffer-types
+          - arrays
+          - console
+          - effect
+          - maybe
+          - media-types
+          - newtype
+          - node-buffer
+          - nullable
+          - prelude
+          - web-streams
+      node-child-process:
+        repo: https://github.com/purescript-node/purescript-node-child-process.git
+        version: v9.0.0
+        dependencies:
+          - exceptions
+          - foreign
+          - foreign-object
+          - functions
+          - node-fs
+          - node-streams
+          - nullable
+          - posix-types
+          - unsafe-coerce
+      node-fs:
+        repo: https://github.com/purescript-node/purescript-node-fs.git
+        version: v8.0.0
+        dependencies:
+          - datetime
+          - effect
+          - either
+          - enums
+          - exceptions
+          - functions
+          - integers
+          - js-date
+          - maybe
+          - node-buffer
+          - node-path
+          - node-streams
+          - nullable
+          - partial
+          - prelude
+          - strings
+          - unsafe-coerce
+      node-fs-aff:
+        repo: https://github.com/purescript-node/purescript-node-fs-aff.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - either
+          - node-fs
+          - node-path
+      node-http:
+        repo: https://github.com/purescript-node/purescript-node-http.git
+        version: v8.0.0
+        dependencies:
+          - arraybuffer-types
+          - contravariant
+          - effect
+          - foreign
+          - foreign-object
+          - maybe
+          - node-buffer
+          - node-net
+          - node-streams
+          - node-url
+          - nullable
+          - options
+          - prelude
+          - unsafe-coerce
+      node-net:
+        repo: https://github.com/purescript-node/purescript-node-net.git
+        version: v4.0.0
+        dependencies:
+          - effect
+          - either
+          - exceptions
+          - foreign
+          - maybe
+          - node-buffer
+          - node-fs
+          - nullable
+          - options
+          - prelude
+          - transformers
+      node-path:
+        repo: https://github.com/purescript-node/purescript-node-path.git
+        version: v5.0.0
+        dependencies:
+          - effect
+      node-process:
+        repo: https://github.com/purescript-node/purescript-node-process.git
+        version: v10.0.0
+        dependencies:
+          - effect
+          - foreign-object
+          - maybe
+          - node-streams
+          - posix-types
+          - prelude
+          - unsafe-coerce
+      node-readline:
+        repo: https://github.com/purescript-node/purescript-node-readline.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - foreign
+          - node-process
+          - node-streams
+          - options
+          - prelude
+      node-streams:
+        repo: https://github.com/purescript-node/purescript-node-streams.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - either
+          - exceptions
+          - node-buffer
+          - nullable
+          - prelude
+      node-streams-aff:
+        repo: https://github.com/jamesdbrock/purescript-node-streams-aff.git
+        version: v2.0.0
+        dependencies:
+          - aff
+          - arrays
+          - effect
+          - either
+          - exceptions
+          - maybe
+          - node-buffer
+          - node-streams
+          - prelude
+          - st
+          - tuples
+      node-url:
+        repo: https://github.com/purescript-node/purescript-node-url.git
+        version: v6.0.0
+        dependencies:
+          - nullable
+      nonempty:
+        repo: https://github.com/purescript/purescript-nonempty.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - maybe
+          - prelude
+          - tuples
+          - unfoldable
+      now:
+        repo: https://github.com/purescript-contrib/purescript-now.git
+        version: v6.0.0
+        dependencies:
+          - datetime
+          - effect
+      npm-package-json:
+        repo: https://github.com/maxdeviant/purescript-npm-package-json.git
+        version: v2.0.0
+        dependencies:
+          - argonaut
+          - control
+          - either
+          - foreign-object
+          - maybe
+          - ordered-collections
+          - prelude
+      nullable:
+        repo: https://github.com/purescript-contrib/purescript-nullable.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - functions
+          - maybe
+      numbers:
+        repo: https://github.com/purescript/purescript-numbers.git
+        version: v9.0.0
+        dependencies:
+          - functions
+          - maybe
+      open-folds:
+        repo: https://github.com/purescript-open-community/purescript-open-folds.git
+        version: v6.3.0
+        dependencies:
+          - bifunctors
+          - console
+          - control
+          - distributive
+          - effect
+          - either
+          - foldable-traversable
+          - identity
+          - invariant
+          - maybe
+          - newtype
+          - ordered-collections
+          - prelude
+          - profunctor
+          - psci-support
+          - tuples
+      open-memoize:
+        repo: https://github.com/purescript-open-community/purescript-open-memoize.git
+        version: v6.1.0
+        dependencies:
+          - console
+          - effect
+          - either
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - psci-support
+          - strings
+          - tuples
+      open-pairing:
+        repo: https://github.com/purescript-open-community/purescript-open-pairing.git
+        version: v6.1.0
+        dependencies:
+          - console
+          - control
+          - effect
+          - either
+          - free
+          - functors
+          - identity
+          - newtype
+          - prelude
+          - psci-support
+          - transformers
+          - tuples
+      options:
+        repo: https://github.com/purescript-contrib/purescript-options.git
+        version: v7.0.0
+        dependencies:
+          - contravariant
+          - foreign
+          - foreign-object
+          - maybe
+          - tuples
+      optparse:
+        repo: https://github.com/f-o-a-m/purescript-optparse.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - control
+          - effect
+          - either
+          - enums
+          - exists
+          - exitcodes
+          - foldable-traversable
+          - free
+          - gen
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - newtype
+          - node-buffer
+          - node-process
+          - node-streams
+          - nonempty
+          - numbers
+          - open-memoize
+          - partial
+          - prelude
+          - quickcheck
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+      ordered-collections:
+        repo: https://github.com/purescript/purescript-ordered-collections.git
+        version: v3.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - gen
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - unfoldable
+      ordered-set:
+        repo: https://github.com/flip111/purescript-ordered-set.git
+        version: v0.4.0
+        dependencies:
+          - argonaut-codecs
+          - arrays
+          - partial
+          - prelude
+          - unfoldable
+      orders:
+        repo: https://github.com/purescript/purescript-orders.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      pairs:
+        repo: https://github.com/sharkdp/purescript-pairs.git
+        version: v9.0.0
+        dependencies:
+          - console
+          - distributive
+          - foldable-traversable
+          - quickcheck
+      parallel:
+        repo: https://github.com/purescript/purescript-parallel.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - functors
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - refs
+          - transformers
+      parsing:
+        repo: https://github.com/purescript-contrib/purescript-parsing.git
+        version: v9.1.0
+        dependencies:
+          - arrays
+          - either
+          - foldable-traversable
+          - identity
+          - integers
+          - lists
+          - maybe
+          - nullable
+          - prelude
+          - strings
+          - transformers
+          - unicode
+      parsing-dataview:
+        repo: https://github.com/jamesdbrock/purescript-parsing-dataview.git
+        version: v3.1.0
+        dependencies:
+          - arraybuffer
+          - arraybuffer-types
+          - effect
+          - float32
+          - maybe
+          - parsing
+          - prelude
+          - transformers
+          - tuples
+          - uint
+      partial:
+        repo: https://github.com/purescript/purescript-partial.git
+        version: v4.0.0
+        dependencies: []
+      pathy:
+        repo: https://github.com/purescript-contrib/purescript-pathy.git
+        version: v9.0.0
+        dependencies:
+          - console
+          - exceptions
+          - lists
+          - partial
+          - profunctor
+          - strings
+          - transformers
+          - typelevel-prelude
+          - unsafe-coerce
+      pha:
+        repo: https://github.com/gbagan/purescript-pha.git
+        version: v0.9.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - datetime
+          - effect
+          - foldable-traversable
+          - free
+          - integers
+          - maybe
+          - prelude
+          - profunctor-lenses
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+          - unsafe-reference
+          - web-dom
+          - web-events
+          - web-html
+          - web-pointerevents
+          - web-uievents
+      phaser:
+        repo: https://github.com/lfarroco/purescript-phaser.git
+        version: v0.6.0
+        dependencies:
+          - canvas
+          - console
+          - effect
+          - maybe
+          - nullable
+          - options
+          - prelude
+          - web-html
+      pipes:
+        repo: https://github.com/felixschl/purescript-pipes.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - lists
+          - mmorph
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      point-free:
+        repo: https://github.com/ursi/purescript-point-free.git
+        version: v1.0.0
+        dependencies:
+          - prelude
+      polymorphic-vectors:
+        repo: https://github.com/artemisSystem/purescript-polymorphic-vectors.git
+        version: v4.0.0
+        dependencies:
+          - distributive
+          - foldable-traversable
+          - numbers
+          - prelude
+          - record
+          - safe-coerce
+          - type-equality
+          - typelevel-prelude
+      posix-types:
+        repo: https://github.com/purescript-node/purescript-posix-types.git
+        version: v6.0.0
+        dependencies:
+          - maybe
+          - prelude
+      precise:
+        repo: https://github.com/purescript-contrib/purescript-precise.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - exceptions
+          - gen
+          - integers
+          - lists
+          - numbers
+          - prelude
+          - strings
+      precise-datetime:
+        repo: https://github.com/awakesecurity/purescript-precise-datetime.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - datetime
+          - decimals
+          - either
+          - enums
+          - foldable-traversable
+          - formatters
+          - integers
+          - js-date
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - strings
+          - tuples
+          - unicode
+      prelude:
+        repo: https://github.com/purescript/purescript-prelude.git
+        version: v6.0.0
+        dependencies: []
+      prettier-printer:
+        repo: https://github.com/paulyoung/purescript-prettier-printer.git
+        version: v3.0.0
+        dependencies:
+          - console
+          - lists
+          - prelude
+          - strings
+          - tuples
+      profunctor:
+        repo: https://github.com/purescript/purescript-profunctor.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - distributive
+          - either
+          - exists
+          - invariant
+          - newtype
+          - prelude
+          - tuples
+      profunctor-lenses:
+        repo: https://github.com/purescript-contrib/purescript-profunctor-lenses.git
+        version: v8.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - const
+          - control
+          - distributive
+          - either
+          - foldable-traversable
+          - foreign-object
+          - functors
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - ordered-collections
+          - partial
+          - prelude
+          - profunctor
+          - record
+          - transformers
+          - tuples
+      protobuf:
+        repo: https://github.com/xc-jp/purescript-protobuf.git
+        version: v4.0.0
+        dependencies:
+          - arraybuffer
+          - arraybuffer-builder
+          - arraybuffer-types
+          - arrays
+          - control
+          - effect
+          - either
+          - enums
+          - exceptions
+          - float32
+          - foldable-traversable
+          - functions
+          - int64
+          - maybe
+          - newtype
+          - parsing
+          - parsing-dataview
+          - prelude
+          - record
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+          - uint
+          - web-encoding
+      ps-cst:
+        repo: https://github.com/purescript-codegen/purescript-ps-cst.git
+        version: v1.2.0
+        dependencies:
+          - ansi
+          - console
+          - dodo-printer
+          - effect
+          - node-fs-aff
+          - node-path
+          - psci-support
+          - record
+          - strings
+      psa-utils:
+        repo: https://github.com/natefaubion/purescript-psa-utils.git
+        version: v8.0.0
+        dependencies:
+          - ansi
+          - argonaut-codecs
+          - argonaut-core
+          - arrays
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - maybe
+          - node-path
+          - ordered-collections
+          - prelude
+          - strings
+          - tuples
+          - unsafe-coerce
+      psc-ide:
+        repo: https://github.com/kRITZCREEK/purescript-psc-ide.git
+        version: v19.0.0
+        dependencies:
+          - aff
+          - argonaut
+          - arrays
+          - console
+          - maybe
+          - node-child-process
+          - node-fs
+          - parallel
+          - random
+      psci-support:
+        repo: https://github.com/purescript/purescript-psci-support.git
+        version: v6.0.0
+        dependencies:
+          - console
+          - effect
+          - prelude
+      qualified-do:
+        repo: https://github.com/artemisSystem/purescript-qualified-do.git
+        version: v2.2.0
+        dependencies:
+          - arrays
+          - control
+          - foldable-traversable
+          - parallel
+          - prelude
+          - unfoldable
+      quantities:
+        repo: https://github.com/sharkdp/purescript-quantities.git
+        version: v12.0.1
+        dependencies:
+          - decimals
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - newtype
+          - nonempty
+          - numbers
+          - pairs
+          - prelude
+          - tuples
+      quickcheck:
+        repo: https://github.com/purescript/purescript-quickcheck.git
+        version: v8.0.1
+        dependencies:
+          - arrays
+          - console
+          - control
+          - effect
+          - either
+          - enums
+          - exceptions
+          - foldable-traversable
+          - gen
+          - identity
+          - integers
+          - lazy
+          - lcg
+          - lists
+          - maybe
+          - newtype
+          - nonempty
+          - numbers
+          - partial
+          - prelude
+          - record
+          - st
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+          - unfoldable
+      quickcheck-combinators:
+        repo: https://github.com/athanclark/purescript-quickcheck-combinators.git
+        version: v0.1.3
+        dependencies:
+          - quickcheck
+          - typelevel
+      quickcheck-laws:
+        repo: https://github.com/purescript-contrib/purescript-quickcheck-laws.git
+        version: v7.0.0
+        dependencies:
+          - enums
+          - quickcheck
+      quickcheck-utf8:
+        repo: https://github.com/openchronology/purescript-quickcheck-utf8.git
+        version: v0.0.0
+        dependencies:
+          - quickcheck
+      quotient:
+        repo: https://github.com/rightfold/purescript-quotient.git
+        version: v3.0.0
+        dependencies:
+          - prelude
+          - quickcheck
+      random:
+        repo: https://github.com/purescript/purescript-random.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - integers
+      rationals:
+        repo: https://github.com/anttih/purescript-rationals.git
+        version: v5.0.0
+        dependencies:
+          - integers
+          - prelude
+      react:
+        repo: https://github.com/purescript-contrib/purescript-react.git
+        version: v10.0.1
+        dependencies:
+          - effect
+          - exceptions
+          - maybe
+          - nullable
+          - prelude
+          - typelevel-prelude
+          - unsafe-coerce
+      react-basic:
+        repo: https://github.com/lumihq/purescript-react-basic.git
+        version: v17.0.0
+        dependencies:
+          - effect
+          - prelude
+          - record
+      react-basic-dom:
+        repo: https://github.com/lumihq/purescript-react-basic-dom.git
+        version: v5.0.0
+        dependencies:
+          - effect
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - nullable
+          - prelude
+          - react-basic
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-file
+          - web-html
+      react-basic-hooks:
+        repo: https://github.com/megamaddu/purescript-react-basic-hooks.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - aff-promise
+          - bifunctors
+          - console
+          - control
+          - datetime
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - functions
+          - indexed-monad
+          - integers
+          - maybe
+          - newtype
+          - now
+          - nullable
+          - ordered-collections
+          - prelude
+          - react-basic
+          - refs
+          - tuples
+          - type-equality
+          - unsafe-coerce
+          - unsafe-reference
+          - web-html
+      react-dom:
+        repo: https://github.com/purescript-contrib/purescript-react-dom.git
+        version: v8.0.0
+        dependencies:
+          - effect
+          - react
+          - web-dom
+      read:
+        repo: https://github.com/truqu/purescript-read.git
+        version: v1.0.1
+        dependencies:
+          - maybe
+          - prelude
+          - strings
+      record:
+        repo: https://github.com/purescript/purescript-record.git
+        version: v4.0.0
+        dependencies:
+          - functions
+          - prelude
+          - unsafe-coerce
+      refined:
+        repo: https://github.com/danieljharvey/purescript-refined.git
+        version: v1.0.0
+        dependencies:
+          - argonaut
+          - effect
+          - prelude
+          - quickcheck
+          - typelevel
+      refs:
+        repo: https://github.com/purescript/purescript-refs.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - prelude
+      remotedata:
+        repo: https://github.com/krisajenkins/purescript-remotedata.git
+        version: v5.0.0
+        dependencies:
+          - bifunctors
+          - either
+          - profunctor-lenses
+      resource:
+        repo: https://github.com/joneshf/purescript-resource.git
+        version: v2.0.1
+        dependencies:
+          - aff
+          - console
+          - control
+          - effect
+          - newtype
+          - prelude
+          - psci-support
+          - refs
+      resourcet:
+        repo: https://github.com/robertdp/purescript-resourcet.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - effect
+          - foldable-traversable
+          - maybe
+          - ordered-collections
+          - parallel
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+      result:
+        repo: https://github.com/ad-si/purescript-result.git
+        version: v1.0.3
+        dependencies:
+          - either
+          - foldable-traversable
+          - prelude
+      return:
+        repo: https://github.com/ursi/purescript-return.git
+        version: v0.2.0
+        dependencies:
+          - foldable-traversable
+          - point-free
+          - prelude
+      ring-modules:
+        repo: https://github.com/f-o-a-m/purescript-ring-modules.git
+        version: v5.0.1
+        dependencies:
+          - prelude
+      routing:
+        repo: https://github.com/purescript-contrib/purescript-routing.git
+        version: v11.0.0
+        dependencies:
+          - aff
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - integers
+          - js-uri
+          - lists
+          - maybe
+          - numbers
+          - partial
+          - prelude
+          - semirings
+          - tuples
+          - validation
+          - web-html
+      routing-duplex:
+        repo: https://github.com/natefaubion/purescript-routing-duplex.git
+        version: v0.6.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - js-uri
+          - lazy
+          - numbers
+          - prelude
+          - profunctor
+          - record
+          - strings
+          - typelevel-prelude
+      run:
+        repo: https://github.com/natefaubion/purescript-run.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - free
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - tailrec
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - variant
+      safe-coerce:
+        repo: https://github.com/purescript/purescript-safe-coerce.git
+        version: v2.0.0
+        dependencies:
+          - unsafe-coerce
+      safely:
+        repo: https://github.com/paf31/purescript-safely.git
+        version: v4.0.1
+        dependencies:
+          - freet
+          - lists
+      selection-foldable:
+        repo: https://github.com/jamieyung/purescript-selection-foldable.git
+        version: v0.2.0
+        dependencies:
+          - filterable
+          - foldable-traversable
+          - maybe
+          - prelude
+      semirings:
+        repo: https://github.com/purescript/purescript-semirings.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - lists
+          - newtype
+          - prelude
+      signal:
+        repo: https://github.com/bodil/purescript-signal.git
+        version: v13.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - foldable-traversable
+          - maybe
+          - prelude
+      simple-emitter:
+        repo: https://github.com/oreshinya/purescript-simple-emitter.git
+        version: v2.0.0
+        dependencies:
+          - ordered-collections
+          - refs
+      sized-matrices:
+        repo: https://github.com/csicar/purescript-sized-matrices.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - distributive
+          - foldable-traversable
+          - maybe
+          - prelude
+          - sized-vectors
+          - strings
+          - typelevel
+          - unfoldable
+          - vectorfield
+      sized-vectors:
+        repo: https://github.com/bodil/purescript-sized-vectors.git
+        version: v5.0.2
+        dependencies:
+          - argonaut
+          - arrays
+          - distributive
+          - foldable-traversable
+          - maybe
+          - prelude
+          - quickcheck
+          - typelevel
+          - unfoldable
+      slug:
+        repo: https://github.com/thomashoneyman/purescript-slug.git
+        version: v3.0.1
+        dependencies:
+          - argonaut-codecs
+          - maybe
+          - prelude
+          - strings
+          - unicode
+      soundfonts:
+        repo: https://github.com/newlandsvalley/purescript-soundfonts.git
+        version: v4.1.0
+        dependencies:
+          - aff
+          - affjax
+          - affjax-web
+          - argonaut-core
+          - arraybuffer-types
+          - arrays
+          - b64
+          - bifunctors
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign-object
+          - http-methods
+          - integers
+          - lists
+          - maybe
+          - midi
+          - ordered-collections
+          - parallel
+          - partial
+          - prelude
+          - strings
+          - transformers
+          - tuples
+      sparse-matrices:
+        repo: https://github.com/Ebmtranceboy/purescript-sparse-matrices.git
+        version: v1.2.1
+        dependencies:
+          - console
+          - effect
+          - prelude
+          - sparse-polynomials
+      sparse-polynomials:
+        repo: https://github.com/Ebmtranceboy/purescript-sparse-polynomials.git
+        version: v1.0.5
+        dependencies:
+          - cartesian
+          - console
+          - effect
+          - ordered-collections
+          - prelude
+          - rationals
+          - tuples
+      spec:
+        repo: https://github.com/purescript-spec/purescript-spec.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - ansi
+          - avar
+          - console
+          - exceptions
+          - foldable-traversable
+          - fork
+          - now
+          - pipes
+          - prelude
+          - strings
+          - transformers
+      spec-discovery:
+        repo: https://github.com/purescript-spec/purescript-spec-discovery.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - aff-promise
+          - arrays
+          - console
+          - effect
+          - foldable-traversable
+          - node-fs
+          - prelude
+          - spec
+      spec-quickcheck:
+        repo: https://github.com/purescript-spec/purescript-spec-quickcheck.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - prelude
+          - quickcheck
+          - random
+          - spec
+      ssrs:
+        repo: https://github.com/PureFunctor/purescript-ssrs.git
+        version: v1.0.0
+        dependencies:
+          - dissect
+          - either
+          - fixed-points
+          - free
+          - lists
+          - prelude
+          - safe-coerce
+          - tailrec
+          - tuples
+          - variant
+      st:
+        repo: https://github.com/purescript/purescript-st.git
+        version: v6.0.0
+        dependencies:
+          - partial
+          - prelude
+          - tailrec
+          - unsafe-coerce
+      strictlypositiveint:
+        repo: https://github.com/jamieyung/purescript-strictlypositiveint.git
+        version: v1.0.1
+        dependencies:
+          - prelude
+      string-parsers:
+        repo: https://github.com/purescript-contrib/purescript-string-parsers.git
+        version: v8.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - prelude
+          - strings
+          - tailrec
+      strings:
+        repo: https://github.com/purescript/purescript-strings.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - enums
+          - foldable-traversable
+          - gen
+          - integers
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+          - unsafe-coerce
+      strings-extra:
+        repo: https://github.com/purescript-contrib/purescript-strings-extra.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - maybe
+          - prelude
+          - strings
+          - unicode
+      stringutils:
+        repo: https://github.com/menelaos/purescript-stringutils.git
+        version: v0.0.12
+        dependencies:
+          - arrays
+          - integers
+          - maybe
+          - partial
+          - prelude
+          - strings
+      substitute:
+        repo: https://github.com/ursi/purescript-substitute.git
+        version: v0.2.3
+        dependencies:
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - prelude
+          - return
+          - strings
+      supply:
+        repo: https://github.com/ajnsit/purescript-supply.git
+        version: v0.2.0
+        dependencies:
+          - console
+          - control
+          - effect
+          - lazy
+          - prelude
+          - refs
+          - tuples
+      tailrec:
+        repo: https://github.com/purescript/purescript-tailrec.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - effect
+          - either
+          - identity
+          - maybe
+          - partial
+          - prelude
+          - refs
+      test-unit:
+        repo: https://github.com/bodil/purescript-test-unit.git
+        version: v17.0.0
+        dependencies:
+          - aff
+          - avar
+          - effect
+          - either
+          - free
+          - js-timers
+          - lists
+          - prelude
+          - quickcheck
+          - strings
+      thermite:
+        repo: https://github.com/paf31/purescript-thermite.git
+        version: v6.3.1
+        dependencies:
+          - aff
+          - coroutines
+          - freet
+          - profunctor-lenses
+          - react
+      thermite-dom:
+        repo: https://github.com/athanclark/purescript-thermite-dom.git
+        version: v0.3.1
+        dependencies:
+          - react
+          - react-dom
+          - thermite
+          - web-html
+      these:
+        repo: https://github.com/purescript-contrib/purescript-these.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - gen
+          - lists
+          - quickcheck
+          - quickcheck-laws
+          - tuples
+      transformers:
+        repo: https://github.com/purescript/purescript-transformers.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - distributive
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - identity
+          - lazy
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      tree-rose:
+        repo: https://github.com/jordanmartinez/purescript-tree-rose.git
+        version: v4.0.2
+        dependencies:
+          - control
+          - foldable-traversable
+          - free
+          - lists
+          - maybe
+          - prelude
+          - tailrec
+      tuples:
+        repo: https://github.com/purescript/purescript-tuples.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - invariant
+          - prelude
+      two-or-more:
+        repo: https://github.com/i-am-the-slime/purescript-two-or-more.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - foldable-traversable
+          - maybe
+          - partial
+          - prelude
+          - psci-support
+          - tuples
+      type-equality:
+        repo: https://github.com/purescript/purescript-type-equality.git
+        version: v4.0.1
+        dependencies: []
+      typelevel:
+        repo: https://github.com/bodil/purescript-typelevel.git
+        version: v6.0.0
+        dependencies:
+          - partial
+          - prelude
+          - tuples
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-lists:
+        repo: https://github.com/PureFunctor/purescript-typelevel-lists.git
+        version: v2.1.0
+        dependencies:
+          - prelude
+          - tuples
+          - typelevel-peano
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-peano:
+        repo: https://github.com/csicar/purescript-typelevel-peano.git
+        version: v1.0.1
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - prelude
+          - psci-support
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-prelude:
+        repo: https://github.com/purescript/purescript-typelevel-prelude.git
+        version: v7.0.0
+        dependencies:
+          - prelude
+          - type-equality
+      typelevel-rows:
+        repo: https://github.com/jordanmartinez/purescript-typelevel-rows.git
+        version: v0.1.0
+        dependencies:
+          - prelude
+      uint:
+        repo: https://github.com/purescript-contrib/purescript-uint.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - enums
+          - gen
+          - maybe
+          - numbers
+          - prelude
+      uncurried-transformers:
+        repo: https://github.com/PureFunctor/purescript-uncurried-transformers.git
+        version: v1.1.0
+        dependencies:
+          - control
+          - effect
+          - either
+          - functions
+          - identity
+          - prelude
+          - safe-coerce
+          - tailrec
+          - transformers
+          - tuples
+      undefined-is-not-a-problem:
+        repo: https://github.com/paluh/purescript-undefined-is-not-a-problem.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - assert
+          - effect
+          - either
+          - foreign
+          - maybe
+          - newtype
+          - prelude
+          - random
+          - tuples
+          - type-equality
+          - unsafe-coerce
+      unfoldable:
+        repo: https://github.com/purescript/purescript-unfoldable.git
+        version: v6.0.0
+        dependencies:
+          - foldable-traversable
+          - maybe
+          - partial
+          - prelude
+          - tuples
+      unicode:
+        repo: https://github.com/purescript-contrib/purescript-unicode.git
+        version: v6.0.0
+        dependencies:
+          - foldable-traversable
+          - maybe
+          - strings
+      unlift:
+        repo: https://github.com/tweag/purescript-unlift.git
+        version: v1.0.1
+        dependencies:
+          - aff
+          - effect
+          - either
+          - freet
+          - identity
+          - lists
+          - maybe
+          - monad-control
+          - prelude
+          - st
+          - transformers
+          - tuples
+      unsafe-coerce:
+        repo: https://github.com/purescript/purescript-unsafe-coerce.git
+        version: v6.0.0
+        dependencies: []
+      unsafe-reference:
+        repo: https://github.com/purescript-contrib/purescript-unsafe-reference.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+      uri:
+        repo: https://github.com/purescript-contrib/purescript-uri.git
+        version: v9.0.0
+        dependencies:
+          - arrays
+          - integers
+          - js-uri
+          - numbers
+          - parsing
+          - prelude
+          - profunctor-lenses
+          - these
+          - transformers
+          - unfoldable
+      validation:
+        repo: https://github.com/purescript/purescript-validation.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - newtype
+          - prelude
+      variant:
+        repo: https://github.com/natefaubion/purescript-variant.git
+        version: v8.0.0
+        dependencies:
+          - enums
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - record
+          - tuples
+          - unsafe-coerce
+      vectorfield:
+        repo: https://github.com/csicar/purescript-vectorfield.git
+        version: v1.0.1
+        dependencies:
+          - console
+          - effect
+          - group
+          - prelude
+          - psci-support
+      versions:
+        repo: https://github.com/hdgarrood/purescript-versions.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - either
+          - foldable-traversable
+          - functions
+          - integers
+          - lists
+          - maybe
+          - orders
+          - parsing
+          - partial
+          - strings
+      web-clipboard:
+        repo: https://github.com/purescript-web/purescript-web-clipboard.git
+        version: v4.0.0
+        dependencies:
+          - web-html
+      web-cssom:
+        repo: https://github.com/purescript-web/purescript-web-cssom.git
+        version: v2.0.0
+        dependencies:
+          - web-dom
+          - web-html
+          - web-uievents
+      web-dom:
+        repo: https://github.com/purescript-web/purescript-web-dom.git
+        version: v6.0.0
+        dependencies:
+          - web-events
+      web-dom-parser:
+        repo: https://github.com/purescript-web/purescript-web-dom-parser.git
+        version: v8.0.0
+        dependencies:
+          - effect
+          - partial
+          - prelude
+          - web-dom
+      web-dom-xpath:
+        repo: https://github.com/purescript-web/purescript-web-dom-xpath.git
+        version: v3.0.0
+        dependencies:
+          - web-dom
+      web-encoding:
+        repo: https://github.com/purescript-web/purescript-web-encoding.git
+        version: v3.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - newtype
+          - prelude
+      web-events:
+        repo: https://github.com/purescript-web/purescript-web-events.git
+        version: v4.0.0
+        dependencies:
+          - datetime
+          - enums
+          - foreign
+          - nullable
+      web-fetch:
+        repo: https://github.com/purescript-web/purescript-web-fetch.git
+        version: v3.0.0
+        dependencies:
+          - effect
+          - foreign-object
+          - http-methods
+          - prelude
+          - record
+          - typelevel-prelude
+          - web-file
+          - web-promise
+          - web-streams
+      web-file:
+        repo: https://github.com/purescript-web/purescript-web-file.git
+        version: v4.0.0
+        dependencies:
+          - foreign
+          - media-types
+          - web-dom
+      web-html:
+        repo: https://github.com/purescript-web/purescript-web-html.git
+        version: v4.0.0
+        dependencies:
+          - js-date
+          - web-dom
+          - web-file
+          - web-storage
+      web-page-visibility:
+        repo: https://git.sr.ht/~toastal/purescript-web-page-visibility
+        version: v2.0.0
+        dependencies:
+          - effect
+          - enums
+          - exceptions
+          - maybe
+          - prelude
+          - strings
+          - web-events
+          - web-html
+      web-pointerevents:
+        repo: https://github.com/purescript-web/purescript-web-pointerevents.git
+        version: v1.0.0
+        dependencies:
+          - effect
+          - maybe
+          - prelude
+          - web-dom
+          - web-uievents
+      web-promise:
+        repo: https://github.com/purescript-web/purescript-web-promise.git
+        version: v3.0.0
+        dependencies:
+          - effect
+          - exceptions
+          - foldable-traversable
+          - functions
+          - maybe
+          - prelude
+      web-socket:
+        repo: https://github.com/purescript-web/purescript-web-socket.git
+        version: v4.0.0
+        dependencies:
+          - arraybuffer-types
+          - web-file
+      web-storage:
+        repo: https://github.com/purescript-web/purescript-web-storage.git
+        version: v5.0.0
+        dependencies:
+          - nullable
+          - web-events
+      web-streams:
+        repo: https://github.com/purescript-web/purescript-web-streams.git
+        version: v3.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - exceptions
+          - nullable
+          - prelude
+          - tuples
+          - web-promise
+      web-touchevents:
+        repo: https://github.com/purescript-web/purescript-web-touchevents.git
+        version: v4.0.0
+        dependencies:
+          - web-uievents
+      web-uievents:
+        repo: https://github.com/purescript-web/purescript-web-uievents.git
+        version: v4.0.0
+        dependencies:
+          - web-html
+      web-workers:
+        repo: https://github.com/gbagan/purescript-web-workers.git
+        version: v1.1.0
+        dependencies:
+          - effect
+          - foreign
+          - maybe
+          - prelude
+          - unsafe-coerce
+          - web-events
+      web-xhr:
+        repo: https://github.com/purescript-web/purescript-web-xhr.git
+        version: v5.0.0
+        dependencies:
+          - arraybuffer-types
+          - datetime
+          - http-methods
+          - web-dom
+          - web-file
+          - web-html
+      yoga-fetch:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-fetch.git
+        version: v1.0.1
+        dependencies:
+          - aff
+          - aff-promise
+          - arraybuffer-types
+          - effect
+          - foreign
+          - foreign-object
+          - newtype
+          - prelude
+          - typelevel-prelude
+          - unsafe-coerce
+      yoga-json:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-json.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - identity
+          - lists
+          - maybe
+          - nullable
+          - partial
+          - prelude
+          - record
+          - transformers
+          - typelevel-prelude
+          - variant
+      yoga-postgres:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-postgres.git
+        version: v6.0.0
+        dependencies:
+          - aff
+          - arrays
+          - datetime
+          - effect
+          - either
+          - enums
+          - foldable-traversable
+          - foreign
+          - integers
+          - maybe
+          - nullable
+          - prelude
+          - transformers
+          - unsafe-coerce
+  extra_packages: {}
+packages:
+  aff:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-aff.git
+    rev: 2d44d9f9d0d6a416a4103fba2fb39e5160f80e36
+    dependencies:
+      - datetime
+      - effect
+      - exceptions
+      - functions
+      - parallel
+      - transformers
+      - unsafe-coerce
+  arrays:
+    type: git
+    url: https://github.com/purescript/purescript-arrays.git
+    rev: d20bae2f76db6cf29b7b75e26e82b8a54c32295e
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - maybe
+      - nonempty
+      - partial
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  avar:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-avar.git
+    rev: d00f5784d9cc8f079babd62740f5c52b87e5caa5
+    dependencies:
+      - aff
+      - effect
+      - either
+      - exceptions
+      - functions
+      - maybe
+  bifunctors:
+    type: git
+    url: https://github.com/purescript/purescript-bifunctors.git
+    rev: 16ba2fb6dd7f05528ebd9e2f9ca3a068b325e5b3
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  catenable-lists:
+    type: git
+    url: https://github.com/purescript/purescript-catenable-lists.git
+    rev: 09abe1f4888bc00841ad2b59e56a9e7ce7ebd4ab
+    dependencies:
+      - control
+      - foldable-traversable
+      - lists
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  console:
+    type: git
+    url: https://github.com/purescript/purescript-console.git
+    rev: 3b83d7b792d03872afeea5e62b4f686ab0f09842
+    dependencies:
+      - effect
+      - prelude
+  const:
+    type: git
+    url: https://github.com/purescript/purescript-const.git
+    rev: ab9570cf2b6e67f7e441178211db1231cfd75c37
+    dependencies:
+      - invariant
+      - newtype
+      - prelude
+  contravariant:
+    type: git
+    url: https://github.com/purescript/purescript-contravariant.git
+    rev: 9ad3e105b8855bcc25f4e0893c784789d05a58de
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  control:
+    type: git
+    url: https://github.com/purescript/purescript-control.git
+    rev: a6033808790879a17b2729e73747a9ed3fb2264e
+    dependencies:
+      - newtype
+      - prelude
+  datetime:
+    type: git
+    url: https://github.com/purescript/purescript-datetime.git
+    rev: a6a0cf1b0324964ad1854bc3377ed8766ba90e6f
+    dependencies:
+      - bifunctors
+      - control
+      - either
+      - enums
+      - foldable-traversable
+      - functions
+      - gen
+      - integers
+      - lists
+      - maybe
+      - newtype
+      - numbers
+      - ordered-collections
+      - partial
+      - prelude
+      - tuples
+  distributive:
+    type: git
+    url: https://github.com/purescript/purescript-distributive.git
+    rev: 6005e513642e855ebf6f884d24a35c2803ca252a
+    dependencies:
+      - identity
+      - newtype
+      - prelude
+      - tuples
+      - type-equality
+  effect:
+    type: git
+    url: https://github.com/purescript/purescript-effect.git
+    rev: a192ddb923027d426d6ea3d8deb030c9aa7c7dda
+    dependencies:
+      - prelude
+  either:
+    type: git
+    url: https://github.com/purescript/purescript-either.git
+    rev: af655a04ed2fd694b6688af39ee20d7907ad0763
+    dependencies:
+      - control
+      - invariant
+      - maybe
+      - prelude
+  enums:
+    type: git
+    url: https://github.com/purescript/purescript-enums.git
+    rev: bae47961d401f9acf88da38f32e87403e5f0cf2f
+    dependencies:
+      - control
+      - either
+      - gen
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tuples
+      - unfoldable
+  exceptions:
+    type: git
+    url: https://github.com/purescript/purescript-exceptions.git
+    rev: afab3c07c820bb49b6c5be50049db46a964a6161
+    dependencies:
+      - effect
+      - either
+      - maybe
+      - prelude
+  exists:
+    type: git
+    url: https://github.com/purescript/purescript-exists.git
+    rev: f765b4ace7869c27b9c05949e18c843881f9173b
+    dependencies:
+      - unsafe-coerce
+  foldable-traversable:
+    type: git
+    url: https://github.com/purescript/purescript-foldable-traversable.git
+    rev: b3926f870532d287ea59e2d5cd3873b81ef2a93a
+    dependencies:
+      - bifunctors
+      - const
+      - control
+      - either
+      - functors
+      - identity
+      - maybe
+      - newtype
+      - orders
+      - prelude
+      - tuples
+  free:
+    type: git
+    url: https://github.com/purescript/purescript-free.git
+    rev: e2d8fa8023a864363857834e11393483bced5e38
+    dependencies:
+      - catenable-lists
+      - control
+      - distributive
+      - either
+      - exists
+      - foldable-traversable
+      - invariant
+      - lazy
+      - maybe
+      - prelude
+      - tailrec
+      - transformers
+      - tuples
+      - unsafe-coerce
+  functions:
+    type: git
+    url: https://github.com/purescript/purescript-functions.git
+    rev: f626f20580483977c5b27a01aac6471e28aff367
+    dependencies:
+      - prelude
+  functors:
+    type: git
+    url: https://github.com/purescript/purescript-functors.git
+    rev: 022ffd7a2a7ec12080314f3d217b400674a247b4
+    dependencies:
+      - bifunctors
+      - const
+      - contravariant
+      - control
+      - distributive
+      - either
+      - invariant
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - tuples
+      - unsafe-coerce
+  gen:
+    type: git
+    url: https://github.com/purescript/purescript-gen.git
+    rev: 9fbcc2a1261c32e30d79c5418edef4d96fe76931
+    dependencies:
+      - either
+      - foldable-traversable
+      - identity
+      - maybe
+      - newtype
+      - nonempty
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  identity:
+    type: git
+    url: https://github.com/purescript/purescript-identity.git
+    rev: ef6768f8a52ab0bc943a85f5761ba07c257f639f
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  integers:
+    type: git
+    url: https://github.com/purescript/purescript-integers.git
+    rev: 54d712b25c594833083d15dc9ff2418eb9c52822
+    dependencies:
+      - maybe
+      - numbers
+      - prelude
+  invariant:
+    type: git
+    url: https://github.com/purescript/purescript-invariant.git
+    rev: 1d2a196d51e90623adb88496c2cfd759c6736894
+    dependencies:
+      - control
+      - prelude
+  js-timers:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-js-timers.git
+    rev: 7cb728b3e6dc29f355143617e6e9ac770ecd9273
+    dependencies:
+      - effect
+  lazy:
+    type: git
+    url: https://github.com/purescript/purescript-lazy.git
+    rev: 48347841226b27af5205a1a8ec71e27a93ce86fd
+    dependencies:
+      - control
+      - foldable-traversable
+      - invariant
+      - prelude
+  lcg:
+    type: git
+    url: https://github.com/purescript/purescript-lcg.git
+    rev: 67c6c6483a563a59ae036d9dca0f1be2835326a5
+    dependencies:
+      - effect
+      - integers
+      - maybe
+      - partial
+      - prelude
+      - random
+  lists:
+    type: git
+    url: https://github.com/purescript/purescript-lists.git
+    rev: b113451e5b41cad87d669a3165f955c71cd863e2
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - lazy
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  maybe:
+    type: git
+    url: https://github.com/purescript/purescript-maybe.git
+    rev: c6f98ac1088766287106c5d9c8e30e7648d36786
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  newtype:
+    type: git
+    url: https://github.com/purescript/purescript-newtype.git
+    rev: 29d8e6dd77aec2c975c948364ec3faf26e14ee7b
+    dependencies:
+      - prelude
+      - safe-coerce
+  nonempty:
+    type: git
+    url: https://github.com/purescript/purescript-nonempty.git
+    rev: 28150ecc7419238b187abd609a92a645273348bb
+    dependencies:
+      - control
+      - foldable-traversable
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  numbers:
+    type: git
+    url: https://github.com/purescript/purescript-numbers.git
+    rev: 2a53528f18f9415334bae28e7bb3cf3be86342c2
+    dependencies:
+      - functions
+      - maybe
+  ordered-collections:
+    type: git
+    url: https://github.com/purescript/purescript-ordered-collections.git
+    rev: 9826b7632d0d0a691173bde308a634195f42a419
+    dependencies:
+      - arrays
+      - foldable-traversable
+      - gen
+      - lists
+      - maybe
+      - partial
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+  orders:
+    type: git
+    url: https://github.com/purescript/purescript-orders.git
+    rev: f86db621ec5eef1274145f8b1fd8ebbfe0ed4a2c
+    dependencies:
+      - newtype
+      - prelude
+  parallel:
+    type: git
+    url: https://github.com/purescript/purescript-parallel.git
+    rev: 85290dca837771ac4870071008c933d315ef678f
+    dependencies:
+      - control
+      - effect
+      - either
+      - foldable-traversable
+      - functors
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - refs
+      - transformers
+  partial:
+    type: git
+    url: https://github.com/purescript/purescript-partial.git
+    rev: 0fa0646f5ea1ec5f0c46dcbd770c705a6c9ad3ec
+    dependencies: []
+  prelude:
+    type: git
+    url: https://github.com/purescript/purescript-prelude.git
+    rev: 32787f4399c92459c41602131a5858559eb868c5
+    dependencies: []
+  profunctor:
+    type: git
+    url: https://github.com/purescript/purescript-profunctor.git
+    rev: 0a966a14e7b0c827d44657dc1710cdc712d2e034
+    dependencies:
+      - control
+      - distributive
+      - either
+      - exists
+      - invariant
+      - newtype
+      - prelude
+      - tuples
+  quickcheck:
+    type: git
+    url: https://github.com/purescript/purescript-quickcheck.git
+    rev: bf5029f97e6c0d7552d3a08d2ab793a19e2c5e3d
+    dependencies:
+      - arrays
+      - console
+      - control
+      - effect
+      - either
+      - enums
+      - exceptions
+      - foldable-traversable
+      - gen
+      - identity
+      - integers
+      - lazy
+      - lcg
+      - lists
+      - maybe
+      - newtype
+      - nonempty
+      - numbers
+      - partial
+      - prelude
+      - record
+      - st
+      - strings
+      - tailrec
+      - transformers
+      - tuples
+      - unfoldable
+  random:
+    type: git
+    url: https://github.com/purescript/purescript-random.git
+    rev: 9540bc965a9596da02fefd9949418bb19c92533a
+    dependencies:
+      - effect
+      - integers
+  record:
+    type: git
+    url: https://github.com/purescript/purescript-record.git
+    rev: c89cd1ada6b636692571fc374196b1c39c4c9f70
+    dependencies:
+      - functions
+      - prelude
+      - unsafe-coerce
+  refs:
+    type: git
+    url: https://github.com/purescript/purescript-refs.git
+    rev: f8e6216da4cb9309fde1f20cd6f69ac3a3b7f9e8
+    dependencies:
+      - effect
+      - prelude
+  safe-coerce:
+    type: git
+    url: https://github.com/purescript/purescript-safe-coerce.git
+    rev: 7fa799ae80a38b8d948efcb52608e58e198b3da7
+    dependencies:
+      - unsafe-coerce
+  st:
+    type: git
+    url: https://github.com/purescript/purescript-st.git
+    rev: 2cc7ae1c3318a303378c4a9f3fa0f10ee7cc3589
+    dependencies:
+      - partial
+      - prelude
+      - tailrec
+      - unsafe-coerce
+  strings:
+    type: git
+    url: https://github.com/purescript/purescript-strings.git
+    rev: 4bc6954448d056f8aa7a659695a6ad60ad4fdf19
+    dependencies:
+      - arrays
+      - control
+      - either
+      - enums
+      - foldable-traversable
+      - gen
+      - integers
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  tailrec:
+    type: git
+    url: https://github.com/purescript/purescript-tailrec.git
+    rev: 5e2104aa734b31a17074cc805bf087d72b65afd1
+    dependencies:
+      - bifunctors
+      - effect
+      - either
+      - identity
+      - maybe
+      - partial
+      - prelude
+      - refs
+  test-unit:
+    type: git
+    url: https://github.com/bodil/purescript-test-unit.git
+    rev: 3112d7ebe06d467238058a6384dc75ffd960d335
+    dependencies:
+      - aff
+      - avar
+      - effect
+      - either
+      - free
+      - js-timers
+      - lists
+      - prelude
+      - quickcheck
+      - strings
+  transformers:
+    type: git
+    url: https://github.com/purescript/purescript-transformers.git
+    rev: be72ab52357d9a665cbf93d73ba1c07c4b0957ee
+    dependencies:
+      - control
+      - distributive
+      - effect
+      - either
+      - exceptions
+      - foldable-traversable
+      - identity
+      - lazy
+      - maybe
+      - newtype
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  tuples:
+    type: git
+    url: https://github.com/purescript/purescript-tuples.git
+    rev: 4f52da2729b448c8564369378f1232d8d2dc1d8b
+    dependencies:
+      - control
+      - invariant
+      - prelude
+  type-equality:
+    type: git
+    url: https://github.com/purescript/purescript-type-equality.git
+    rev: 0525b7d39e0fbd81b4209518139fb8ab02695774
+    dependencies: []
+  unfoldable:
+    type: git
+    url: https://github.com/purescript/purescript-unfoldable.git
+    rev: 493dfe04ed590e20d8f69079df2f58486882748d
+    dependencies:
+      - foldable-traversable
+      - maybe
+      - partial
+      - prelude
+      - tuples
+  unsafe-coerce:
+    type: git
+    url: https://github.com/purescript/purescript-unsafe-coerce.git
+    rev: ab956f82e66e633f647fb3098e8ddd3ec58d689f
+    dependencies: []
+  validation:
+    type: git
+    url: https://github.com/purescript/purescript-validation.git
+    rev: a3d9ec2176a7a808d70a01fa7e6f16d10e05429a
+    dependencies:
+      - bifunctors
+      - control
+      - either
+      - foldable-traversable
+      - newtype
+      - prelude

--- a/exercises/chapter7/spago.yaml
+++ b/exercises/chapter7/spago.yaml
@@ -1,0 +1,21 @@
+package:
+  dependencies:
+    - arrays
+    - console
+    - effect
+    - either
+    - foldable-traversable
+    - integers
+    - lists
+    - maybe
+    - prelude
+    - strings
+    - test-unit
+    - transformers
+    - tuples
+    - validation
+  name: my-project
+workspace:
+  extraPackages: {}
+  packageSet:
+    url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json

--- a/exercises/chapter7/spago.yaml
+++ b/exercises/chapter7/spago.yaml
@@ -18,4 +18,4 @@ package:
 workspace:
   extraPackages: {}
   packageSet:
-    url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
+    registry: 10.0.0

--- a/exercises/chapter8/spago.lock
+++ b/exercises/chapter8/spago.lock
@@ -1,0 +1,4302 @@
+workspace:
+  packages:
+    my-project:
+      path: ./
+      dependencies:
+        - arrays
+        - console
+        - control
+        - effect
+        - either
+        - exceptions
+        - foldable-traversable
+        - integers
+        - lists
+        - maybe
+        - numbers
+        - prelude
+        - random
+        - react-basic
+        - react-basic-dom
+        - react-basic-hooks
+        - st
+        - strings
+        - test-unit
+        - tuples
+        - validation
+        - web-dom
+        - web-html
+      test_dependencies: []
+      build_plan:
+        - aff
+        - aff-promise
+        - arrays
+        - avar
+        - bifunctors
+        - catenable-lists
+        - console
+        - const
+        - contravariant
+        - control
+        - datetime
+        - distributive
+        - effect
+        - either
+        - enums
+        - exceptions
+        - exists
+        - foldable-traversable
+        - foreign
+        - foreign-object
+        - free
+        - functions
+        - functors
+        - gen
+        - identity
+        - indexed-monad
+        - integers
+        - invariant
+        - js-date
+        - js-timers
+        - lazy
+        - lcg
+        - lists
+        - maybe
+        - media-types
+        - newtype
+        - nonempty
+        - now
+        - nullable
+        - numbers
+        - ordered-collections
+        - orders
+        - parallel
+        - partial
+        - prelude
+        - profunctor
+        - quickcheck
+        - random
+        - react-basic
+        - react-basic-dom
+        - react-basic-hooks
+        - record
+        - refs
+        - safe-coerce
+        - st
+        - strings
+        - tailrec
+        - test-unit
+        - transformers
+        - tuples
+        - type-equality
+        - typelevel-prelude
+        - unfoldable
+        - unsafe-coerce
+        - unsafe-reference
+        - validation
+        - web-dom
+        - web-events
+        - web-file
+        - web-html
+        - web-storage
+  package_set:
+    address:
+      url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
+    compiler: ">=0.15.0 <0.16.0"
+    content:
+      ace:
+        repo: https://github.com/purescript-contrib/purescript-ace.git
+        version: v9.0.0
+        dependencies:
+          - arrays
+          - effect
+          - foreign
+          - nullable
+          - prelude
+          - web-html
+          - web-uievents
+      aff:
+        repo: https://github.com/purescript-contrib/purescript-aff.git
+        version: v7.0.0
+        dependencies:
+          - datetime
+          - effect
+          - exceptions
+          - functions
+          - parallel
+          - transformers
+          - unsafe-coerce
+      aff-bus:
+        repo: https://github.com/purescript-contrib/purescript-aff-bus.git
+        version: v6.0.0
+        dependencies:
+          - aff
+          - avar
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - lists
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+      aff-coroutines:
+        repo: https://github.com/purescript-contrib/purescript-aff-coroutines.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - avar
+          - coroutines
+          - effect
+      aff-promise:
+        repo: https://github.com/nwolverson/purescript-aff-promise.git
+        version: v4.0.0
+        dependencies:
+          - aff
+          - foreign
+      aff-retry:
+        repo: https://github.com/Unisay/purescript-aff-retry.git
+        version: v2.0.0
+        dependencies:
+          - aff
+          - arrays
+          - datetime
+          - effect
+          - either
+          - exceptions
+          - integers
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - random
+          - transformers
+      affjax:
+        repo: https://github.com/purescript-contrib/purescript-affjax.git
+        version: v13.0.0
+        dependencies:
+          - aff
+          - argonaut-core
+          - arraybuffer-types
+          - foreign
+          - form-urlencoded
+          - http-methods
+          - integers
+          - media-types
+          - nullable
+          - refs
+          - unsafe-coerce
+          - web-xhr
+      affjax-node:
+        repo: https://github.com/purescript-contrib/purescript-affjax-node.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - affjax
+          - either
+          - maybe
+          - prelude
+      affjax-web:
+        repo: https://github.com/purescript-contrib/purescript-affjax-web.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - affjax
+          - either
+          - maybe
+          - prelude
+      ansi:
+        repo: https://github.com/hdgarrood/purescript-ansi.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - lists
+          - strings
+      argonaut:
+        repo: https://github.com/purescript-contrib/purescript-argonaut.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - argonaut-traversals
+      argonaut-codecs:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-codecs.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-core
+          - arrays
+          - effect
+          - foreign-object
+          - identity
+          - integers
+          - maybe
+          - nonempty
+          - ordered-collections
+          - prelude
+          - record
+      argonaut-core:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-core.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - foreign-object
+          - functions
+          - gen
+          - maybe
+          - nonempty
+          - prelude
+          - strings
+          - tailrec
+      argonaut-generic:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-generic.git
+        version: v8.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - prelude
+          - record
+      argonaut-traversals:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-traversals.git
+        version: v10.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - profunctor-lenses
+      argparse-basic:
+        repo: https://github.com/natefaubion/purescript-argparse-basic.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - record
+          - strings
+          - tuples
+          - unfoldable
+      arraybuffer:
+        repo: https://github.com/purescript-contrib/purescript-arraybuffer.git
+        version: v13.0.0
+        dependencies:
+          - arraybuffer-types
+          - arrays
+          - effect
+          - float32
+          - functions
+          - gen
+          - maybe
+          - nullable
+          - prelude
+          - tailrec
+          - uint
+          - unfoldable
+      arraybuffer-builder:
+        repo: https://github.com/jamesdbrock/purescript-arraybuffer-builder.git
+        version: v3.0.1
+        dependencies:
+          - arraybuffer
+          - arraybuffer-types
+          - effect
+          - float32
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - transformers
+          - uint
+      arraybuffer-types:
+        repo: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
+        version: v3.0.2
+        dependencies: []
+      arrays:
+        repo: https://github.com/purescript/purescript-arrays.git
+        version: v7.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - foldable-traversable
+          - maybe
+          - nonempty
+          - partial
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - unfoldable
+          - unsafe-coerce
+      arrays-zipper:
+        repo: https://github.com/JordanMartinez/purescript-arrays-zipper.git
+        version: v2.0.1
+        dependencies:
+          - arrays
+          - control
+          - quickcheck
+      ask:
+        repo: https://github.com/Mateiadrielrafael/purescript-ask.git
+        version: v1.0.0
+        dependencies:
+          - unsafe-coerce
+      assert:
+        repo: https://github.com/purescript/purescript-assert.git
+        version: v6.0.0
+        dependencies:
+          - console
+          - effect
+          - prelude
+      avar:
+        repo: https://github.com/purescript-contrib/purescript-avar.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - exceptions
+          - functions
+          - maybe
+      b64:
+        repo: https://github.com/menelaos/purescript-b64.git
+        version: v0.0.8
+        dependencies:
+          - arraybuffer-types
+          - either
+          - encoding
+          - enums
+          - exceptions
+          - functions
+          - partial
+          - prelude
+          - strings
+      barlow-lens:
+        repo: https://github.com/sigma-andex/purescript-barlow-lens.git
+        version: v0.9.0
+        dependencies:
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - profunctor-lenses
+          - tuples
+          - typelevel-prelude
+      bifunctors:
+        repo: https://github.com/purescript/purescript-bifunctors.git
+        version: v6.0.0
+        dependencies:
+          - const
+          - either
+          - newtype
+          - prelude
+          - tuples
+      bigints:
+        repo: https://github.com/sharkdp/purescript-bigints.git
+        version: v7.0.1
+        dependencies:
+          - integers
+          - maybe
+          - strings
+      bower-json:
+        repo: https://github.com/klntsky/purescript-bower-json.git
+        version: v3.0.0
+        dependencies:
+          - argonaut-codecs
+          - arrays
+          - either
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - newtype
+          - prelude
+          - tuples
+      call-by-name:
+        repo: https://github.com/natefaubion/purescript-call-by-name.git
+        version: v4.0.1
+        dependencies:
+          - control
+          - either
+          - lazy
+          - maybe
+          - unsafe-coerce
+      canvas:
+        repo: https://github.com/purescript-web/purescript-canvas.git
+        version: v6.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - exceptions
+          - functions
+          - maybe
+      canvas-action:
+        repo: https://github.com/artemisSystem/purescript-canvas-action.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - arrays
+          - canvas
+          - colors
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - maybe
+          - numbers
+          - polymorphic-vectors
+          - prelude
+          - refs
+          - run
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-html
+      cartesian:
+        repo: https://github.com/Ebmtranceboy/purescript-cartesian.git
+        version: v1.0.6
+        dependencies:
+          - console
+          - effect
+          - integers
+          - psci-support
+      catenable-lists:
+        repo: https://github.com/purescript/purescript-catenable-lists.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - lists
+          - maybe
+          - prelude
+          - tuples
+          - unfoldable
+      channel:
+        repo: https://github.com/ConnorDillon/purescript-channel.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - assert
+          - avar
+          - console
+          - contravariant
+          - control
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - lazy
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      checked-exceptions:
+        repo: https://github.com/natefaubion/purescript-checked-exceptions.git
+        version: v3.1.1
+        dependencies:
+          - prelude
+          - transformers
+          - variant
+      codec:
+        repo: https://github.com/garyb/purescript-codec.git
+        version: v5.0.0
+        dependencies:
+          - profunctor
+          - transformers
+      codec-argonaut:
+        repo: https://github.com/garyb/purescript-codec-argonaut.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-core
+          - codec
+          - ordered-collections
+          - type-equality
+          - variant
+      colors:
+        repo: https://github.com/purescript-contrib/purescript-colors.git
+        version: v7.0.1
+        dependencies:
+          - arrays
+          - integers
+          - lists
+          - numbers
+          - partial
+          - strings
+      concurrent-queues:
+        repo: https://github.com/purescript-contrib/purescript-concurrent-queues.git
+        version: v3.0.0
+        dependencies:
+          - aff
+          - avar
+          - effect
+      console:
+        repo: https://github.com/purescript/purescript-console.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - prelude
+      const:
+        repo: https://github.com/purescript/purescript-const.git
+        version: v6.0.0
+        dependencies:
+          - invariant
+          - newtype
+          - prelude
+      contravariant:
+        repo: https://github.com/purescript/purescript-contravariant.git
+        version: v6.0.0
+        dependencies:
+          - const
+          - either
+          - newtype
+          - prelude
+          - tuples
+      control:
+        repo: https://github.com/purescript/purescript-control.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      convertable-options:
+        repo: https://github.com/natefaubion/purescript-convertable-options.git
+        version: v1.0.0
+        dependencies:
+          - console
+          - effect
+          - maybe
+          - record
+      coroutines:
+        repo: https://github.com/purescript-contrib/purescript-coroutines.git
+        version: v7.0.0
+        dependencies:
+          - freet
+          - parallel
+          - profunctor
+      css:
+        repo: https://github.com/purescript-contrib/purescript-css.git
+        version: v6.0.0
+        dependencies:
+          - colors
+          - console
+          - effect
+          - nonempty
+          - profunctor
+          - strings
+          - these
+          - transformers
+      datetime:
+        repo: https://github.com/purescript/purescript-datetime.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - either
+          - enums
+          - foldable-traversable
+          - functions
+          - gen
+          - integers
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - ordered-collections
+          - partial
+          - prelude
+          - tuples
+      datetime-parsing:
+        repo: https://github.com/flounders/purescript-datetime-parsing.git
+        version: v0.2.0
+        dependencies:
+          - arrays
+          - datetime
+          - either
+          - enums
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - numbers
+          - parsing
+          - prelude
+          - strings
+          - unicode
+      debug:
+        repo: https://github.com/garyb/purescript-debug.git
+        version: v6.0.0
+        dependencies:
+          - functions
+          - prelude
+      decimals:
+        repo: https://github.com/sharkdp/purescript-decimals.git
+        version: v7.0.0
+        dependencies:
+          - maybe
+      dissect:
+        repo: https://github.com/PureFunctor/purescript-dissect.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - foreign-object
+          - functors
+          - newtype
+          - partial
+          - prelude
+          - tailrec
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - variant
+      distributive:
+        repo: https://github.com/purescript/purescript-distributive.git
+        version: v6.0.0
+        dependencies:
+          - identity
+          - newtype
+          - prelude
+          - tuples
+          - type-equality
+      dodo-printer:
+        repo: https://github.com/natefaubion/purescript-dodo-printer.git
+        version: v2.2.0
+        dependencies:
+          - aff
+          - ansi
+          - avar
+          - console
+          - effect
+          - foldable-traversable
+          - lists
+          - maybe
+          - minibench
+          - node-child-process
+          - node-fs-aff
+          - node-process
+          - psci-support
+          - strings
+      dom-indexed:
+        repo: https://github.com/purescript-halogen/purescript-dom-indexed.git
+        version: v11.0.0
+        dependencies:
+          - media-types
+          - prelude
+          - web-clipboard
+          - web-pointerevents
+          - web-touchevents
+      droplet:
+        repo: https://github.com/easafe/purescript-droplet.git
+        version: v0.4.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - bigints
+          - datetime
+          - debug
+          - effect
+          - either
+          - enums
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - integers
+          - maybe
+          - newtype
+          - nullable
+          - ordered-collections
+          - partial
+          - prelude
+          - profunctor
+          - record
+          - spec
+          - strings
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+      dynamic-buffer:
+        repo: https://github.com/kritzcreek/purescript-dynamic-buffer.git
+        version: v3.0.1
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - refs
+      effect:
+        repo: https://github.com/purescript/purescript-effect.git
+        version: v4.0.0
+        dependencies:
+          - prelude
+      either:
+        repo: https://github.com/purescript/purescript-either.git
+        version: v6.1.0
+        dependencies:
+          - control
+          - invariant
+          - maybe
+          - prelude
+      elmish:
+        repo: https://github.com/collegevine/purescript-elmish.git
+        version: v0.8.1
+        dependencies:
+          - aff
+          - argonaut-core
+          - arrays
+          - bifunctors
+          - console
+          - debug
+          - effect
+          - either
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - functions
+          - integers
+          - js-date
+          - maybe
+          - nullable
+          - partial
+          - prelude
+          - refs
+          - typelevel-prelude
+          - undefined-is-not-a-problem
+          - unsafe-coerce
+          - web-dom
+          - web-html
+      elmish-enzyme:
+        repo: https://github.com/collegevine/purescript-elmish-enzyme.git
+        version: v0.1.1
+        dependencies:
+          - aff
+          - aff-promise
+          - arrays
+          - console
+          - debug
+          - effect
+          - elmish
+          - foldable-traversable
+          - foreign
+          - functions
+          - prelude
+          - transformers
+          - unsafe-coerce
+      elmish-hooks:
+        repo: https://github.com/collegevine/purescript-elmish-hooks.git
+        version: v0.8.2
+        dependencies:
+          - aff
+          - debug
+          - elmish
+          - maybe
+          - prelude
+          - tuples
+          - undefined-is-not-a-problem
+      elmish-html:
+        repo: https://github.com/collegevine/purescript-elmish-html.git
+        version: v0.7.1
+        dependencies:
+          - effect
+          - elmish
+          - foreign
+          - foreign-object
+          - prelude
+          - record
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-html
+      email-validate:
+        repo: https://github.com/cdepillabout/purescript-email-validate.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - string-parsers
+          - transformers
+      encoding:
+        repo: https://github.com/menelaos/purescript-encoding.git
+        version: v0.0.8
+        dependencies:
+          - arraybuffer-types
+          - either
+          - exceptions
+          - functions
+          - prelude
+      enums:
+        repo: https://github.com/purescript/purescript-enums.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - either
+          - gen
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tuples
+          - unfoldable
+      exceptions:
+        repo: https://github.com/purescript/purescript-exceptions.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - either
+          - maybe
+          - prelude
+      exists:
+        repo: https://github.com/purescript/purescript-exists.git
+        version: v6.0.0
+        dependencies:
+          - unsafe-coerce
+      exitcodes:
+        repo: https://github.com/Risto-Stevcev/purescript-exitcodes.git
+        version: v4.0.0
+        dependencies:
+          - enums
+      expect-inferred:
+        repo: https://github.com/justinwoo/purescript-expect-inferred.git
+        version: v3.0.0
+        dependencies:
+          - prelude
+          - typelevel-prelude
+      fast-vect:
+        repo: https://github.com/sigma-andex/purescript-fast-vect.git
+        version: v0.7.0
+        dependencies:
+          - arrays
+          - filterable
+          - foldable-traversable
+          - lists
+          - maybe
+          - ordered-collections
+          - prelude
+          - profunctor
+          - tuples
+          - unfoldable
+      filterable:
+        repo: https://github.com/purescript/purescript-filterable.git
+        version: v5.0.0
+        dependencies:
+          - arrays
+          - either
+          - foldable-traversable
+          - identity
+          - lists
+          - ordered-collections
+      fixed-points:
+        repo: https://github.com/purescript-contrib/purescript-fixed-points.git
+        version: v7.0.0
+        dependencies:
+          - exists
+          - newtype
+          - prelude
+          - transformers
+      fixed-precision:
+        repo: https://github.com/lumihq/purescript-fixed-precision.git
+        version: v5.0.0
+        dependencies:
+          - arrays
+          - bigints
+          - control
+          - integers
+          - maybe
+          - numbers
+          - partial
+          - prelude
+          - strings
+      flame:
+        repo: https://github.com/easafe/purescript-flame.git
+        version: v1.2.0
+        dependencies:
+          - aff
+          - argonaut-codecs
+          - argonaut-core
+          - argonaut-generic
+          - arrays
+          - bifunctors
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - maybe
+          - newtype
+          - nullable
+          - partial
+          - prelude
+          - random
+          - refs
+          - spec
+          - strings
+          - tuples
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-html
+          - web-uievents
+      float32:
+        repo: https://github.com/purescript-contrib/purescript-float32.git
+        version: v2.0.0
+        dependencies:
+          - gen
+          - maybe
+          - prelude
+      foldable-traversable:
+        repo: https://github.com/purescript/purescript-foldable-traversable.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - const
+          - control
+          - either
+          - functors
+          - identity
+          - maybe
+          - newtype
+          - orders
+          - prelude
+          - tuples
+      foreign:
+        repo: https://github.com/purescript/purescript-foreign.git
+        version: v7.0.0
+        dependencies:
+          - either
+          - functions
+          - identity
+          - integers
+          - lists
+          - maybe
+          - prelude
+          - strings
+          - transformers
+      foreign-object:
+        repo: https://github.com/purescript/purescript-foreign-object.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - functions
+          - gen
+          - lists
+          - maybe
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - typelevel-prelude
+          - unfoldable
+      foreign-readwrite:
+        repo: https://github.com/artemisSystem/purescript-foreign-readwrite.git
+        version: v3.0.0
+        dependencies:
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - record
+          - safe-coerce
+          - transformers
+          - unsafe-coerce
+      fork:
+        repo: https://github.com/purescript-contrib/purescript-fork.git
+        version: v6.0.0
+        dependencies:
+          - aff
+      form-urlencoded:
+        repo: https://github.com/purescript-contrib/purescript-form-urlencoded.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - js-uri
+          - maybe
+          - newtype
+          - prelude
+          - strings
+          - tuples
+      formatters:
+        repo: https://github.com/purescript-contrib/purescript-formatters.git
+        version: v7.0.0
+        dependencies:
+          - datetime
+          - fixed-points
+          - lists
+          - numbers
+          - parsing
+          - prelude
+          - transformers
+      free:
+        repo: https://github.com/purescript/purescript-free.git
+        version: v7.0.0
+        dependencies:
+          - catenable-lists
+          - control
+          - distributive
+          - either
+          - exists
+          - foldable-traversable
+          - invariant
+          - lazy
+          - maybe
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+      freeap:
+        repo: https://github.com/ethul/purescript-freeap.git
+        version: v7.0.0
+        dependencies:
+          - const
+          - exists
+          - gen
+          - lists
+      freet:
+        repo: https://github.com/purescript-contrib/purescript-freet.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - bifunctors
+          - effect
+          - either
+          - exists
+          - free
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      functions:
+        repo: https://github.com/purescript/purescript-functions.git
+        version: v6.0.0
+        dependencies:
+          - prelude
+      functors:
+        repo: https://github.com/purescript/purescript-functors.git
+        version: v5.0.0
+        dependencies:
+          - bifunctors
+          - const
+          - contravariant
+          - control
+          - distributive
+          - either
+          - invariant
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - tuples
+          - unsafe-coerce
+      fuzzy:
+        repo: https://github.com/citizennet/purescript-fuzzy.git
+        version: v0.4.0
+        dependencies:
+          - foldable-traversable
+          - foreign-object
+          - newtype
+          - ordered-collections
+          - prelude
+          - rationals
+          - strings
+          - tuples
+      gen:
+        repo: https://github.com/purescript/purescript-gen.git
+        version: v4.0.0
+        dependencies:
+          - either
+          - foldable-traversable
+          - identity
+          - maybe
+          - newtype
+          - nonempty
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      generate-values:
+        repo: https://github.com/jordanmartinez/purescript-generate-values.git
+        version: v1.0.1
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - enums
+          - foldable-traversable
+          - gen
+          - identity
+          - integers
+          - lcg
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - partial
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      geometry-plane:
+        repo: https://github.com/Ebmtranceboy/purescript-geometry-plane.git
+        version: v1.0.3
+        dependencies:
+          - console
+          - effect
+          - psci-support
+          - sparse-polynomials
+      github-actions-toolkit:
+        repo: https://github.com/purescript-contrib/purescript-github-actions-toolkit.git
+        version: v0.5.0
+        dependencies:
+          - aff
+          - aff-promise
+          - effect
+          - foreign-object
+          - node-buffer
+          - node-path
+          - node-streams
+          - nullable
+          - transformers
+      graphs:
+        repo: https://github.com/purescript/purescript-graphs.git
+        version: v8.0.0
+        dependencies:
+          - catenable-lists
+          - ordered-collections
+      group:
+        repo: https://github.com/morganthomas/purescript-group.git
+        version: v4.1.1
+        dependencies:
+          - lists
+      halogen:
+        repo: https://github.com/purescript-halogen/purescript-halogen.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - avar
+          - console
+          - const
+          - dom-indexed
+          - effect
+          - foreign
+          - fork
+          - free
+          - freeap
+          - halogen-subscriptions
+          - halogen-vdom
+          - media-types
+          - nullable
+          - ordered-collections
+          - parallel
+          - profunctor
+          - transformers
+          - unsafe-coerce
+          - unsafe-reference
+          - web-file
+          - web-uievents
+      halogen-css:
+        repo: https://github.com/purescript-halogen/purescript-halogen-css.git
+        version: v10.0.0
+        dependencies:
+          - css
+          - halogen
+      halogen-formless:
+        repo: https://github.com/thomashoneyman/purescript-halogen-formless.git
+        version: v4.0.0
+        dependencies:
+          - convertable-options
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - halogen
+          - heterogeneous
+          - maybe
+          - prelude
+          - record
+          - safe-coerce
+          - type-equality
+          - unsafe-coerce
+          - unsafe-reference
+          - variant
+          - web-events
+          - web-uievents
+      halogen-hooks:
+        repo: https://github.com/thomashoneyman/purescript-halogen-hooks.git
+        version: v0.6.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - effect
+          - exceptions
+          - foldable-traversable
+          - foreign-object
+          - free
+          - freeap
+          - halogen
+          - halogen-subscriptions
+          - maybe
+          - newtype
+          - ordered-collections
+          - parallel
+          - partial
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+          - unsafe-reference
+          - web-dom
+          - web-html
+      halogen-hooks-extra:
+        repo: https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git
+        version: v0.9.0
+        dependencies:
+          - halogen-hooks
+      halogen-store:
+        repo: https://github.com/thomashoneyman/purescript-halogen-store.git
+        version: v0.5.0
+        dependencies:
+          - aff
+          - distributive
+          - effect
+          - fork
+          - halogen
+          - halogen-hooks
+          - halogen-subscriptions
+          - maybe
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-reference
+      halogen-storybook:
+        repo: https://github.com/rnons/purescript-halogen-storybook.git
+        version: v2.0.0
+        dependencies:
+          - foreign-object
+          - halogen
+          - prelude
+          - routing
+      halogen-subscriptions:
+        repo: https://github.com/purescript-halogen/purescript-halogen-subscriptions.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - effect
+          - foldable-traversable
+          - functors
+          - refs
+          - safe-coerce
+          - unsafe-reference
+      halogen-svg-elems:
+        repo: https://github.com/JordanMartinez/purescript-halogen-svg-elems.git
+        version: v6.0.0
+        dependencies:
+          - halogen
+      halogen-vdom:
+        repo: https://github.com/purescript-halogen/purescript-halogen-vdom.git
+        version: v8.0.0
+        dependencies:
+          - bifunctors
+          - effect
+          - foreign
+          - foreign-object
+          - maybe
+          - prelude
+          - refs
+          - tuples
+          - unsafe-coerce
+          - web-html
+      halogen-vdom-string-renderer:
+        repo: https://github.com/purescript-halogen/purescript-halogen-vdom-string-renderer.git
+        version: v0.5.0
+        dependencies:
+          - foreign
+          - halogen-vdom
+          - ordered-collections
+          - prelude
+      heckin:
+        repo: https://github.com/maxdeviant/purescript-heckin.git
+        version: v2.0.1
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - maybe
+          - prelude
+          - strings
+          - transformers
+          - tuples
+          - unicode
+      heterogeneous:
+        repo: https://github.com/natefaubion/purescript-heterogeneous.git
+        version: v0.6.0
+        dependencies:
+          - either
+          - functors
+          - prelude
+          - record
+          - tuples
+          - variant
+      heterogeneous-extrablatt:
+        repo: https://github.com/sigma-andex/purescript-heterogeneous-extrablatt.git
+        version: v0.2.1
+        dependencies:
+          - heterogeneous
+          - prelude
+          - record
+      http-methods:
+        repo: https://github.com/purescript-contrib/purescript-http-methods.git
+        version: v6.0.0
+        dependencies:
+          - either
+          - prelude
+          - strings
+      httpure:
+        repo: https://github.com/citizennet/purescript-httpure.git
+        version: v0.15.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - js-uri
+          - maybe
+          - newtype
+          - node-buffer
+          - node-fs
+          - node-http
+          - node-streams
+          - options
+          - ordered-collections
+          - prelude
+          - refs
+          - strings
+          - tuples
+          - type-equality
+      httpurple:
+        repo: https://github.com/sigma-andex/purescript-httpurple.git
+        version: v1.3.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - js-uri
+          - justifill
+          - maybe
+          - newtype
+          - node-buffer
+          - node-fs
+          - node-http
+          - node-net
+          - node-process
+          - node-streams
+          - options
+          - ordered-collections
+          - posix-types
+          - prelude
+          - profunctor
+          - record
+          - refs
+          - routing-duplex
+          - strings
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+      httpurple-argonaut:
+        repo: https://github.com/sigma-andex/purescript-httpurple-argonaut.git
+        version: v1.0.1
+        dependencies:
+          - argonaut
+          - console
+          - effect
+          - either
+          - httpurple
+          - prelude
+      httpurple-yoga-json:
+        repo: https://github.com/sigma-andex/purescript-httpurple-yoga-json.git
+        version: v1.0.0
+        dependencies:
+          - console
+          - effect
+          - either
+          - foreign
+          - httpurple
+          - lists
+          - prelude
+          - yoga-json
+      identity:
+        repo: https://github.com/purescript/purescript-identity.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - invariant
+          - newtype
+          - prelude
+      indexed-monad:
+        repo: https://github.com/garyb/purescript-indexed-monad.git
+        version: v2.1.0
+        dependencies:
+          - control
+          - newtype
+      int64:
+        repo: https://github.com/purescript-contrib/purescript-int64.git
+        version: v2.0.0
+        dependencies:
+          - effect
+          - foreign
+          - functions
+          - integers
+          - maybe
+          - nullable
+          - prelude
+          - quickcheck
+      integers:
+        repo: https://github.com/purescript/purescript-integers.git
+        version: v6.0.0
+        dependencies:
+          - maybe
+          - numbers
+          - prelude
+      interpolate:
+        repo: https://github.com/jordanmartinez/purescript-interpolate.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+      invariant:
+        repo: https://github.com/purescript/purescript-invariant.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - prelude
+      js-date:
+        repo: https://github.com/purescript-contrib/purescript-js-date.git
+        version: v8.0.0
+        dependencies:
+          - datetime
+          - effect
+          - exceptions
+          - foreign
+          - integers
+          - now
+      js-fileio:
+        repo: https://github.com/newlandsvalley/purescript-js-fileio.git
+        version: v3.0.0
+        dependencies:
+          - aff
+          - effect
+          - prelude
+      js-timers:
+        repo: https://github.com/purescript-contrib/purescript-js-timers.git
+        version: v6.1.0
+        dependencies:
+          - effect
+      js-uri:
+        repo: https://github.com/purescript-contrib/purescript-js-uri.git
+        version: v3.0.0
+        dependencies:
+          - functions
+          - maybe
+      justifill:
+        repo: https://github.com/i-am-the-slime/purescript-justifill.git
+        version: v0.5.0
+        dependencies:
+          - maybe
+          - prelude
+          - record
+          - typelevel-prelude
+      jwt:
+        repo: https://github.com/menelaos/purescript-jwt.git
+        version: v0.0.9
+        dependencies:
+          - argonaut-core
+          - arrays
+          - b64
+          - either
+          - exceptions
+          - prelude
+          - profunctor-lenses
+          - strings
+      language-cst-parser:
+        repo: https://github.com/natefaubion/purescript-language-cst-parser.git
+        version: v0.12.0
+        dependencies:
+          - arrays
+          - const
+          - control
+          - either
+          - foldable-traversable
+          - free
+          - functions
+          - functors
+          - identity
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - ordered-collections
+          - partial
+          - prelude
+          - st
+          - strings
+          - transformers
+          - tuples
+          - typelevel-prelude
+          - unfoldable
+          - unsafe-coerce
+      lazy:
+        repo: https://github.com/purescript/purescript-lazy.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - invariant
+          - prelude
+      lcg:
+        repo: https://github.com/purescript/purescript-lcg.git
+        version: v4.0.0
+        dependencies:
+          - effect
+          - integers
+          - maybe
+          - partial
+          - prelude
+          - random
+      leibniz:
+        repo: https://github.com/paf31/purescript-leibniz.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+          - unsafe-coerce
+      linalg:
+        repo: https://github.com/gbagan/purescript-linalg.git
+        version: v5.1.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - functions
+          - maybe
+          - prelude
+          - tuples
+      lists:
+        repo: https://github.com/purescript/purescript-lists.git
+        version: v7.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - foldable-traversable
+          - lazy
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      logging:
+        repo: https://github.com/rightfold/purescript-logging.git
+        version: v3.0.0
+        dependencies:
+          - console
+          - contravariant
+          - effect
+          - either
+          - prelude
+          - transformers
+          - tuples
+      machines:
+        repo: https://github.com/purescript-contrib/purescript-machines.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - lists
+          - maybe
+          - prelude
+          - profunctor
+          - tuples
+          - unfoldable
+      matrices:
+        repo: https://github.com/kRITZCREEK/purescript-matrices.git
+        version: v5.0.1
+        dependencies:
+          - arrays
+          - strings
+      matryoshka:
+        repo: https://github.com/purescript-contrib/purescript-matryoshka.git
+        version: v1.0.0
+        dependencies:
+          - fixed-points
+          - free
+          - prelude
+          - profunctor
+          - transformers
+      maybe:
+        repo: https://github.com/purescript/purescript-maybe.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - invariant
+          - newtype
+          - prelude
+      media-types:
+        repo: https://github.com/purescript-contrib/purescript-media-types.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      metadata:
+        repo: https://github.com/purescript/purescript-metadata.git
+        version: v0.15.0
+        dependencies: []
+      midi:
+        repo: https://github.com/newlandsvalley/purescript-midi.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - ordered-collections
+          - prelude
+          - signal
+          - string-parsers
+          - strings
+          - tuples
+          - unfoldable
+      minibench:
+        repo: https://github.com/purescript/purescript-minibench.git
+        version: v4.0.0
+        dependencies:
+          - console
+          - effect
+          - integers
+          - numbers
+          - partial
+          - prelude
+          - refs
+      mmorph:
+        repo: https://github.com/Thimoteus/purescript-mmorph.git
+        version: v7.0.0
+        dependencies:
+          - free
+          - functors
+          - transformers
+      monad-control:
+        repo: https://github.com/athanclark/purescript-monad-control.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - freet
+          - identity
+          - lists
+      monad-logger:
+        repo: https://github.com/cprussin/purescript-monad-logger.git
+        version: v1.3.1
+        dependencies:
+          - aff
+          - ansi
+          - argonaut
+          - arrays
+          - console
+          - control
+          - effect
+          - foldable-traversable
+          - foreign-object
+          - integers
+          - js-date
+          - maybe
+          - newtype
+          - ordered-collections
+          - prelude
+          - strings
+          - transformers
+          - tuples
+      monad-loops:
+        repo: https://github.com/mlang/purescript-monad-loops.git
+        version: v0.5.0
+        dependencies:
+          - lists
+          - maybe
+          - prelude
+          - tailrec
+          - tuples
+      monad-unlift:
+        repo: https://github.com/athanclark/purescript-monad-unlift.git
+        version: v1.0.1
+        dependencies:
+          - monad-control
+      monoidal:
+        repo: https://github.com/mcneissue/purescript-monoidal.git
+        version: v0.16.0
+        dependencies:
+          - either
+          - profunctor
+          - these
+          - tuples
+      morello:
+        repo: https://github.com/sigma-andex/purescript-morello.git
+        version: v0.3.2
+        dependencies:
+          - arrays
+          - barlow-lens
+          - foldable-traversable
+          - heterogeneous
+          - heterogeneous-extrablatt
+          - newtype
+          - prelude
+          - profunctor
+          - profunctor-lenses
+          - record
+          - tuples
+          - typelevel-prelude
+          - validation
+      motsunabe:
+        repo: https://github.com/justinwoo/purescript-motsunabe.git
+        version: v2.0.0
+        dependencies:
+          - lists
+          - strings
+      nano-id:
+        repo: https://github.com/eikooc/nano-id.git
+        version: v1.1.0
+        dependencies:
+          - aff
+          - effect
+          - lists
+          - maybe
+          - prelude
+          - random
+          - spec
+          - strings
+          - stringutils
+      naturals:
+        repo: https://github.com/LiamGoodacre/purescript-naturals.git
+        version: v3.0.0
+        dependencies:
+          - enums
+          - maybe
+          - prelude
+      nested-functor:
+        repo: https://github.com/acple/purescript-nested-functor.git
+        version: v0.2.1
+        dependencies:
+          - prelude
+          - type-equality
+      newtype:
+        repo: https://github.com/purescript/purescript-newtype.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+          - safe-coerce
+      node-buffer:
+        repo: https://github.com/purescript-node/purescript-node-buffer.git
+        version: v8.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - maybe
+          - st
+          - unsafe-coerce
+      node-buffer-blob:
+        repo: https://github.com/purescript-node/purescript-node-buffer-blob.git
+        version: v1.0.0
+        dependencies:
+          - aff-promise
+          - arraybuffer-types
+          - arrays
+          - console
+          - effect
+          - maybe
+          - media-types
+          - newtype
+          - node-buffer
+          - nullable
+          - prelude
+          - web-streams
+      node-child-process:
+        repo: https://github.com/purescript-node/purescript-node-child-process.git
+        version: v9.0.0
+        dependencies:
+          - exceptions
+          - foreign
+          - foreign-object
+          - functions
+          - node-fs
+          - node-streams
+          - nullable
+          - posix-types
+          - unsafe-coerce
+      node-fs:
+        repo: https://github.com/purescript-node/purescript-node-fs.git
+        version: v8.0.0
+        dependencies:
+          - datetime
+          - effect
+          - either
+          - enums
+          - exceptions
+          - functions
+          - integers
+          - js-date
+          - maybe
+          - node-buffer
+          - node-path
+          - node-streams
+          - nullable
+          - partial
+          - prelude
+          - strings
+          - unsafe-coerce
+      node-fs-aff:
+        repo: https://github.com/purescript-node/purescript-node-fs-aff.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - either
+          - node-fs
+          - node-path
+      node-http:
+        repo: https://github.com/purescript-node/purescript-node-http.git
+        version: v8.0.0
+        dependencies:
+          - arraybuffer-types
+          - contravariant
+          - effect
+          - foreign
+          - foreign-object
+          - maybe
+          - node-buffer
+          - node-net
+          - node-streams
+          - node-url
+          - nullable
+          - options
+          - prelude
+          - unsafe-coerce
+      node-net:
+        repo: https://github.com/purescript-node/purescript-node-net.git
+        version: v4.0.0
+        dependencies:
+          - effect
+          - either
+          - exceptions
+          - foreign
+          - maybe
+          - node-buffer
+          - node-fs
+          - nullable
+          - options
+          - prelude
+          - transformers
+      node-path:
+        repo: https://github.com/purescript-node/purescript-node-path.git
+        version: v5.0.0
+        dependencies:
+          - effect
+      node-process:
+        repo: https://github.com/purescript-node/purescript-node-process.git
+        version: v10.0.0
+        dependencies:
+          - effect
+          - foreign-object
+          - maybe
+          - node-streams
+          - posix-types
+          - prelude
+          - unsafe-coerce
+      node-readline:
+        repo: https://github.com/purescript-node/purescript-node-readline.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - foreign
+          - node-process
+          - node-streams
+          - options
+          - prelude
+      node-streams:
+        repo: https://github.com/purescript-node/purescript-node-streams.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - either
+          - exceptions
+          - node-buffer
+          - nullable
+          - prelude
+      node-streams-aff:
+        repo: https://github.com/jamesdbrock/purescript-node-streams-aff.git
+        version: v2.0.0
+        dependencies:
+          - aff
+          - arrays
+          - effect
+          - either
+          - exceptions
+          - maybe
+          - node-buffer
+          - node-streams
+          - prelude
+          - st
+          - tuples
+      node-url:
+        repo: https://github.com/purescript-node/purescript-node-url.git
+        version: v6.0.0
+        dependencies:
+          - nullable
+      nonempty:
+        repo: https://github.com/purescript/purescript-nonempty.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - maybe
+          - prelude
+          - tuples
+          - unfoldable
+      now:
+        repo: https://github.com/purescript-contrib/purescript-now.git
+        version: v6.0.0
+        dependencies:
+          - datetime
+          - effect
+      npm-package-json:
+        repo: https://github.com/maxdeviant/purescript-npm-package-json.git
+        version: v2.0.0
+        dependencies:
+          - argonaut
+          - control
+          - either
+          - foreign-object
+          - maybe
+          - ordered-collections
+          - prelude
+      nullable:
+        repo: https://github.com/purescript-contrib/purescript-nullable.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - functions
+          - maybe
+      numbers:
+        repo: https://github.com/purescript/purescript-numbers.git
+        version: v9.0.0
+        dependencies:
+          - functions
+          - maybe
+      open-folds:
+        repo: https://github.com/purescript-open-community/purescript-open-folds.git
+        version: v6.3.0
+        dependencies:
+          - bifunctors
+          - console
+          - control
+          - distributive
+          - effect
+          - either
+          - foldable-traversable
+          - identity
+          - invariant
+          - maybe
+          - newtype
+          - ordered-collections
+          - prelude
+          - profunctor
+          - psci-support
+          - tuples
+      open-memoize:
+        repo: https://github.com/purescript-open-community/purescript-open-memoize.git
+        version: v6.1.0
+        dependencies:
+          - console
+          - effect
+          - either
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - psci-support
+          - strings
+          - tuples
+      open-pairing:
+        repo: https://github.com/purescript-open-community/purescript-open-pairing.git
+        version: v6.1.0
+        dependencies:
+          - console
+          - control
+          - effect
+          - either
+          - free
+          - functors
+          - identity
+          - newtype
+          - prelude
+          - psci-support
+          - transformers
+          - tuples
+      options:
+        repo: https://github.com/purescript-contrib/purescript-options.git
+        version: v7.0.0
+        dependencies:
+          - contravariant
+          - foreign
+          - foreign-object
+          - maybe
+          - tuples
+      optparse:
+        repo: https://github.com/f-o-a-m/purescript-optparse.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - control
+          - effect
+          - either
+          - enums
+          - exists
+          - exitcodes
+          - foldable-traversable
+          - free
+          - gen
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - newtype
+          - node-buffer
+          - node-process
+          - node-streams
+          - nonempty
+          - numbers
+          - open-memoize
+          - partial
+          - prelude
+          - quickcheck
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+      ordered-collections:
+        repo: https://github.com/purescript/purescript-ordered-collections.git
+        version: v3.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - gen
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - unfoldable
+      ordered-set:
+        repo: https://github.com/flip111/purescript-ordered-set.git
+        version: v0.4.0
+        dependencies:
+          - argonaut-codecs
+          - arrays
+          - partial
+          - prelude
+          - unfoldable
+      orders:
+        repo: https://github.com/purescript/purescript-orders.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      pairs:
+        repo: https://github.com/sharkdp/purescript-pairs.git
+        version: v9.0.0
+        dependencies:
+          - console
+          - distributive
+          - foldable-traversable
+          - quickcheck
+      parallel:
+        repo: https://github.com/purescript/purescript-parallel.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - functors
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - refs
+          - transformers
+      parsing:
+        repo: https://github.com/purescript-contrib/purescript-parsing.git
+        version: v9.1.0
+        dependencies:
+          - arrays
+          - either
+          - foldable-traversable
+          - identity
+          - integers
+          - lists
+          - maybe
+          - nullable
+          - prelude
+          - strings
+          - transformers
+          - unicode
+      parsing-dataview:
+        repo: https://github.com/jamesdbrock/purescript-parsing-dataview.git
+        version: v3.1.0
+        dependencies:
+          - arraybuffer
+          - arraybuffer-types
+          - effect
+          - float32
+          - maybe
+          - parsing
+          - prelude
+          - transformers
+          - tuples
+          - uint
+      partial:
+        repo: https://github.com/purescript/purescript-partial.git
+        version: v4.0.0
+        dependencies: []
+      pathy:
+        repo: https://github.com/purescript-contrib/purescript-pathy.git
+        version: v9.0.0
+        dependencies:
+          - console
+          - exceptions
+          - lists
+          - partial
+          - profunctor
+          - strings
+          - transformers
+          - typelevel-prelude
+          - unsafe-coerce
+      pha:
+        repo: https://github.com/gbagan/purescript-pha.git
+        version: v0.9.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - datetime
+          - effect
+          - foldable-traversable
+          - free
+          - integers
+          - maybe
+          - prelude
+          - profunctor-lenses
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+          - unsafe-reference
+          - web-dom
+          - web-events
+          - web-html
+          - web-pointerevents
+          - web-uievents
+      phaser:
+        repo: https://github.com/lfarroco/purescript-phaser.git
+        version: v0.6.0
+        dependencies:
+          - canvas
+          - console
+          - effect
+          - maybe
+          - nullable
+          - options
+          - prelude
+          - web-html
+      pipes:
+        repo: https://github.com/felixschl/purescript-pipes.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - lists
+          - mmorph
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      point-free:
+        repo: https://github.com/ursi/purescript-point-free.git
+        version: v1.0.0
+        dependencies:
+          - prelude
+      polymorphic-vectors:
+        repo: https://github.com/artemisSystem/purescript-polymorphic-vectors.git
+        version: v4.0.0
+        dependencies:
+          - distributive
+          - foldable-traversable
+          - numbers
+          - prelude
+          - record
+          - safe-coerce
+          - type-equality
+          - typelevel-prelude
+      posix-types:
+        repo: https://github.com/purescript-node/purescript-posix-types.git
+        version: v6.0.0
+        dependencies:
+          - maybe
+          - prelude
+      precise:
+        repo: https://github.com/purescript-contrib/purescript-precise.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - exceptions
+          - gen
+          - integers
+          - lists
+          - numbers
+          - prelude
+          - strings
+      precise-datetime:
+        repo: https://github.com/awakesecurity/purescript-precise-datetime.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - datetime
+          - decimals
+          - either
+          - enums
+          - foldable-traversable
+          - formatters
+          - integers
+          - js-date
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - strings
+          - tuples
+          - unicode
+      prelude:
+        repo: https://github.com/purescript/purescript-prelude.git
+        version: v6.0.0
+        dependencies: []
+      prettier-printer:
+        repo: https://github.com/paulyoung/purescript-prettier-printer.git
+        version: v3.0.0
+        dependencies:
+          - console
+          - lists
+          - prelude
+          - strings
+          - tuples
+      profunctor:
+        repo: https://github.com/purescript/purescript-profunctor.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - distributive
+          - either
+          - exists
+          - invariant
+          - newtype
+          - prelude
+          - tuples
+      profunctor-lenses:
+        repo: https://github.com/purescript-contrib/purescript-profunctor-lenses.git
+        version: v8.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - const
+          - control
+          - distributive
+          - either
+          - foldable-traversable
+          - foreign-object
+          - functors
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - ordered-collections
+          - partial
+          - prelude
+          - profunctor
+          - record
+          - transformers
+          - tuples
+      protobuf:
+        repo: https://github.com/xc-jp/purescript-protobuf.git
+        version: v4.0.0
+        dependencies:
+          - arraybuffer
+          - arraybuffer-builder
+          - arraybuffer-types
+          - arrays
+          - control
+          - effect
+          - either
+          - enums
+          - exceptions
+          - float32
+          - foldable-traversable
+          - functions
+          - int64
+          - maybe
+          - newtype
+          - parsing
+          - parsing-dataview
+          - prelude
+          - record
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+          - uint
+          - web-encoding
+      ps-cst:
+        repo: https://github.com/purescript-codegen/purescript-ps-cst.git
+        version: v1.2.0
+        dependencies:
+          - ansi
+          - console
+          - dodo-printer
+          - effect
+          - node-fs-aff
+          - node-path
+          - psci-support
+          - record
+          - strings
+      psa-utils:
+        repo: https://github.com/natefaubion/purescript-psa-utils.git
+        version: v8.0.0
+        dependencies:
+          - ansi
+          - argonaut-codecs
+          - argonaut-core
+          - arrays
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - maybe
+          - node-path
+          - ordered-collections
+          - prelude
+          - strings
+          - tuples
+          - unsafe-coerce
+      psc-ide:
+        repo: https://github.com/kRITZCREEK/purescript-psc-ide.git
+        version: v19.0.0
+        dependencies:
+          - aff
+          - argonaut
+          - arrays
+          - console
+          - maybe
+          - node-child-process
+          - node-fs
+          - parallel
+          - random
+      psci-support:
+        repo: https://github.com/purescript/purescript-psci-support.git
+        version: v6.0.0
+        dependencies:
+          - console
+          - effect
+          - prelude
+      qualified-do:
+        repo: https://github.com/artemisSystem/purescript-qualified-do.git
+        version: v2.2.0
+        dependencies:
+          - arrays
+          - control
+          - foldable-traversable
+          - parallel
+          - prelude
+          - unfoldable
+      quantities:
+        repo: https://github.com/sharkdp/purescript-quantities.git
+        version: v12.0.1
+        dependencies:
+          - decimals
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - newtype
+          - nonempty
+          - numbers
+          - pairs
+          - prelude
+          - tuples
+      quickcheck:
+        repo: https://github.com/purescript/purescript-quickcheck.git
+        version: v8.0.1
+        dependencies:
+          - arrays
+          - console
+          - control
+          - effect
+          - either
+          - enums
+          - exceptions
+          - foldable-traversable
+          - gen
+          - identity
+          - integers
+          - lazy
+          - lcg
+          - lists
+          - maybe
+          - newtype
+          - nonempty
+          - numbers
+          - partial
+          - prelude
+          - record
+          - st
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+          - unfoldable
+      quickcheck-combinators:
+        repo: https://github.com/athanclark/purescript-quickcheck-combinators.git
+        version: v0.1.3
+        dependencies:
+          - quickcheck
+          - typelevel
+      quickcheck-laws:
+        repo: https://github.com/purescript-contrib/purescript-quickcheck-laws.git
+        version: v7.0.0
+        dependencies:
+          - enums
+          - quickcheck
+      quickcheck-utf8:
+        repo: https://github.com/openchronology/purescript-quickcheck-utf8.git
+        version: v0.0.0
+        dependencies:
+          - quickcheck
+      quotient:
+        repo: https://github.com/rightfold/purescript-quotient.git
+        version: v3.0.0
+        dependencies:
+          - prelude
+          - quickcheck
+      random:
+        repo: https://github.com/purescript/purescript-random.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - integers
+      rationals:
+        repo: https://github.com/anttih/purescript-rationals.git
+        version: v5.0.0
+        dependencies:
+          - integers
+          - prelude
+      react:
+        repo: https://github.com/purescript-contrib/purescript-react.git
+        version: v10.0.1
+        dependencies:
+          - effect
+          - exceptions
+          - maybe
+          - nullable
+          - prelude
+          - typelevel-prelude
+          - unsafe-coerce
+      react-basic:
+        repo: https://github.com/lumihq/purescript-react-basic.git
+        version: v17.0.0
+        dependencies:
+          - effect
+          - prelude
+          - record
+      react-basic-dom:
+        repo: https://github.com/lumihq/purescript-react-basic-dom.git
+        version: v5.0.0
+        dependencies:
+          - effect
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - nullable
+          - prelude
+          - react-basic
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-file
+          - web-html
+      react-basic-hooks:
+        repo: https://github.com/megamaddu/purescript-react-basic-hooks.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - aff-promise
+          - bifunctors
+          - console
+          - control
+          - datetime
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - functions
+          - indexed-monad
+          - integers
+          - maybe
+          - newtype
+          - now
+          - nullable
+          - ordered-collections
+          - prelude
+          - react-basic
+          - refs
+          - tuples
+          - type-equality
+          - unsafe-coerce
+          - unsafe-reference
+          - web-html
+      react-dom:
+        repo: https://github.com/purescript-contrib/purescript-react-dom.git
+        version: v8.0.0
+        dependencies:
+          - effect
+          - react
+          - web-dom
+      read:
+        repo: https://github.com/truqu/purescript-read.git
+        version: v1.0.1
+        dependencies:
+          - maybe
+          - prelude
+          - strings
+      record:
+        repo: https://github.com/purescript/purescript-record.git
+        version: v4.0.0
+        dependencies:
+          - functions
+          - prelude
+          - unsafe-coerce
+      refined:
+        repo: https://github.com/danieljharvey/purescript-refined.git
+        version: v1.0.0
+        dependencies:
+          - argonaut
+          - effect
+          - prelude
+          - quickcheck
+          - typelevel
+      refs:
+        repo: https://github.com/purescript/purescript-refs.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - prelude
+      remotedata:
+        repo: https://github.com/krisajenkins/purescript-remotedata.git
+        version: v5.0.0
+        dependencies:
+          - bifunctors
+          - either
+          - profunctor-lenses
+      resource:
+        repo: https://github.com/joneshf/purescript-resource.git
+        version: v2.0.1
+        dependencies:
+          - aff
+          - console
+          - control
+          - effect
+          - newtype
+          - prelude
+          - psci-support
+          - refs
+      resourcet:
+        repo: https://github.com/robertdp/purescript-resourcet.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - effect
+          - foldable-traversable
+          - maybe
+          - ordered-collections
+          - parallel
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+      result:
+        repo: https://github.com/ad-si/purescript-result.git
+        version: v1.0.3
+        dependencies:
+          - either
+          - foldable-traversable
+          - prelude
+      return:
+        repo: https://github.com/ursi/purescript-return.git
+        version: v0.2.0
+        dependencies:
+          - foldable-traversable
+          - point-free
+          - prelude
+      ring-modules:
+        repo: https://github.com/f-o-a-m/purescript-ring-modules.git
+        version: v5.0.1
+        dependencies:
+          - prelude
+      routing:
+        repo: https://github.com/purescript-contrib/purescript-routing.git
+        version: v11.0.0
+        dependencies:
+          - aff
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - integers
+          - js-uri
+          - lists
+          - maybe
+          - numbers
+          - partial
+          - prelude
+          - semirings
+          - tuples
+          - validation
+          - web-html
+      routing-duplex:
+        repo: https://github.com/natefaubion/purescript-routing-duplex.git
+        version: v0.6.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - js-uri
+          - lazy
+          - numbers
+          - prelude
+          - profunctor
+          - record
+          - strings
+          - typelevel-prelude
+      run:
+        repo: https://github.com/natefaubion/purescript-run.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - free
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - tailrec
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - variant
+      safe-coerce:
+        repo: https://github.com/purescript/purescript-safe-coerce.git
+        version: v2.0.0
+        dependencies:
+          - unsafe-coerce
+      safely:
+        repo: https://github.com/paf31/purescript-safely.git
+        version: v4.0.1
+        dependencies:
+          - freet
+          - lists
+      selection-foldable:
+        repo: https://github.com/jamieyung/purescript-selection-foldable.git
+        version: v0.2.0
+        dependencies:
+          - filterable
+          - foldable-traversable
+          - maybe
+          - prelude
+      semirings:
+        repo: https://github.com/purescript/purescript-semirings.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - lists
+          - newtype
+          - prelude
+      signal:
+        repo: https://github.com/bodil/purescript-signal.git
+        version: v13.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - foldable-traversable
+          - maybe
+          - prelude
+      simple-emitter:
+        repo: https://github.com/oreshinya/purescript-simple-emitter.git
+        version: v2.0.0
+        dependencies:
+          - ordered-collections
+          - refs
+      sized-matrices:
+        repo: https://github.com/csicar/purescript-sized-matrices.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - distributive
+          - foldable-traversable
+          - maybe
+          - prelude
+          - sized-vectors
+          - strings
+          - typelevel
+          - unfoldable
+          - vectorfield
+      sized-vectors:
+        repo: https://github.com/bodil/purescript-sized-vectors.git
+        version: v5.0.2
+        dependencies:
+          - argonaut
+          - arrays
+          - distributive
+          - foldable-traversable
+          - maybe
+          - prelude
+          - quickcheck
+          - typelevel
+          - unfoldable
+      slug:
+        repo: https://github.com/thomashoneyman/purescript-slug.git
+        version: v3.0.1
+        dependencies:
+          - argonaut-codecs
+          - maybe
+          - prelude
+          - strings
+          - unicode
+      soundfonts:
+        repo: https://github.com/newlandsvalley/purescript-soundfonts.git
+        version: v4.1.0
+        dependencies:
+          - aff
+          - affjax
+          - affjax-web
+          - argonaut-core
+          - arraybuffer-types
+          - arrays
+          - b64
+          - bifunctors
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign-object
+          - http-methods
+          - integers
+          - lists
+          - maybe
+          - midi
+          - ordered-collections
+          - parallel
+          - partial
+          - prelude
+          - strings
+          - transformers
+          - tuples
+      sparse-matrices:
+        repo: https://github.com/Ebmtranceboy/purescript-sparse-matrices.git
+        version: v1.2.1
+        dependencies:
+          - console
+          - effect
+          - prelude
+          - sparse-polynomials
+      sparse-polynomials:
+        repo: https://github.com/Ebmtranceboy/purescript-sparse-polynomials.git
+        version: v1.0.5
+        dependencies:
+          - cartesian
+          - console
+          - effect
+          - ordered-collections
+          - prelude
+          - rationals
+          - tuples
+      spec:
+        repo: https://github.com/purescript-spec/purescript-spec.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - ansi
+          - avar
+          - console
+          - exceptions
+          - foldable-traversable
+          - fork
+          - now
+          - pipes
+          - prelude
+          - strings
+          - transformers
+      spec-discovery:
+        repo: https://github.com/purescript-spec/purescript-spec-discovery.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - aff-promise
+          - arrays
+          - console
+          - effect
+          - foldable-traversable
+          - node-fs
+          - prelude
+          - spec
+      spec-quickcheck:
+        repo: https://github.com/purescript-spec/purescript-spec-quickcheck.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - prelude
+          - quickcheck
+          - random
+          - spec
+      ssrs:
+        repo: https://github.com/PureFunctor/purescript-ssrs.git
+        version: v1.0.0
+        dependencies:
+          - dissect
+          - either
+          - fixed-points
+          - free
+          - lists
+          - prelude
+          - safe-coerce
+          - tailrec
+          - tuples
+          - variant
+      st:
+        repo: https://github.com/purescript/purescript-st.git
+        version: v6.0.0
+        dependencies:
+          - partial
+          - prelude
+          - tailrec
+          - unsafe-coerce
+      strictlypositiveint:
+        repo: https://github.com/jamieyung/purescript-strictlypositiveint.git
+        version: v1.0.1
+        dependencies:
+          - prelude
+      string-parsers:
+        repo: https://github.com/purescript-contrib/purescript-string-parsers.git
+        version: v8.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - prelude
+          - strings
+          - tailrec
+      strings:
+        repo: https://github.com/purescript/purescript-strings.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - enums
+          - foldable-traversable
+          - gen
+          - integers
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+          - unsafe-coerce
+      strings-extra:
+        repo: https://github.com/purescript-contrib/purescript-strings-extra.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - maybe
+          - prelude
+          - strings
+          - unicode
+      stringutils:
+        repo: https://github.com/menelaos/purescript-stringutils.git
+        version: v0.0.12
+        dependencies:
+          - arrays
+          - integers
+          - maybe
+          - partial
+          - prelude
+          - strings
+      substitute:
+        repo: https://github.com/ursi/purescript-substitute.git
+        version: v0.2.3
+        dependencies:
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - prelude
+          - return
+          - strings
+      supply:
+        repo: https://github.com/ajnsit/purescript-supply.git
+        version: v0.2.0
+        dependencies:
+          - console
+          - control
+          - effect
+          - lazy
+          - prelude
+          - refs
+          - tuples
+      tailrec:
+        repo: https://github.com/purescript/purescript-tailrec.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - effect
+          - either
+          - identity
+          - maybe
+          - partial
+          - prelude
+          - refs
+      test-unit:
+        repo: https://github.com/bodil/purescript-test-unit.git
+        version: v17.0.0
+        dependencies:
+          - aff
+          - avar
+          - effect
+          - either
+          - free
+          - js-timers
+          - lists
+          - prelude
+          - quickcheck
+          - strings
+      thermite:
+        repo: https://github.com/paf31/purescript-thermite.git
+        version: v6.3.1
+        dependencies:
+          - aff
+          - coroutines
+          - freet
+          - profunctor-lenses
+          - react
+      thermite-dom:
+        repo: https://github.com/athanclark/purescript-thermite-dom.git
+        version: v0.3.1
+        dependencies:
+          - react
+          - react-dom
+          - thermite
+          - web-html
+      these:
+        repo: https://github.com/purescript-contrib/purescript-these.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - gen
+          - lists
+          - quickcheck
+          - quickcheck-laws
+          - tuples
+      transformers:
+        repo: https://github.com/purescript/purescript-transformers.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - distributive
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - identity
+          - lazy
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      tree-rose:
+        repo: https://github.com/jordanmartinez/purescript-tree-rose.git
+        version: v4.0.2
+        dependencies:
+          - control
+          - foldable-traversable
+          - free
+          - lists
+          - maybe
+          - prelude
+          - tailrec
+      tuples:
+        repo: https://github.com/purescript/purescript-tuples.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - invariant
+          - prelude
+      two-or-more:
+        repo: https://github.com/i-am-the-slime/purescript-two-or-more.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - foldable-traversable
+          - maybe
+          - partial
+          - prelude
+          - psci-support
+          - tuples
+      type-equality:
+        repo: https://github.com/purescript/purescript-type-equality.git
+        version: v4.0.1
+        dependencies: []
+      typelevel:
+        repo: https://github.com/bodil/purescript-typelevel.git
+        version: v6.0.0
+        dependencies:
+          - partial
+          - prelude
+          - tuples
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-lists:
+        repo: https://github.com/PureFunctor/purescript-typelevel-lists.git
+        version: v2.1.0
+        dependencies:
+          - prelude
+          - tuples
+          - typelevel-peano
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-peano:
+        repo: https://github.com/csicar/purescript-typelevel-peano.git
+        version: v1.0.1
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - prelude
+          - psci-support
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-prelude:
+        repo: https://github.com/purescript/purescript-typelevel-prelude.git
+        version: v7.0.0
+        dependencies:
+          - prelude
+          - type-equality
+      typelevel-rows:
+        repo: https://github.com/jordanmartinez/purescript-typelevel-rows.git
+        version: v0.1.0
+        dependencies:
+          - prelude
+      uint:
+        repo: https://github.com/purescript-contrib/purescript-uint.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - enums
+          - gen
+          - maybe
+          - numbers
+          - prelude
+      uncurried-transformers:
+        repo: https://github.com/PureFunctor/purescript-uncurried-transformers.git
+        version: v1.1.0
+        dependencies:
+          - control
+          - effect
+          - either
+          - functions
+          - identity
+          - prelude
+          - safe-coerce
+          - tailrec
+          - transformers
+          - tuples
+      undefined-is-not-a-problem:
+        repo: https://github.com/paluh/purescript-undefined-is-not-a-problem.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - assert
+          - effect
+          - either
+          - foreign
+          - maybe
+          - newtype
+          - prelude
+          - random
+          - tuples
+          - type-equality
+          - unsafe-coerce
+      unfoldable:
+        repo: https://github.com/purescript/purescript-unfoldable.git
+        version: v6.0.0
+        dependencies:
+          - foldable-traversable
+          - maybe
+          - partial
+          - prelude
+          - tuples
+      unicode:
+        repo: https://github.com/purescript-contrib/purescript-unicode.git
+        version: v6.0.0
+        dependencies:
+          - foldable-traversable
+          - maybe
+          - strings
+      unlift:
+        repo: https://github.com/tweag/purescript-unlift.git
+        version: v1.0.1
+        dependencies:
+          - aff
+          - effect
+          - either
+          - freet
+          - identity
+          - lists
+          - maybe
+          - monad-control
+          - prelude
+          - st
+          - transformers
+          - tuples
+      unsafe-coerce:
+        repo: https://github.com/purescript/purescript-unsafe-coerce.git
+        version: v6.0.0
+        dependencies: []
+      unsafe-reference:
+        repo: https://github.com/purescript-contrib/purescript-unsafe-reference.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+      uri:
+        repo: https://github.com/purescript-contrib/purescript-uri.git
+        version: v9.0.0
+        dependencies:
+          - arrays
+          - integers
+          - js-uri
+          - numbers
+          - parsing
+          - prelude
+          - profunctor-lenses
+          - these
+          - transformers
+          - unfoldable
+      validation:
+        repo: https://github.com/purescript/purescript-validation.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - newtype
+          - prelude
+      variant:
+        repo: https://github.com/natefaubion/purescript-variant.git
+        version: v8.0.0
+        dependencies:
+          - enums
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - record
+          - tuples
+          - unsafe-coerce
+      vectorfield:
+        repo: https://github.com/csicar/purescript-vectorfield.git
+        version: v1.0.1
+        dependencies:
+          - console
+          - effect
+          - group
+          - prelude
+          - psci-support
+      versions:
+        repo: https://github.com/hdgarrood/purescript-versions.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - either
+          - foldable-traversable
+          - functions
+          - integers
+          - lists
+          - maybe
+          - orders
+          - parsing
+          - partial
+          - strings
+      web-clipboard:
+        repo: https://github.com/purescript-web/purescript-web-clipboard.git
+        version: v4.0.0
+        dependencies:
+          - web-html
+      web-cssom:
+        repo: https://github.com/purescript-web/purescript-web-cssom.git
+        version: v2.0.0
+        dependencies:
+          - web-dom
+          - web-html
+          - web-uievents
+      web-dom:
+        repo: https://github.com/purescript-web/purescript-web-dom.git
+        version: v6.0.0
+        dependencies:
+          - web-events
+      web-dom-parser:
+        repo: https://github.com/purescript-web/purescript-web-dom-parser.git
+        version: v8.0.0
+        dependencies:
+          - effect
+          - partial
+          - prelude
+          - web-dom
+      web-dom-xpath:
+        repo: https://github.com/purescript-web/purescript-web-dom-xpath.git
+        version: v3.0.0
+        dependencies:
+          - web-dom
+      web-encoding:
+        repo: https://github.com/purescript-web/purescript-web-encoding.git
+        version: v3.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - newtype
+          - prelude
+      web-events:
+        repo: https://github.com/purescript-web/purescript-web-events.git
+        version: v4.0.0
+        dependencies:
+          - datetime
+          - enums
+          - foreign
+          - nullable
+      web-fetch:
+        repo: https://github.com/purescript-web/purescript-web-fetch.git
+        version: v3.0.0
+        dependencies:
+          - effect
+          - foreign-object
+          - http-methods
+          - prelude
+          - record
+          - typelevel-prelude
+          - web-file
+          - web-promise
+          - web-streams
+      web-file:
+        repo: https://github.com/purescript-web/purescript-web-file.git
+        version: v4.0.0
+        dependencies:
+          - foreign
+          - media-types
+          - web-dom
+      web-html:
+        repo: https://github.com/purescript-web/purescript-web-html.git
+        version: v4.0.0
+        dependencies:
+          - js-date
+          - web-dom
+          - web-file
+          - web-storage
+      web-page-visibility:
+        repo: https://git.sr.ht/~toastal/purescript-web-page-visibility
+        version: v2.0.0
+        dependencies:
+          - effect
+          - enums
+          - exceptions
+          - maybe
+          - prelude
+          - strings
+          - web-events
+          - web-html
+      web-pointerevents:
+        repo: https://github.com/purescript-web/purescript-web-pointerevents.git
+        version: v1.0.0
+        dependencies:
+          - effect
+          - maybe
+          - prelude
+          - web-dom
+          - web-uievents
+      web-promise:
+        repo: https://github.com/purescript-web/purescript-web-promise.git
+        version: v3.0.0
+        dependencies:
+          - effect
+          - exceptions
+          - foldable-traversable
+          - functions
+          - maybe
+          - prelude
+      web-socket:
+        repo: https://github.com/purescript-web/purescript-web-socket.git
+        version: v4.0.0
+        dependencies:
+          - arraybuffer-types
+          - web-file
+      web-storage:
+        repo: https://github.com/purescript-web/purescript-web-storage.git
+        version: v5.0.0
+        dependencies:
+          - nullable
+          - web-events
+      web-streams:
+        repo: https://github.com/purescript-web/purescript-web-streams.git
+        version: v3.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - exceptions
+          - nullable
+          - prelude
+          - tuples
+          - web-promise
+      web-touchevents:
+        repo: https://github.com/purescript-web/purescript-web-touchevents.git
+        version: v4.0.0
+        dependencies:
+          - web-uievents
+      web-uievents:
+        repo: https://github.com/purescript-web/purescript-web-uievents.git
+        version: v4.0.0
+        dependencies:
+          - web-html
+      web-workers:
+        repo: https://github.com/gbagan/purescript-web-workers.git
+        version: v1.1.0
+        dependencies:
+          - effect
+          - foreign
+          - maybe
+          - prelude
+          - unsafe-coerce
+          - web-events
+      web-xhr:
+        repo: https://github.com/purescript-web/purescript-web-xhr.git
+        version: v5.0.0
+        dependencies:
+          - arraybuffer-types
+          - datetime
+          - http-methods
+          - web-dom
+          - web-file
+          - web-html
+      yoga-fetch:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-fetch.git
+        version: v1.0.1
+        dependencies:
+          - aff
+          - aff-promise
+          - arraybuffer-types
+          - effect
+          - foreign
+          - foreign-object
+          - newtype
+          - prelude
+          - typelevel-prelude
+          - unsafe-coerce
+      yoga-json:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-json.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - identity
+          - lists
+          - maybe
+          - nullable
+          - partial
+          - prelude
+          - record
+          - transformers
+          - typelevel-prelude
+          - variant
+      yoga-postgres:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-postgres.git
+        version: v6.0.0
+        dependencies:
+          - aff
+          - arrays
+          - datetime
+          - effect
+          - either
+          - enums
+          - foldable-traversable
+          - foreign
+          - integers
+          - maybe
+          - nullable
+          - prelude
+          - transformers
+          - unsafe-coerce
+  extra_packages: {}
+packages:
+  aff:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-aff.git
+    rev: 2d44d9f9d0d6a416a4103fba2fb39e5160f80e36
+    dependencies:
+      - datetime
+      - effect
+      - exceptions
+      - functions
+      - parallel
+      - transformers
+      - unsafe-coerce
+  aff-promise:
+    type: git
+    url: https://github.com/nwolverson/purescript-aff-promise.git
+    rev: 3aa74e68e3e4c3e38d821375703e0b2f49d831eb
+    dependencies:
+      - aff
+      - foreign
+  arrays:
+    type: git
+    url: https://github.com/purescript/purescript-arrays.git
+    rev: d20bae2f76db6cf29b7b75e26e82b8a54c32295e
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - maybe
+      - nonempty
+      - partial
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  avar:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-avar.git
+    rev: d00f5784d9cc8f079babd62740f5c52b87e5caa5
+    dependencies:
+      - aff
+      - effect
+      - either
+      - exceptions
+      - functions
+      - maybe
+  bifunctors:
+    type: git
+    url: https://github.com/purescript/purescript-bifunctors.git
+    rev: 16ba2fb6dd7f05528ebd9e2f9ca3a068b325e5b3
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  catenable-lists:
+    type: git
+    url: https://github.com/purescript/purescript-catenable-lists.git
+    rev: 09abe1f4888bc00841ad2b59e56a9e7ce7ebd4ab
+    dependencies:
+      - control
+      - foldable-traversable
+      - lists
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  console:
+    type: git
+    url: https://github.com/purescript/purescript-console.git
+    rev: 3b83d7b792d03872afeea5e62b4f686ab0f09842
+    dependencies:
+      - effect
+      - prelude
+  const:
+    type: git
+    url: https://github.com/purescript/purescript-const.git
+    rev: ab9570cf2b6e67f7e441178211db1231cfd75c37
+    dependencies:
+      - invariant
+      - newtype
+      - prelude
+  contravariant:
+    type: git
+    url: https://github.com/purescript/purescript-contravariant.git
+    rev: 9ad3e105b8855bcc25f4e0893c784789d05a58de
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  control:
+    type: git
+    url: https://github.com/purescript/purescript-control.git
+    rev: a6033808790879a17b2729e73747a9ed3fb2264e
+    dependencies:
+      - newtype
+      - prelude
+  datetime:
+    type: git
+    url: https://github.com/purescript/purescript-datetime.git
+    rev: a6a0cf1b0324964ad1854bc3377ed8766ba90e6f
+    dependencies:
+      - bifunctors
+      - control
+      - either
+      - enums
+      - foldable-traversable
+      - functions
+      - gen
+      - integers
+      - lists
+      - maybe
+      - newtype
+      - numbers
+      - ordered-collections
+      - partial
+      - prelude
+      - tuples
+  distributive:
+    type: git
+    url: https://github.com/purescript/purescript-distributive.git
+    rev: 6005e513642e855ebf6f884d24a35c2803ca252a
+    dependencies:
+      - identity
+      - newtype
+      - prelude
+      - tuples
+      - type-equality
+  effect:
+    type: git
+    url: https://github.com/purescript/purescript-effect.git
+    rev: a192ddb923027d426d6ea3d8deb030c9aa7c7dda
+    dependencies:
+      - prelude
+  either:
+    type: git
+    url: https://github.com/purescript/purescript-either.git
+    rev: af655a04ed2fd694b6688af39ee20d7907ad0763
+    dependencies:
+      - control
+      - invariant
+      - maybe
+      - prelude
+  enums:
+    type: git
+    url: https://github.com/purescript/purescript-enums.git
+    rev: bae47961d401f9acf88da38f32e87403e5f0cf2f
+    dependencies:
+      - control
+      - either
+      - gen
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tuples
+      - unfoldable
+  exceptions:
+    type: git
+    url: https://github.com/purescript/purescript-exceptions.git
+    rev: afab3c07c820bb49b6c5be50049db46a964a6161
+    dependencies:
+      - effect
+      - either
+      - maybe
+      - prelude
+  exists:
+    type: git
+    url: https://github.com/purescript/purescript-exists.git
+    rev: f765b4ace7869c27b9c05949e18c843881f9173b
+    dependencies:
+      - unsafe-coerce
+  foldable-traversable:
+    type: git
+    url: https://github.com/purescript/purescript-foldable-traversable.git
+    rev: b3926f870532d287ea59e2d5cd3873b81ef2a93a
+    dependencies:
+      - bifunctors
+      - const
+      - control
+      - either
+      - functors
+      - identity
+      - maybe
+      - newtype
+      - orders
+      - prelude
+      - tuples
+  foreign:
+    type: git
+    url: https://github.com/purescript/purescript-foreign.git
+    rev: 2dd222d1ec7363fa0a0a7adb0d8eaf81bb7006dd
+    dependencies:
+      - either
+      - functions
+      - identity
+      - integers
+      - lists
+      - maybe
+      - prelude
+      - strings
+      - transformers
+  foreign-object:
+    type: git
+    url: https://github.com/purescript/purescript-foreign-object.git
+    rev: 28a635827a9a6c251df73f68874070d51fe9f756
+    dependencies:
+      - arrays
+      - foldable-traversable
+      - functions
+      - gen
+      - lists
+      - maybe
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - typelevel-prelude
+      - unfoldable
+  free:
+    type: git
+    url: https://github.com/purescript/purescript-free.git
+    rev: e2d8fa8023a864363857834e11393483bced5e38
+    dependencies:
+      - catenable-lists
+      - control
+      - distributive
+      - either
+      - exists
+      - foldable-traversable
+      - invariant
+      - lazy
+      - maybe
+      - prelude
+      - tailrec
+      - transformers
+      - tuples
+      - unsafe-coerce
+  functions:
+    type: git
+    url: https://github.com/purescript/purescript-functions.git
+    rev: f626f20580483977c5b27a01aac6471e28aff367
+    dependencies:
+      - prelude
+  functors:
+    type: git
+    url: https://github.com/purescript/purescript-functors.git
+    rev: 022ffd7a2a7ec12080314f3d217b400674a247b4
+    dependencies:
+      - bifunctors
+      - const
+      - contravariant
+      - control
+      - distributive
+      - either
+      - invariant
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - tuples
+      - unsafe-coerce
+  gen:
+    type: git
+    url: https://github.com/purescript/purescript-gen.git
+    rev: 9fbcc2a1261c32e30d79c5418edef4d96fe76931
+    dependencies:
+      - either
+      - foldable-traversable
+      - identity
+      - maybe
+      - newtype
+      - nonempty
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  identity:
+    type: git
+    url: https://github.com/purescript/purescript-identity.git
+    rev: ef6768f8a52ab0bc943a85f5761ba07c257f639f
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  indexed-monad:
+    type: git
+    url: https://github.com/garyb/purescript-indexed-monad.git
+    rev: b95d33cea26bfbbdc17d8d80fb664df2ad79d28b
+    dependencies:
+      - control
+      - newtype
+  integers:
+    type: git
+    url: https://github.com/purescript/purescript-integers.git
+    rev: 54d712b25c594833083d15dc9ff2418eb9c52822
+    dependencies:
+      - maybe
+      - numbers
+      - prelude
+  invariant:
+    type: git
+    url: https://github.com/purescript/purescript-invariant.git
+    rev: 1d2a196d51e90623adb88496c2cfd759c6736894
+    dependencies:
+      - control
+      - prelude
+  js-date:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-js-date.git
+    rev: 1ea020316946cc4b87195bca9c54d0c16abaa490
+    dependencies:
+      - datetime
+      - effect
+      - exceptions
+      - foreign
+      - integers
+      - now
+  js-timers:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-js-timers.git
+    rev: 7cb728b3e6dc29f355143617e6e9ac770ecd9273
+    dependencies:
+      - effect
+  lazy:
+    type: git
+    url: https://github.com/purescript/purescript-lazy.git
+    rev: 48347841226b27af5205a1a8ec71e27a93ce86fd
+    dependencies:
+      - control
+      - foldable-traversable
+      - invariant
+      - prelude
+  lcg:
+    type: git
+    url: https://github.com/purescript/purescript-lcg.git
+    rev: 67c6c6483a563a59ae036d9dca0f1be2835326a5
+    dependencies:
+      - effect
+      - integers
+      - maybe
+      - partial
+      - prelude
+      - random
+  lists:
+    type: git
+    url: https://github.com/purescript/purescript-lists.git
+    rev: b113451e5b41cad87d669a3165f955c71cd863e2
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - lazy
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  maybe:
+    type: git
+    url: https://github.com/purescript/purescript-maybe.git
+    rev: c6f98ac1088766287106c5d9c8e30e7648d36786
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  media-types:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-media-types.git
+    rev: af853de226592f319a953637069a943dd261cba3
+    dependencies:
+      - newtype
+      - prelude
+  newtype:
+    type: git
+    url: https://github.com/purescript/purescript-newtype.git
+    rev: 29d8e6dd77aec2c975c948364ec3faf26e14ee7b
+    dependencies:
+      - prelude
+      - safe-coerce
+  nonempty:
+    type: git
+    url: https://github.com/purescript/purescript-nonempty.git
+    rev: 28150ecc7419238b187abd609a92a645273348bb
+    dependencies:
+      - control
+      - foldable-traversable
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  now:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-now.git
+    rev: b5ffed2381e5fefc063f484e607e8499e79eaf32
+    dependencies:
+      - datetime
+      - effect
+  nullable:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-nullable.git
+    rev: 3202744c6c65e8d1fbba7f4256a1c482078e7fb5
+    dependencies:
+      - effect
+      - functions
+      - maybe
+  numbers:
+    type: git
+    url: https://github.com/purescript/purescript-numbers.git
+    rev: 2a53528f18f9415334bae28e7bb3cf3be86342c2
+    dependencies:
+      - functions
+      - maybe
+  ordered-collections:
+    type: git
+    url: https://github.com/purescript/purescript-ordered-collections.git
+    rev: 9826b7632d0d0a691173bde308a634195f42a419
+    dependencies:
+      - arrays
+      - foldable-traversable
+      - gen
+      - lists
+      - maybe
+      - partial
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+  orders:
+    type: git
+    url: https://github.com/purescript/purescript-orders.git
+    rev: f86db621ec5eef1274145f8b1fd8ebbfe0ed4a2c
+    dependencies:
+      - newtype
+      - prelude
+  parallel:
+    type: git
+    url: https://github.com/purescript/purescript-parallel.git
+    rev: 85290dca837771ac4870071008c933d315ef678f
+    dependencies:
+      - control
+      - effect
+      - either
+      - foldable-traversable
+      - functors
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - refs
+      - transformers
+  partial:
+    type: git
+    url: https://github.com/purescript/purescript-partial.git
+    rev: 0fa0646f5ea1ec5f0c46dcbd770c705a6c9ad3ec
+    dependencies: []
+  prelude:
+    type: git
+    url: https://github.com/purescript/purescript-prelude.git
+    rev: 32787f4399c92459c41602131a5858559eb868c5
+    dependencies: []
+  profunctor:
+    type: git
+    url: https://github.com/purescript/purescript-profunctor.git
+    rev: 0a966a14e7b0c827d44657dc1710cdc712d2e034
+    dependencies:
+      - control
+      - distributive
+      - either
+      - exists
+      - invariant
+      - newtype
+      - prelude
+      - tuples
+  quickcheck:
+    type: git
+    url: https://github.com/purescript/purescript-quickcheck.git
+    rev: bf5029f97e6c0d7552d3a08d2ab793a19e2c5e3d
+    dependencies:
+      - arrays
+      - console
+      - control
+      - effect
+      - either
+      - enums
+      - exceptions
+      - foldable-traversable
+      - gen
+      - identity
+      - integers
+      - lazy
+      - lcg
+      - lists
+      - maybe
+      - newtype
+      - nonempty
+      - numbers
+      - partial
+      - prelude
+      - record
+      - st
+      - strings
+      - tailrec
+      - transformers
+      - tuples
+      - unfoldable
+  random:
+    type: git
+    url: https://github.com/purescript/purescript-random.git
+    rev: 9540bc965a9596da02fefd9949418bb19c92533a
+    dependencies:
+      - effect
+      - integers
+  react-basic:
+    type: git
+    url: https://github.com/lumihq/purescript-react-basic.git
+    rev: 821ac4cb55b5919cc6248b45139164ad1a560e3f
+    dependencies:
+      - effect
+      - prelude
+      - record
+  react-basic-dom:
+    type: git
+    url: https://github.com/lumihq/purescript-react-basic-dom.git
+    rev: 4ee3cd2ec6086aae1476d08f2348f7f9bce8feac
+    dependencies:
+      - effect
+      - foldable-traversable
+      - foreign-object
+      - maybe
+      - nullable
+      - prelude
+      - react-basic
+      - unsafe-coerce
+      - web-dom
+      - web-events
+      - web-file
+      - web-html
+  react-basic-hooks:
+    type: git
+    url: https://github.com/megamaddu/purescript-react-basic-hooks.git
+    rev: 50575f50a68dc8b756b378674dea5c568b8c109d
+    dependencies:
+      - aff
+      - aff-promise
+      - bifunctors
+      - console
+      - control
+      - datetime
+      - effect
+      - either
+      - exceptions
+      - foldable-traversable
+      - functions
+      - indexed-monad
+      - integers
+      - maybe
+      - newtype
+      - now
+      - nullable
+      - ordered-collections
+      - prelude
+      - react-basic
+      - refs
+      - tuples
+      - type-equality
+      - unsafe-coerce
+      - unsafe-reference
+      - web-html
+  record:
+    type: git
+    url: https://github.com/purescript/purescript-record.git
+    rev: c89cd1ada6b636692571fc374196b1c39c4c9f70
+    dependencies:
+      - functions
+      - prelude
+      - unsafe-coerce
+  refs:
+    type: git
+    url: https://github.com/purescript/purescript-refs.git
+    rev: f8e6216da4cb9309fde1f20cd6f69ac3a3b7f9e8
+    dependencies:
+      - effect
+      - prelude
+  safe-coerce:
+    type: git
+    url: https://github.com/purescript/purescript-safe-coerce.git
+    rev: 7fa799ae80a38b8d948efcb52608e58e198b3da7
+    dependencies:
+      - unsafe-coerce
+  st:
+    type: git
+    url: https://github.com/purescript/purescript-st.git
+    rev: 2cc7ae1c3318a303378c4a9f3fa0f10ee7cc3589
+    dependencies:
+      - partial
+      - prelude
+      - tailrec
+      - unsafe-coerce
+  strings:
+    type: git
+    url: https://github.com/purescript/purescript-strings.git
+    rev: 4bc6954448d056f8aa7a659695a6ad60ad4fdf19
+    dependencies:
+      - arrays
+      - control
+      - either
+      - enums
+      - foldable-traversable
+      - gen
+      - integers
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  tailrec:
+    type: git
+    url: https://github.com/purescript/purescript-tailrec.git
+    rev: 5e2104aa734b31a17074cc805bf087d72b65afd1
+    dependencies:
+      - bifunctors
+      - effect
+      - either
+      - identity
+      - maybe
+      - partial
+      - prelude
+      - refs
+  test-unit:
+    type: git
+    url: https://github.com/bodil/purescript-test-unit.git
+    rev: 3112d7ebe06d467238058a6384dc75ffd960d335
+    dependencies:
+      - aff
+      - avar
+      - effect
+      - either
+      - free
+      - js-timers
+      - lists
+      - prelude
+      - quickcheck
+      - strings
+  transformers:
+    type: git
+    url: https://github.com/purescript/purescript-transformers.git
+    rev: be72ab52357d9a665cbf93d73ba1c07c4b0957ee
+    dependencies:
+      - control
+      - distributive
+      - effect
+      - either
+      - exceptions
+      - foldable-traversable
+      - identity
+      - lazy
+      - maybe
+      - newtype
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  tuples:
+    type: git
+    url: https://github.com/purescript/purescript-tuples.git
+    rev: 4f52da2729b448c8564369378f1232d8d2dc1d8b
+    dependencies:
+      - control
+      - invariant
+      - prelude
+  type-equality:
+    type: git
+    url: https://github.com/purescript/purescript-type-equality.git
+    rev: 0525b7d39e0fbd81b4209518139fb8ab02695774
+    dependencies: []
+  typelevel-prelude:
+    type: git
+    url: https://github.com/purescript/purescript-typelevel-prelude.git
+    rev: dca2fe3c8cfd5527d4fe70c4bedfda30148405bf
+    dependencies:
+      - prelude
+      - type-equality
+  unfoldable:
+    type: git
+    url: https://github.com/purescript/purescript-unfoldable.git
+    rev: 493dfe04ed590e20d8f69079df2f58486882748d
+    dependencies:
+      - foldable-traversable
+      - maybe
+      - partial
+      - prelude
+      - tuples
+  unsafe-coerce:
+    type: git
+    url: https://github.com/purescript/purescript-unsafe-coerce.git
+    rev: ab956f82e66e633f647fb3098e8ddd3ec58d689f
+    dependencies: []
+  unsafe-reference:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-unsafe-reference.git
+    rev: 058e23b8b9adcf776a910f9934ff515ddee73af5
+    dependencies:
+      - prelude
+  validation:
+    type: git
+    url: https://github.com/purescript/purescript-validation.git
+    rev: a3d9ec2176a7a808d70a01fa7e6f16d10e05429a
+    dependencies:
+      - bifunctors
+      - control
+      - either
+      - foldable-traversable
+      - newtype
+      - prelude
+  web-dom:
+    type: git
+    url: https://github.com/purescript-web/purescript-web-dom.git
+    rev: 568a1ee158b29e6e739e7a9aaed3e35ca4c4305a
+    dependencies:
+      - web-events
+  web-events:
+    type: git
+    url: https://github.com/purescript-web/purescript-web-events.git
+    rev: 2124356117be7b764a2f3948032255ac4dab7051
+    dependencies:
+      - datetime
+      - enums
+      - foreign
+      - nullable
+  web-file:
+    type: git
+    url: https://github.com/purescript-web/purescript-web-file.git
+    rev: 023786ae62bbb8bf58156dd7f02011fa38221ef1
+    dependencies:
+      - foreign
+      - media-types
+      - web-dom
+  web-html:
+    type: git
+    url: https://github.com/purescript-web/purescript-web-html.git
+    rev: be189cf91b9a19cf493637423522e2fe4a0088cc
+    dependencies:
+      - js-date
+      - web-dom
+      - web-file
+      - web-storage
+  web-storage:
+    type: git
+    url: https://github.com/purescript-web/purescript-web-storage.git
+    rev: 6b74461e136755db70c271dc898d51776363d7e2
+    dependencies:
+      - nullable
+      - web-events

--- a/exercises/chapter8/spago.lock
+++ b/exercises/chapter8/spago.lock
@@ -101,3459 +101,469 @@ workspace:
         - web-storage
   package_set:
     address:
-      url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
-    compiler: ">=0.15.0 <0.16.0"
+      registry: 10.0.0
+    compiler: ">=0.15.4 <0.16.0"
     content:
-      ace:
-        repo: https://github.com/purescript-contrib/purescript-ace.git
-        version: v9.0.0
-        dependencies:
-          - arrays
-          - effect
-          - foreign
-          - nullable
-          - prelude
-          - web-html
-          - web-uievents
-      aff:
-        repo: https://github.com/purescript-contrib/purescript-aff.git
-        version: v7.0.0
-        dependencies:
-          - datetime
-          - effect
-          - exceptions
-          - functions
-          - parallel
-          - transformers
-          - unsafe-coerce
-      aff-bus:
-        repo: https://github.com/purescript-contrib/purescript-aff-bus.git
-        version: v6.0.0
-        dependencies:
-          - aff
-          - avar
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - lists
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-      aff-coroutines:
-        repo: https://github.com/purescript-contrib/purescript-aff-coroutines.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - avar
-          - coroutines
-          - effect
-      aff-promise:
-        repo: https://github.com/nwolverson/purescript-aff-promise.git
-        version: v4.0.0
-        dependencies:
-          - aff
-          - foreign
-      aff-retry:
-        repo: https://github.com/Unisay/purescript-aff-retry.git
-        version: v2.0.0
-        dependencies:
-          - aff
-          - arrays
-          - datetime
-          - effect
-          - either
-          - exceptions
-          - integers
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - random
-          - transformers
-      affjax:
-        repo: https://github.com/purescript-contrib/purescript-affjax.git
-        version: v13.0.0
-        dependencies:
-          - aff
-          - argonaut-core
-          - arraybuffer-types
-          - foreign
-          - form-urlencoded
-          - http-methods
-          - integers
-          - media-types
-          - nullable
-          - refs
-          - unsafe-coerce
-          - web-xhr
-      affjax-node:
-        repo: https://github.com/purescript-contrib/purescript-affjax-node.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - affjax
-          - either
-          - maybe
-          - prelude
-      affjax-web:
-        repo: https://github.com/purescript-contrib/purescript-affjax-web.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - affjax
-          - either
-          - maybe
-          - prelude
-      ansi:
-        repo: https://github.com/hdgarrood/purescript-ansi.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - lists
-          - strings
-      argonaut:
-        repo: https://github.com/purescript-contrib/purescript-argonaut.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - argonaut-traversals
-      argonaut-codecs:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-codecs.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-core
-          - arrays
-          - effect
-          - foreign-object
-          - identity
-          - integers
-          - maybe
-          - nonempty
-          - ordered-collections
-          - prelude
-          - record
-      argonaut-core:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-core.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - foreign-object
-          - functions
-          - gen
-          - maybe
-          - nonempty
-          - prelude
-          - strings
-          - tailrec
-      argonaut-generic:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-generic.git
-        version: v8.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - prelude
-          - record
-      argonaut-traversals:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-traversals.git
-        version: v10.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - profunctor-lenses
-      argparse-basic:
-        repo: https://github.com/natefaubion/purescript-argparse-basic.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - record
-          - strings
-          - tuples
-          - unfoldable
-      arraybuffer:
-        repo: https://github.com/purescript-contrib/purescript-arraybuffer.git
-        version: v13.0.0
-        dependencies:
-          - arraybuffer-types
-          - arrays
-          - effect
-          - float32
-          - functions
-          - gen
-          - maybe
-          - nullable
-          - prelude
-          - tailrec
-          - uint
-          - unfoldable
-      arraybuffer-builder:
-        repo: https://github.com/jamesdbrock/purescript-arraybuffer-builder.git
-        version: v3.0.1
-        dependencies:
-          - arraybuffer
-          - arraybuffer-types
-          - effect
-          - float32
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - transformers
-          - uint
-      arraybuffer-types:
-        repo: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
-        version: v3.0.2
-        dependencies: []
-      arrays:
-        repo: https://github.com/purescript/purescript-arrays.git
-        version: v7.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - foldable-traversable
-          - maybe
-          - nonempty
-          - partial
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - unfoldable
-          - unsafe-coerce
-      arrays-zipper:
-        repo: https://github.com/JordanMartinez/purescript-arrays-zipper.git
-        version: v2.0.1
-        dependencies:
-          - arrays
-          - control
-          - quickcheck
-      ask:
-        repo: https://github.com/Mateiadrielrafael/purescript-ask.git
-        version: v1.0.0
-        dependencies:
-          - unsafe-coerce
-      assert:
-        repo: https://github.com/purescript/purescript-assert.git
-        version: v6.0.0
-        dependencies:
-          - console
-          - effect
-          - prelude
-      avar:
-        repo: https://github.com/purescript-contrib/purescript-avar.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - exceptions
-          - functions
-          - maybe
-      b64:
-        repo: https://github.com/menelaos/purescript-b64.git
-        version: v0.0.8
-        dependencies:
-          - arraybuffer-types
-          - either
-          - encoding
-          - enums
-          - exceptions
-          - functions
-          - partial
-          - prelude
-          - strings
-      barlow-lens:
-        repo: https://github.com/sigma-andex/purescript-barlow-lens.git
-        version: v0.9.0
-        dependencies:
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - profunctor-lenses
-          - tuples
-          - typelevel-prelude
-      bifunctors:
-        repo: https://github.com/purescript/purescript-bifunctors.git
-        version: v6.0.0
-        dependencies:
-          - const
-          - either
-          - newtype
-          - prelude
-          - tuples
-      bigints:
-        repo: https://github.com/sharkdp/purescript-bigints.git
-        version: v7.0.1
-        dependencies:
-          - integers
-          - maybe
-          - strings
-      bower-json:
-        repo: https://github.com/klntsky/purescript-bower-json.git
-        version: v3.0.0
-        dependencies:
-          - argonaut-codecs
-          - arrays
-          - either
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - newtype
-          - prelude
-          - tuples
-      call-by-name:
-        repo: https://github.com/natefaubion/purescript-call-by-name.git
-        version: v4.0.1
-        dependencies:
-          - control
-          - either
-          - lazy
-          - maybe
-          - unsafe-coerce
-      canvas:
-        repo: https://github.com/purescript-web/purescript-canvas.git
-        version: v6.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - exceptions
-          - functions
-          - maybe
-      canvas-action:
-        repo: https://github.com/artemisSystem/purescript-canvas-action.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - arrays
-          - canvas
-          - colors
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - maybe
-          - numbers
-          - polymorphic-vectors
-          - prelude
-          - refs
-          - run
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-html
-      cartesian:
-        repo: https://github.com/Ebmtranceboy/purescript-cartesian.git
-        version: v1.0.6
-        dependencies:
-          - console
-          - effect
-          - integers
-          - psci-support
-      catenable-lists:
-        repo: https://github.com/purescript/purescript-catenable-lists.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - lists
-          - maybe
-          - prelude
-          - tuples
-          - unfoldable
-      channel:
-        repo: https://github.com/ConnorDillon/purescript-channel.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - assert
-          - avar
-          - console
-          - contravariant
-          - control
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - lazy
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      checked-exceptions:
-        repo: https://github.com/natefaubion/purescript-checked-exceptions.git
-        version: v3.1.1
-        dependencies:
-          - prelude
-          - transformers
-          - variant
-      codec:
-        repo: https://github.com/garyb/purescript-codec.git
-        version: v5.0.0
-        dependencies:
-          - profunctor
-          - transformers
-      codec-argonaut:
-        repo: https://github.com/garyb/purescript-codec-argonaut.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-core
-          - codec
-          - ordered-collections
-          - type-equality
-          - variant
-      colors:
-        repo: https://github.com/purescript-contrib/purescript-colors.git
-        version: v7.0.1
-        dependencies:
-          - arrays
-          - integers
-          - lists
-          - numbers
-          - partial
-          - strings
-      concurrent-queues:
-        repo: https://github.com/purescript-contrib/purescript-concurrent-queues.git
-        version: v3.0.0
-        dependencies:
-          - aff
-          - avar
-          - effect
-      console:
-        repo: https://github.com/purescript/purescript-console.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - prelude
-      const:
-        repo: https://github.com/purescript/purescript-const.git
-        version: v6.0.0
-        dependencies:
-          - invariant
-          - newtype
-          - prelude
-      contravariant:
-        repo: https://github.com/purescript/purescript-contravariant.git
-        version: v6.0.0
-        dependencies:
-          - const
-          - either
-          - newtype
-          - prelude
-          - tuples
-      control:
-        repo: https://github.com/purescript/purescript-control.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      convertable-options:
-        repo: https://github.com/natefaubion/purescript-convertable-options.git
-        version: v1.0.0
-        dependencies:
-          - console
-          - effect
-          - maybe
-          - record
-      coroutines:
-        repo: https://github.com/purescript-contrib/purescript-coroutines.git
-        version: v7.0.0
-        dependencies:
-          - freet
-          - parallel
-          - profunctor
-      css:
-        repo: https://github.com/purescript-contrib/purescript-css.git
-        version: v6.0.0
-        dependencies:
-          - colors
-          - console
-          - effect
-          - nonempty
-          - profunctor
-          - strings
-          - these
-          - transformers
-      datetime:
-        repo: https://github.com/purescript/purescript-datetime.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - either
-          - enums
-          - foldable-traversable
-          - functions
-          - gen
-          - integers
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - ordered-collections
-          - partial
-          - prelude
-          - tuples
-      datetime-parsing:
-        repo: https://github.com/flounders/purescript-datetime-parsing.git
-        version: v0.2.0
-        dependencies:
-          - arrays
-          - datetime
-          - either
-          - enums
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - numbers
-          - parsing
-          - prelude
-          - strings
-          - unicode
-      debug:
-        repo: https://github.com/garyb/purescript-debug.git
-        version: v6.0.0
-        dependencies:
-          - functions
-          - prelude
-      decimals:
-        repo: https://github.com/sharkdp/purescript-decimals.git
-        version: v7.0.0
-        dependencies:
-          - maybe
-      dissect:
-        repo: https://github.com/PureFunctor/purescript-dissect.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - foreign-object
-          - functors
-          - newtype
-          - partial
-          - prelude
-          - tailrec
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - variant
-      distributive:
-        repo: https://github.com/purescript/purescript-distributive.git
-        version: v6.0.0
-        dependencies:
-          - identity
-          - newtype
-          - prelude
-          - tuples
-          - type-equality
-      dodo-printer:
-        repo: https://github.com/natefaubion/purescript-dodo-printer.git
-        version: v2.2.0
-        dependencies:
-          - aff
-          - ansi
-          - avar
-          - console
-          - effect
-          - foldable-traversable
-          - lists
-          - maybe
-          - minibench
-          - node-child-process
-          - node-fs-aff
-          - node-process
-          - psci-support
-          - strings
-      dom-indexed:
-        repo: https://github.com/purescript-halogen/purescript-dom-indexed.git
-        version: v11.0.0
-        dependencies:
-          - media-types
-          - prelude
-          - web-clipboard
-          - web-pointerevents
-          - web-touchevents
-      droplet:
-        repo: https://github.com/easafe/purescript-droplet.git
-        version: v0.4.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - bigints
-          - datetime
-          - debug
-          - effect
-          - either
-          - enums
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - integers
-          - maybe
-          - newtype
-          - nullable
-          - ordered-collections
-          - partial
-          - prelude
-          - profunctor
-          - record
-          - spec
-          - strings
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-      dynamic-buffer:
-        repo: https://github.com/kritzcreek/purescript-dynamic-buffer.git
-        version: v3.0.1
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - refs
-      effect:
-        repo: https://github.com/purescript/purescript-effect.git
-        version: v4.0.0
-        dependencies:
-          - prelude
-      either:
-        repo: https://github.com/purescript/purescript-either.git
-        version: v6.1.0
-        dependencies:
-          - control
-          - invariant
-          - maybe
-          - prelude
-      elmish:
-        repo: https://github.com/collegevine/purescript-elmish.git
-        version: v0.8.1
-        dependencies:
-          - aff
-          - argonaut-core
-          - arrays
-          - bifunctors
-          - console
-          - debug
-          - effect
-          - either
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - functions
-          - integers
-          - js-date
-          - maybe
-          - nullable
-          - partial
-          - prelude
-          - refs
-          - typelevel-prelude
-          - undefined-is-not-a-problem
-          - unsafe-coerce
-          - web-dom
-          - web-html
-      elmish-enzyme:
-        repo: https://github.com/collegevine/purescript-elmish-enzyme.git
-        version: v0.1.1
-        dependencies:
-          - aff
-          - aff-promise
-          - arrays
-          - console
-          - debug
-          - effect
-          - elmish
-          - foldable-traversable
-          - foreign
-          - functions
-          - prelude
-          - transformers
-          - unsafe-coerce
-      elmish-hooks:
-        repo: https://github.com/collegevine/purescript-elmish-hooks.git
-        version: v0.8.2
-        dependencies:
-          - aff
-          - debug
-          - elmish
-          - maybe
-          - prelude
-          - tuples
-          - undefined-is-not-a-problem
-      elmish-html:
-        repo: https://github.com/collegevine/purescript-elmish-html.git
-        version: v0.7.1
-        dependencies:
-          - effect
-          - elmish
-          - foreign
-          - foreign-object
-          - prelude
-          - record
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-html
-      email-validate:
-        repo: https://github.com/cdepillabout/purescript-email-validate.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - string-parsers
-          - transformers
-      encoding:
-        repo: https://github.com/menelaos/purescript-encoding.git
-        version: v0.0.8
-        dependencies:
-          - arraybuffer-types
-          - either
-          - exceptions
-          - functions
-          - prelude
-      enums:
-        repo: https://github.com/purescript/purescript-enums.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - either
-          - gen
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tuples
-          - unfoldable
-      exceptions:
-        repo: https://github.com/purescript/purescript-exceptions.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - either
-          - maybe
-          - prelude
-      exists:
-        repo: https://github.com/purescript/purescript-exists.git
-        version: v6.0.0
-        dependencies:
-          - unsafe-coerce
-      exitcodes:
-        repo: https://github.com/Risto-Stevcev/purescript-exitcodes.git
-        version: v4.0.0
-        dependencies:
-          - enums
-      expect-inferred:
-        repo: https://github.com/justinwoo/purescript-expect-inferred.git
-        version: v3.0.0
-        dependencies:
-          - prelude
-          - typelevel-prelude
-      fast-vect:
-        repo: https://github.com/sigma-andex/purescript-fast-vect.git
-        version: v0.7.0
-        dependencies:
-          - arrays
-          - filterable
-          - foldable-traversable
-          - lists
-          - maybe
-          - ordered-collections
-          - prelude
-          - profunctor
-          - tuples
-          - unfoldable
-      filterable:
-        repo: https://github.com/purescript/purescript-filterable.git
-        version: v5.0.0
-        dependencies:
-          - arrays
-          - either
-          - foldable-traversable
-          - identity
-          - lists
-          - ordered-collections
-      fixed-points:
-        repo: https://github.com/purescript-contrib/purescript-fixed-points.git
-        version: v7.0.0
-        dependencies:
-          - exists
-          - newtype
-          - prelude
-          - transformers
-      fixed-precision:
-        repo: https://github.com/lumihq/purescript-fixed-precision.git
-        version: v5.0.0
-        dependencies:
-          - arrays
-          - bigints
-          - control
-          - integers
-          - maybe
-          - numbers
-          - partial
-          - prelude
-          - strings
-      flame:
-        repo: https://github.com/easafe/purescript-flame.git
-        version: v1.2.0
-        dependencies:
-          - aff
-          - argonaut-codecs
-          - argonaut-core
-          - argonaut-generic
-          - arrays
-          - bifunctors
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - maybe
-          - newtype
-          - nullable
-          - partial
-          - prelude
-          - random
-          - refs
-          - spec
-          - strings
-          - tuples
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-html
-          - web-uievents
-      float32:
-        repo: https://github.com/purescript-contrib/purescript-float32.git
-        version: v2.0.0
-        dependencies:
-          - gen
-          - maybe
-          - prelude
-      foldable-traversable:
-        repo: https://github.com/purescript/purescript-foldable-traversable.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - const
-          - control
-          - either
-          - functors
-          - identity
-          - maybe
-          - newtype
-          - orders
-          - prelude
-          - tuples
-      foreign:
-        repo: https://github.com/purescript/purescript-foreign.git
-        version: v7.0.0
-        dependencies:
-          - either
-          - functions
-          - identity
-          - integers
-          - lists
-          - maybe
-          - prelude
-          - strings
-          - transformers
-      foreign-object:
-        repo: https://github.com/purescript/purescript-foreign-object.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - functions
-          - gen
-          - lists
-          - maybe
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - typelevel-prelude
-          - unfoldable
-      foreign-readwrite:
-        repo: https://github.com/artemisSystem/purescript-foreign-readwrite.git
-        version: v3.0.0
-        dependencies:
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - record
-          - safe-coerce
-          - transformers
-          - unsafe-coerce
-      fork:
-        repo: https://github.com/purescript-contrib/purescript-fork.git
-        version: v6.0.0
-        dependencies:
-          - aff
-      form-urlencoded:
-        repo: https://github.com/purescript-contrib/purescript-form-urlencoded.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - js-uri
-          - maybe
-          - newtype
-          - prelude
-          - strings
-          - tuples
-      formatters:
-        repo: https://github.com/purescript-contrib/purescript-formatters.git
-        version: v7.0.0
-        dependencies:
-          - datetime
-          - fixed-points
-          - lists
-          - numbers
-          - parsing
-          - prelude
-          - transformers
-      free:
-        repo: https://github.com/purescript/purescript-free.git
-        version: v7.0.0
-        dependencies:
-          - catenable-lists
-          - control
-          - distributive
-          - either
-          - exists
-          - foldable-traversable
-          - invariant
-          - lazy
-          - maybe
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-      freeap:
-        repo: https://github.com/ethul/purescript-freeap.git
-        version: v7.0.0
-        dependencies:
-          - const
-          - exists
-          - gen
-          - lists
-      freet:
-        repo: https://github.com/purescript-contrib/purescript-freet.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - bifunctors
-          - effect
-          - either
-          - exists
-          - free
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      functions:
-        repo: https://github.com/purescript/purescript-functions.git
-        version: v6.0.0
-        dependencies:
-          - prelude
-      functors:
-        repo: https://github.com/purescript/purescript-functors.git
-        version: v5.0.0
-        dependencies:
-          - bifunctors
-          - const
-          - contravariant
-          - control
-          - distributive
-          - either
-          - invariant
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - tuples
-          - unsafe-coerce
-      fuzzy:
-        repo: https://github.com/citizennet/purescript-fuzzy.git
-        version: v0.4.0
-        dependencies:
-          - foldable-traversable
-          - foreign-object
-          - newtype
-          - ordered-collections
-          - prelude
-          - rationals
-          - strings
-          - tuples
-      gen:
-        repo: https://github.com/purescript/purescript-gen.git
-        version: v4.0.0
-        dependencies:
-          - either
-          - foldable-traversable
-          - identity
-          - maybe
-          - newtype
-          - nonempty
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      generate-values:
-        repo: https://github.com/jordanmartinez/purescript-generate-values.git
-        version: v1.0.1
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - enums
-          - foldable-traversable
-          - gen
-          - identity
-          - integers
-          - lcg
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - partial
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      geometry-plane:
-        repo: https://github.com/Ebmtranceboy/purescript-geometry-plane.git
-        version: v1.0.3
-        dependencies:
-          - console
-          - effect
-          - psci-support
-          - sparse-polynomials
-      github-actions-toolkit:
-        repo: https://github.com/purescript-contrib/purescript-github-actions-toolkit.git
-        version: v0.5.0
-        dependencies:
-          - aff
-          - aff-promise
-          - effect
-          - foreign-object
-          - node-buffer
-          - node-path
-          - node-streams
-          - nullable
-          - transformers
-      graphs:
-        repo: https://github.com/purescript/purescript-graphs.git
-        version: v8.0.0
-        dependencies:
-          - catenable-lists
-          - ordered-collections
-      group:
-        repo: https://github.com/morganthomas/purescript-group.git
-        version: v4.1.1
-        dependencies:
-          - lists
-      halogen:
-        repo: https://github.com/purescript-halogen/purescript-halogen.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - avar
-          - console
-          - const
-          - dom-indexed
-          - effect
-          - foreign
-          - fork
-          - free
-          - freeap
-          - halogen-subscriptions
-          - halogen-vdom
-          - media-types
-          - nullable
-          - ordered-collections
-          - parallel
-          - profunctor
-          - transformers
-          - unsafe-coerce
-          - unsafe-reference
-          - web-file
-          - web-uievents
-      halogen-css:
-        repo: https://github.com/purescript-halogen/purescript-halogen-css.git
-        version: v10.0.0
-        dependencies:
-          - css
-          - halogen
-      halogen-formless:
-        repo: https://github.com/thomashoneyman/purescript-halogen-formless.git
-        version: v4.0.0
-        dependencies:
-          - convertable-options
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - halogen
-          - heterogeneous
-          - maybe
-          - prelude
-          - record
-          - safe-coerce
-          - type-equality
-          - unsafe-coerce
-          - unsafe-reference
-          - variant
-          - web-events
-          - web-uievents
-      halogen-hooks:
-        repo: https://github.com/thomashoneyman/purescript-halogen-hooks.git
-        version: v0.6.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - effect
-          - exceptions
-          - foldable-traversable
-          - foreign-object
-          - free
-          - freeap
-          - halogen
-          - halogen-subscriptions
-          - maybe
-          - newtype
-          - ordered-collections
-          - parallel
-          - partial
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-          - unsafe-reference
-          - web-dom
-          - web-html
-      halogen-hooks-extra:
-        repo: https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git
-        version: v0.9.0
-        dependencies:
-          - halogen-hooks
-      halogen-store:
-        repo: https://github.com/thomashoneyman/purescript-halogen-store.git
-        version: v0.5.0
-        dependencies:
-          - aff
-          - distributive
-          - effect
-          - fork
-          - halogen
-          - halogen-hooks
-          - halogen-subscriptions
-          - maybe
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-reference
-      halogen-storybook:
-        repo: https://github.com/rnons/purescript-halogen-storybook.git
-        version: v2.0.0
-        dependencies:
-          - foreign-object
-          - halogen
-          - prelude
-          - routing
-      halogen-subscriptions:
-        repo: https://github.com/purescript-halogen/purescript-halogen-subscriptions.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - effect
-          - foldable-traversable
-          - functors
-          - refs
-          - safe-coerce
-          - unsafe-reference
-      halogen-svg-elems:
-        repo: https://github.com/JordanMartinez/purescript-halogen-svg-elems.git
-        version: v6.0.0
-        dependencies:
-          - halogen
-      halogen-vdom:
-        repo: https://github.com/purescript-halogen/purescript-halogen-vdom.git
-        version: v8.0.0
-        dependencies:
-          - bifunctors
-          - effect
-          - foreign
-          - foreign-object
-          - maybe
-          - prelude
-          - refs
-          - tuples
-          - unsafe-coerce
-          - web-html
-      halogen-vdom-string-renderer:
-        repo: https://github.com/purescript-halogen/purescript-halogen-vdom-string-renderer.git
-        version: v0.5.0
-        dependencies:
-          - foreign
-          - halogen-vdom
-          - ordered-collections
-          - prelude
-      heckin:
-        repo: https://github.com/maxdeviant/purescript-heckin.git
-        version: v2.0.1
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - maybe
-          - prelude
-          - strings
-          - transformers
-          - tuples
-          - unicode
-      heterogeneous:
-        repo: https://github.com/natefaubion/purescript-heterogeneous.git
-        version: v0.6.0
-        dependencies:
-          - either
-          - functors
-          - prelude
-          - record
-          - tuples
-          - variant
-      heterogeneous-extrablatt:
-        repo: https://github.com/sigma-andex/purescript-heterogeneous-extrablatt.git
-        version: v0.2.1
-        dependencies:
-          - heterogeneous
-          - prelude
-          - record
-      http-methods:
-        repo: https://github.com/purescript-contrib/purescript-http-methods.git
-        version: v6.0.0
-        dependencies:
-          - either
-          - prelude
-          - strings
-      httpure:
-        repo: https://github.com/citizennet/purescript-httpure.git
-        version: v0.15.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - js-uri
-          - maybe
-          - newtype
-          - node-buffer
-          - node-fs
-          - node-http
-          - node-streams
-          - options
-          - ordered-collections
-          - prelude
-          - refs
-          - strings
-          - tuples
-          - type-equality
-      httpurple:
-        repo: https://github.com/sigma-andex/purescript-httpurple.git
-        version: v1.3.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - js-uri
-          - justifill
-          - maybe
-          - newtype
-          - node-buffer
-          - node-fs
-          - node-http
-          - node-net
-          - node-process
-          - node-streams
-          - options
-          - ordered-collections
-          - posix-types
-          - prelude
-          - profunctor
-          - record
-          - refs
-          - routing-duplex
-          - strings
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-      httpurple-argonaut:
-        repo: https://github.com/sigma-andex/purescript-httpurple-argonaut.git
-        version: v1.0.1
-        dependencies:
-          - argonaut
-          - console
-          - effect
-          - either
-          - httpurple
-          - prelude
-      httpurple-yoga-json:
-        repo: https://github.com/sigma-andex/purescript-httpurple-yoga-json.git
-        version: v1.0.0
-        dependencies:
-          - console
-          - effect
-          - either
-          - foreign
-          - httpurple
-          - lists
-          - prelude
-          - yoga-json
-      identity:
-        repo: https://github.com/purescript/purescript-identity.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - invariant
-          - newtype
-          - prelude
-      indexed-monad:
-        repo: https://github.com/garyb/purescript-indexed-monad.git
-        version: v2.1.0
-        dependencies:
-          - control
-          - newtype
-      int64:
-        repo: https://github.com/purescript-contrib/purescript-int64.git
-        version: v2.0.0
-        dependencies:
-          - effect
-          - foreign
-          - functions
-          - integers
-          - maybe
-          - nullable
-          - prelude
-          - quickcheck
-      integers:
-        repo: https://github.com/purescript/purescript-integers.git
-        version: v6.0.0
-        dependencies:
-          - maybe
-          - numbers
-          - prelude
-      interpolate:
-        repo: https://github.com/jordanmartinez/purescript-interpolate.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-      invariant:
-        repo: https://github.com/purescript/purescript-invariant.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - prelude
-      js-date:
-        repo: https://github.com/purescript-contrib/purescript-js-date.git
-        version: v8.0.0
-        dependencies:
-          - datetime
-          - effect
-          - exceptions
-          - foreign
-          - integers
-          - now
-      js-fileio:
-        repo: https://github.com/newlandsvalley/purescript-js-fileio.git
-        version: v3.0.0
-        dependencies:
-          - aff
-          - effect
-          - prelude
-      js-timers:
-        repo: https://github.com/purescript-contrib/purescript-js-timers.git
-        version: v6.1.0
-        dependencies:
-          - effect
-      js-uri:
-        repo: https://github.com/purescript-contrib/purescript-js-uri.git
-        version: v3.0.0
-        dependencies:
-          - functions
-          - maybe
-      justifill:
-        repo: https://github.com/i-am-the-slime/purescript-justifill.git
-        version: v0.5.0
-        dependencies:
-          - maybe
-          - prelude
-          - record
-          - typelevel-prelude
-      jwt:
-        repo: https://github.com/menelaos/purescript-jwt.git
-        version: v0.0.9
-        dependencies:
-          - argonaut-core
-          - arrays
-          - b64
-          - either
-          - exceptions
-          - prelude
-          - profunctor-lenses
-          - strings
-      language-cst-parser:
-        repo: https://github.com/natefaubion/purescript-language-cst-parser.git
-        version: v0.12.0
-        dependencies:
-          - arrays
-          - const
-          - control
-          - either
-          - foldable-traversable
-          - free
-          - functions
-          - functors
-          - identity
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - ordered-collections
-          - partial
-          - prelude
-          - st
-          - strings
-          - transformers
-          - tuples
-          - typelevel-prelude
-          - unfoldable
-          - unsafe-coerce
-      lazy:
-        repo: https://github.com/purescript/purescript-lazy.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - invariant
-          - prelude
-      lcg:
-        repo: https://github.com/purescript/purescript-lcg.git
-        version: v4.0.0
-        dependencies:
-          - effect
-          - integers
-          - maybe
-          - partial
-          - prelude
-          - random
-      leibniz:
-        repo: https://github.com/paf31/purescript-leibniz.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-          - unsafe-coerce
-      linalg:
-        repo: https://github.com/gbagan/purescript-linalg.git
-        version: v5.1.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - functions
-          - maybe
-          - prelude
-          - tuples
-      lists:
-        repo: https://github.com/purescript/purescript-lists.git
-        version: v7.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - foldable-traversable
-          - lazy
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      logging:
-        repo: https://github.com/rightfold/purescript-logging.git
-        version: v3.0.0
-        dependencies:
-          - console
-          - contravariant
-          - effect
-          - either
-          - prelude
-          - transformers
-          - tuples
-      machines:
-        repo: https://github.com/purescript-contrib/purescript-machines.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - lists
-          - maybe
-          - prelude
-          - profunctor
-          - tuples
-          - unfoldable
-      matrices:
-        repo: https://github.com/kRITZCREEK/purescript-matrices.git
-        version: v5.0.1
-        dependencies:
-          - arrays
-          - strings
-      matryoshka:
-        repo: https://github.com/purescript-contrib/purescript-matryoshka.git
-        version: v1.0.0
-        dependencies:
-          - fixed-points
-          - free
-          - prelude
-          - profunctor
-          - transformers
-      maybe:
-        repo: https://github.com/purescript/purescript-maybe.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - invariant
-          - newtype
-          - prelude
-      media-types:
-        repo: https://github.com/purescript-contrib/purescript-media-types.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      metadata:
-        repo: https://github.com/purescript/purescript-metadata.git
-        version: v0.15.0
-        dependencies: []
-      midi:
-        repo: https://github.com/newlandsvalley/purescript-midi.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - ordered-collections
-          - prelude
-          - signal
-          - string-parsers
-          - strings
-          - tuples
-          - unfoldable
-      minibench:
-        repo: https://github.com/purescript/purescript-minibench.git
-        version: v4.0.0
-        dependencies:
-          - console
-          - effect
-          - integers
-          - numbers
-          - partial
-          - prelude
-          - refs
-      mmorph:
-        repo: https://github.com/Thimoteus/purescript-mmorph.git
-        version: v7.0.0
-        dependencies:
-          - free
-          - functors
-          - transformers
-      monad-control:
-        repo: https://github.com/athanclark/purescript-monad-control.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - freet
-          - identity
-          - lists
-      monad-logger:
-        repo: https://github.com/cprussin/purescript-monad-logger.git
-        version: v1.3.1
-        dependencies:
-          - aff
-          - ansi
-          - argonaut
-          - arrays
-          - console
-          - control
-          - effect
-          - foldable-traversable
-          - foreign-object
-          - integers
-          - js-date
-          - maybe
-          - newtype
-          - ordered-collections
-          - prelude
-          - strings
-          - transformers
-          - tuples
-      monad-loops:
-        repo: https://github.com/mlang/purescript-monad-loops.git
-        version: v0.5.0
-        dependencies:
-          - lists
-          - maybe
-          - prelude
-          - tailrec
-          - tuples
-      monad-unlift:
-        repo: https://github.com/athanclark/purescript-monad-unlift.git
-        version: v1.0.1
-        dependencies:
-          - monad-control
-      monoidal:
-        repo: https://github.com/mcneissue/purescript-monoidal.git
-        version: v0.16.0
-        dependencies:
-          - either
-          - profunctor
-          - these
-          - tuples
-      morello:
-        repo: https://github.com/sigma-andex/purescript-morello.git
-        version: v0.3.2
-        dependencies:
-          - arrays
-          - barlow-lens
-          - foldable-traversable
-          - heterogeneous
-          - heterogeneous-extrablatt
-          - newtype
-          - prelude
-          - profunctor
-          - profunctor-lenses
-          - record
-          - tuples
-          - typelevel-prelude
-          - validation
-      motsunabe:
-        repo: https://github.com/justinwoo/purescript-motsunabe.git
-        version: v2.0.0
-        dependencies:
-          - lists
-          - strings
-      nano-id:
-        repo: https://github.com/eikooc/nano-id.git
-        version: v1.1.0
-        dependencies:
-          - aff
-          - effect
-          - lists
-          - maybe
-          - prelude
-          - random
-          - spec
-          - strings
-          - stringutils
-      naturals:
-        repo: https://github.com/LiamGoodacre/purescript-naturals.git
-        version: v3.0.0
-        dependencies:
-          - enums
-          - maybe
-          - prelude
-      nested-functor:
-        repo: https://github.com/acple/purescript-nested-functor.git
-        version: v0.2.1
-        dependencies:
-          - prelude
-          - type-equality
-      newtype:
-        repo: https://github.com/purescript/purescript-newtype.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-          - safe-coerce
-      node-buffer:
-        repo: https://github.com/purescript-node/purescript-node-buffer.git
-        version: v8.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - maybe
-          - st
-          - unsafe-coerce
-      node-buffer-blob:
-        repo: https://github.com/purescript-node/purescript-node-buffer-blob.git
-        version: v1.0.0
-        dependencies:
-          - aff-promise
-          - arraybuffer-types
-          - arrays
-          - console
-          - effect
-          - maybe
-          - media-types
-          - newtype
-          - node-buffer
-          - nullable
-          - prelude
-          - web-streams
-      node-child-process:
-        repo: https://github.com/purescript-node/purescript-node-child-process.git
-        version: v9.0.0
-        dependencies:
-          - exceptions
-          - foreign
-          - foreign-object
-          - functions
-          - node-fs
-          - node-streams
-          - nullable
-          - posix-types
-          - unsafe-coerce
-      node-fs:
-        repo: https://github.com/purescript-node/purescript-node-fs.git
-        version: v8.0.0
-        dependencies:
-          - datetime
-          - effect
-          - either
-          - enums
-          - exceptions
-          - functions
-          - integers
-          - js-date
-          - maybe
-          - node-buffer
-          - node-path
-          - node-streams
-          - nullable
-          - partial
-          - prelude
-          - strings
-          - unsafe-coerce
-      node-fs-aff:
-        repo: https://github.com/purescript-node/purescript-node-fs-aff.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - either
-          - node-fs
-          - node-path
-      node-http:
-        repo: https://github.com/purescript-node/purescript-node-http.git
-        version: v8.0.0
-        dependencies:
-          - arraybuffer-types
-          - contravariant
-          - effect
-          - foreign
-          - foreign-object
-          - maybe
-          - node-buffer
-          - node-net
-          - node-streams
-          - node-url
-          - nullable
-          - options
-          - prelude
-          - unsafe-coerce
-      node-net:
-        repo: https://github.com/purescript-node/purescript-node-net.git
-        version: v4.0.0
-        dependencies:
-          - effect
-          - either
-          - exceptions
-          - foreign
-          - maybe
-          - node-buffer
-          - node-fs
-          - nullable
-          - options
-          - prelude
-          - transformers
-      node-path:
-        repo: https://github.com/purescript-node/purescript-node-path.git
-        version: v5.0.0
-        dependencies:
-          - effect
-      node-process:
-        repo: https://github.com/purescript-node/purescript-node-process.git
-        version: v10.0.0
-        dependencies:
-          - effect
-          - foreign-object
-          - maybe
-          - node-streams
-          - posix-types
-          - prelude
-          - unsafe-coerce
-      node-readline:
-        repo: https://github.com/purescript-node/purescript-node-readline.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - foreign
-          - node-process
-          - node-streams
-          - options
-          - prelude
-      node-streams:
-        repo: https://github.com/purescript-node/purescript-node-streams.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - either
-          - exceptions
-          - node-buffer
-          - nullable
-          - prelude
-      node-streams-aff:
-        repo: https://github.com/jamesdbrock/purescript-node-streams-aff.git
-        version: v2.0.0
-        dependencies:
-          - aff
-          - arrays
-          - effect
-          - either
-          - exceptions
-          - maybe
-          - node-buffer
-          - node-streams
-          - prelude
-          - st
-          - tuples
-      node-url:
-        repo: https://github.com/purescript-node/purescript-node-url.git
-        version: v6.0.0
-        dependencies:
-          - nullable
-      nonempty:
-        repo: https://github.com/purescript/purescript-nonempty.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - maybe
-          - prelude
-          - tuples
-          - unfoldable
-      now:
-        repo: https://github.com/purescript-contrib/purescript-now.git
-        version: v6.0.0
-        dependencies:
-          - datetime
-          - effect
-      npm-package-json:
-        repo: https://github.com/maxdeviant/purescript-npm-package-json.git
-        version: v2.0.0
-        dependencies:
-          - argonaut
-          - control
-          - either
-          - foreign-object
-          - maybe
-          - ordered-collections
-          - prelude
-      nullable:
-        repo: https://github.com/purescript-contrib/purescript-nullable.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - functions
-          - maybe
-      numbers:
-        repo: https://github.com/purescript/purescript-numbers.git
-        version: v9.0.0
-        dependencies:
-          - functions
-          - maybe
-      open-folds:
-        repo: https://github.com/purescript-open-community/purescript-open-folds.git
-        version: v6.3.0
-        dependencies:
-          - bifunctors
-          - console
-          - control
-          - distributive
-          - effect
-          - either
-          - foldable-traversable
-          - identity
-          - invariant
-          - maybe
-          - newtype
-          - ordered-collections
-          - prelude
-          - profunctor
-          - psci-support
-          - tuples
-      open-memoize:
-        repo: https://github.com/purescript-open-community/purescript-open-memoize.git
-        version: v6.1.0
-        dependencies:
-          - console
-          - effect
-          - either
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - psci-support
-          - strings
-          - tuples
-      open-pairing:
-        repo: https://github.com/purescript-open-community/purescript-open-pairing.git
-        version: v6.1.0
-        dependencies:
-          - console
-          - control
-          - effect
-          - either
-          - free
-          - functors
-          - identity
-          - newtype
-          - prelude
-          - psci-support
-          - transformers
-          - tuples
-      options:
-        repo: https://github.com/purescript-contrib/purescript-options.git
-        version: v7.0.0
-        dependencies:
-          - contravariant
-          - foreign
-          - foreign-object
-          - maybe
-          - tuples
-      optparse:
-        repo: https://github.com/f-o-a-m/purescript-optparse.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - control
-          - effect
-          - either
-          - enums
-          - exists
-          - exitcodes
-          - foldable-traversable
-          - free
-          - gen
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - newtype
-          - node-buffer
-          - node-process
-          - node-streams
-          - nonempty
-          - numbers
-          - open-memoize
-          - partial
-          - prelude
-          - quickcheck
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-      ordered-collections:
-        repo: https://github.com/purescript/purescript-ordered-collections.git
-        version: v3.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - gen
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - unfoldable
-      ordered-set:
-        repo: https://github.com/flip111/purescript-ordered-set.git
-        version: v0.4.0
-        dependencies:
-          - argonaut-codecs
-          - arrays
-          - partial
-          - prelude
-          - unfoldable
-      orders:
-        repo: https://github.com/purescript/purescript-orders.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      pairs:
-        repo: https://github.com/sharkdp/purescript-pairs.git
-        version: v9.0.0
-        dependencies:
-          - console
-          - distributive
-          - foldable-traversable
-          - quickcheck
-      parallel:
-        repo: https://github.com/purescript/purescript-parallel.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - functors
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - refs
-          - transformers
-      parsing:
-        repo: https://github.com/purescript-contrib/purescript-parsing.git
-        version: v9.1.0
-        dependencies:
-          - arrays
-          - either
-          - foldable-traversable
-          - identity
-          - integers
-          - lists
-          - maybe
-          - nullable
-          - prelude
-          - strings
-          - transformers
-          - unicode
-      parsing-dataview:
-        repo: https://github.com/jamesdbrock/purescript-parsing-dataview.git
-        version: v3.1.0
-        dependencies:
-          - arraybuffer
-          - arraybuffer-types
-          - effect
-          - float32
-          - maybe
-          - parsing
-          - prelude
-          - transformers
-          - tuples
-          - uint
-      partial:
-        repo: https://github.com/purescript/purescript-partial.git
-        version: v4.0.0
-        dependencies: []
-      pathy:
-        repo: https://github.com/purescript-contrib/purescript-pathy.git
-        version: v9.0.0
-        dependencies:
-          - console
-          - exceptions
-          - lists
-          - partial
-          - profunctor
-          - strings
-          - transformers
-          - typelevel-prelude
-          - unsafe-coerce
-      pha:
-        repo: https://github.com/gbagan/purescript-pha.git
-        version: v0.9.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - datetime
-          - effect
-          - foldable-traversable
-          - free
-          - integers
-          - maybe
-          - prelude
-          - profunctor-lenses
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-          - unsafe-reference
-          - web-dom
-          - web-events
-          - web-html
-          - web-pointerevents
-          - web-uievents
-      phaser:
-        repo: https://github.com/lfarroco/purescript-phaser.git
-        version: v0.6.0
-        dependencies:
-          - canvas
-          - console
-          - effect
-          - maybe
-          - nullable
-          - options
-          - prelude
-          - web-html
-      pipes:
-        repo: https://github.com/felixschl/purescript-pipes.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - lists
-          - mmorph
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      point-free:
-        repo: https://github.com/ursi/purescript-point-free.git
-        version: v1.0.0
-        dependencies:
-          - prelude
-      polymorphic-vectors:
-        repo: https://github.com/artemisSystem/purescript-polymorphic-vectors.git
-        version: v4.0.0
-        dependencies:
-          - distributive
-          - foldable-traversable
-          - numbers
-          - prelude
-          - record
-          - safe-coerce
-          - type-equality
-          - typelevel-prelude
-      posix-types:
-        repo: https://github.com/purescript-node/purescript-posix-types.git
-        version: v6.0.0
-        dependencies:
-          - maybe
-          - prelude
-      precise:
-        repo: https://github.com/purescript-contrib/purescript-precise.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - exceptions
-          - gen
-          - integers
-          - lists
-          - numbers
-          - prelude
-          - strings
-      precise-datetime:
-        repo: https://github.com/awakesecurity/purescript-precise-datetime.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - datetime
-          - decimals
-          - either
-          - enums
-          - foldable-traversable
-          - formatters
-          - integers
-          - js-date
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - strings
-          - tuples
-          - unicode
-      prelude:
-        repo: https://github.com/purescript/purescript-prelude.git
-        version: v6.0.0
-        dependencies: []
-      prettier-printer:
-        repo: https://github.com/paulyoung/purescript-prettier-printer.git
-        version: v3.0.0
-        dependencies:
-          - console
-          - lists
-          - prelude
-          - strings
-          - tuples
-      profunctor:
-        repo: https://github.com/purescript/purescript-profunctor.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - distributive
-          - either
-          - exists
-          - invariant
-          - newtype
-          - prelude
-          - tuples
-      profunctor-lenses:
-        repo: https://github.com/purescript-contrib/purescript-profunctor-lenses.git
-        version: v8.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - const
-          - control
-          - distributive
-          - either
-          - foldable-traversable
-          - foreign-object
-          - functors
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - ordered-collections
-          - partial
-          - prelude
-          - profunctor
-          - record
-          - transformers
-          - tuples
-      protobuf:
-        repo: https://github.com/xc-jp/purescript-protobuf.git
-        version: v4.0.0
-        dependencies:
-          - arraybuffer
-          - arraybuffer-builder
-          - arraybuffer-types
-          - arrays
-          - control
-          - effect
-          - either
-          - enums
-          - exceptions
-          - float32
-          - foldable-traversable
-          - functions
-          - int64
-          - maybe
-          - newtype
-          - parsing
-          - parsing-dataview
-          - prelude
-          - record
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-          - uint
-          - web-encoding
-      ps-cst:
-        repo: https://github.com/purescript-codegen/purescript-ps-cst.git
-        version: v1.2.0
-        dependencies:
-          - ansi
-          - console
-          - dodo-printer
-          - effect
-          - node-fs-aff
-          - node-path
-          - psci-support
-          - record
-          - strings
-      psa-utils:
-        repo: https://github.com/natefaubion/purescript-psa-utils.git
-        version: v8.0.0
-        dependencies:
-          - ansi
-          - argonaut-codecs
-          - argonaut-core
-          - arrays
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - maybe
-          - node-path
-          - ordered-collections
-          - prelude
-          - strings
-          - tuples
-          - unsafe-coerce
-      psc-ide:
-        repo: https://github.com/kRITZCREEK/purescript-psc-ide.git
-        version: v19.0.0
-        dependencies:
-          - aff
-          - argonaut
-          - arrays
-          - console
-          - maybe
-          - node-child-process
-          - node-fs
-          - parallel
-          - random
-      psci-support:
-        repo: https://github.com/purescript/purescript-psci-support.git
-        version: v6.0.0
-        dependencies:
-          - console
-          - effect
-          - prelude
-      qualified-do:
-        repo: https://github.com/artemisSystem/purescript-qualified-do.git
-        version: v2.2.0
-        dependencies:
-          - arrays
-          - control
-          - foldable-traversable
-          - parallel
-          - prelude
-          - unfoldable
-      quantities:
-        repo: https://github.com/sharkdp/purescript-quantities.git
-        version: v12.0.1
-        dependencies:
-          - decimals
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - newtype
-          - nonempty
-          - numbers
-          - pairs
-          - prelude
-          - tuples
-      quickcheck:
-        repo: https://github.com/purescript/purescript-quickcheck.git
-        version: v8.0.1
-        dependencies:
-          - arrays
-          - console
-          - control
-          - effect
-          - either
-          - enums
-          - exceptions
-          - foldable-traversable
-          - gen
-          - identity
-          - integers
-          - lazy
-          - lcg
-          - lists
-          - maybe
-          - newtype
-          - nonempty
-          - numbers
-          - partial
-          - prelude
-          - record
-          - st
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-          - unfoldable
-      quickcheck-combinators:
-        repo: https://github.com/athanclark/purescript-quickcheck-combinators.git
-        version: v0.1.3
-        dependencies:
-          - quickcheck
-          - typelevel
-      quickcheck-laws:
-        repo: https://github.com/purescript-contrib/purescript-quickcheck-laws.git
-        version: v7.0.0
-        dependencies:
-          - enums
-          - quickcheck
-      quickcheck-utf8:
-        repo: https://github.com/openchronology/purescript-quickcheck-utf8.git
-        version: v0.0.0
-        dependencies:
-          - quickcheck
-      quotient:
-        repo: https://github.com/rightfold/purescript-quotient.git
-        version: v3.0.0
-        dependencies:
-          - prelude
-          - quickcheck
-      random:
-        repo: https://github.com/purescript/purescript-random.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - integers
-      rationals:
-        repo: https://github.com/anttih/purescript-rationals.git
-        version: v5.0.0
-        dependencies:
-          - integers
-          - prelude
-      react:
-        repo: https://github.com/purescript-contrib/purescript-react.git
-        version: v10.0.1
-        dependencies:
-          - effect
-          - exceptions
-          - maybe
-          - nullable
-          - prelude
-          - typelevel-prelude
-          - unsafe-coerce
-      react-basic:
-        repo: https://github.com/lumihq/purescript-react-basic.git
-        version: v17.0.0
-        dependencies:
-          - effect
-          - prelude
-          - record
-      react-basic-dom:
-        repo: https://github.com/lumihq/purescript-react-basic-dom.git
-        version: v5.0.0
-        dependencies:
-          - effect
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - nullable
-          - prelude
-          - react-basic
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-file
-          - web-html
-      react-basic-hooks:
-        repo: https://github.com/megamaddu/purescript-react-basic-hooks.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - aff-promise
-          - bifunctors
-          - console
-          - control
-          - datetime
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - functions
-          - indexed-monad
-          - integers
-          - maybe
-          - newtype
-          - now
-          - nullable
-          - ordered-collections
-          - prelude
-          - react-basic
-          - refs
-          - tuples
-          - type-equality
-          - unsafe-coerce
-          - unsafe-reference
-          - web-html
-      react-dom:
-        repo: https://github.com/purescript-contrib/purescript-react-dom.git
-        version: v8.0.0
-        dependencies:
-          - effect
-          - react
-          - web-dom
-      read:
-        repo: https://github.com/truqu/purescript-read.git
-        version: v1.0.1
-        dependencies:
-          - maybe
-          - prelude
-          - strings
-      record:
-        repo: https://github.com/purescript/purescript-record.git
-        version: v4.0.0
-        dependencies:
-          - functions
-          - prelude
-          - unsafe-coerce
-      refined:
-        repo: https://github.com/danieljharvey/purescript-refined.git
-        version: v1.0.0
-        dependencies:
-          - argonaut
-          - effect
-          - prelude
-          - quickcheck
-          - typelevel
-      refs:
-        repo: https://github.com/purescript/purescript-refs.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - prelude
-      remotedata:
-        repo: https://github.com/krisajenkins/purescript-remotedata.git
-        version: v5.0.0
-        dependencies:
-          - bifunctors
-          - either
-          - profunctor-lenses
-      resource:
-        repo: https://github.com/joneshf/purescript-resource.git
-        version: v2.0.1
-        dependencies:
-          - aff
-          - console
-          - control
-          - effect
-          - newtype
-          - prelude
-          - psci-support
-          - refs
-      resourcet:
-        repo: https://github.com/robertdp/purescript-resourcet.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - effect
-          - foldable-traversable
-          - maybe
-          - ordered-collections
-          - parallel
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-      result:
-        repo: https://github.com/ad-si/purescript-result.git
-        version: v1.0.3
-        dependencies:
-          - either
-          - foldable-traversable
-          - prelude
-      return:
-        repo: https://github.com/ursi/purescript-return.git
-        version: v0.2.0
-        dependencies:
-          - foldable-traversable
-          - point-free
-          - prelude
-      ring-modules:
-        repo: https://github.com/f-o-a-m/purescript-ring-modules.git
-        version: v5.0.1
-        dependencies:
-          - prelude
-      routing:
-        repo: https://github.com/purescript-contrib/purescript-routing.git
-        version: v11.0.0
-        dependencies:
-          - aff
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - integers
-          - js-uri
-          - lists
-          - maybe
-          - numbers
-          - partial
-          - prelude
-          - semirings
-          - tuples
-          - validation
-          - web-html
-      routing-duplex:
-        repo: https://github.com/natefaubion/purescript-routing-duplex.git
-        version: v0.6.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - js-uri
-          - lazy
-          - numbers
-          - prelude
-          - profunctor
-          - record
-          - strings
-          - typelevel-prelude
-      run:
-        repo: https://github.com/natefaubion/purescript-run.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - free
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - tailrec
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - variant
-      safe-coerce:
-        repo: https://github.com/purescript/purescript-safe-coerce.git
-        version: v2.0.0
-        dependencies:
-          - unsafe-coerce
-      safely:
-        repo: https://github.com/paf31/purescript-safely.git
-        version: v4.0.1
-        dependencies:
-          - freet
-          - lists
-      selection-foldable:
-        repo: https://github.com/jamieyung/purescript-selection-foldable.git
-        version: v0.2.0
-        dependencies:
-          - filterable
-          - foldable-traversable
-          - maybe
-          - prelude
-      semirings:
-        repo: https://github.com/purescript/purescript-semirings.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - lists
-          - newtype
-          - prelude
-      signal:
-        repo: https://github.com/bodil/purescript-signal.git
-        version: v13.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - foldable-traversable
-          - maybe
-          - prelude
-      simple-emitter:
-        repo: https://github.com/oreshinya/purescript-simple-emitter.git
-        version: v2.0.0
-        dependencies:
-          - ordered-collections
-          - refs
-      sized-matrices:
-        repo: https://github.com/csicar/purescript-sized-matrices.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - distributive
-          - foldable-traversable
-          - maybe
-          - prelude
-          - sized-vectors
-          - strings
-          - typelevel
-          - unfoldable
-          - vectorfield
-      sized-vectors:
-        repo: https://github.com/bodil/purescript-sized-vectors.git
-        version: v5.0.2
-        dependencies:
-          - argonaut
-          - arrays
-          - distributive
-          - foldable-traversable
-          - maybe
-          - prelude
-          - quickcheck
-          - typelevel
-          - unfoldable
-      slug:
-        repo: https://github.com/thomashoneyman/purescript-slug.git
-        version: v3.0.1
-        dependencies:
-          - argonaut-codecs
-          - maybe
-          - prelude
-          - strings
-          - unicode
-      soundfonts:
-        repo: https://github.com/newlandsvalley/purescript-soundfonts.git
-        version: v4.1.0
-        dependencies:
-          - aff
-          - affjax
-          - affjax-web
-          - argonaut-core
-          - arraybuffer-types
-          - arrays
-          - b64
-          - bifunctors
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign-object
-          - http-methods
-          - integers
-          - lists
-          - maybe
-          - midi
-          - ordered-collections
-          - parallel
-          - partial
-          - prelude
-          - strings
-          - transformers
-          - tuples
-      sparse-matrices:
-        repo: https://github.com/Ebmtranceboy/purescript-sparse-matrices.git
-        version: v1.2.1
-        dependencies:
-          - console
-          - effect
-          - prelude
-          - sparse-polynomials
-      sparse-polynomials:
-        repo: https://github.com/Ebmtranceboy/purescript-sparse-polynomials.git
-        version: v1.0.5
-        dependencies:
-          - cartesian
-          - console
-          - effect
-          - ordered-collections
-          - prelude
-          - rationals
-          - tuples
-      spec:
-        repo: https://github.com/purescript-spec/purescript-spec.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - ansi
-          - avar
-          - console
-          - exceptions
-          - foldable-traversable
-          - fork
-          - now
-          - pipes
-          - prelude
-          - strings
-          - transformers
-      spec-discovery:
-        repo: https://github.com/purescript-spec/purescript-spec-discovery.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - aff-promise
-          - arrays
-          - console
-          - effect
-          - foldable-traversable
-          - node-fs
-          - prelude
-          - spec
-      spec-quickcheck:
-        repo: https://github.com/purescript-spec/purescript-spec-quickcheck.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - prelude
-          - quickcheck
-          - random
-          - spec
-      ssrs:
-        repo: https://github.com/PureFunctor/purescript-ssrs.git
-        version: v1.0.0
-        dependencies:
-          - dissect
-          - either
-          - fixed-points
-          - free
-          - lists
-          - prelude
-          - safe-coerce
-          - tailrec
-          - tuples
-          - variant
-      st:
-        repo: https://github.com/purescript/purescript-st.git
-        version: v6.0.0
-        dependencies:
-          - partial
-          - prelude
-          - tailrec
-          - unsafe-coerce
-      strictlypositiveint:
-        repo: https://github.com/jamieyung/purescript-strictlypositiveint.git
-        version: v1.0.1
-        dependencies:
-          - prelude
-      string-parsers:
-        repo: https://github.com/purescript-contrib/purescript-string-parsers.git
-        version: v8.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - prelude
-          - strings
-          - tailrec
-      strings:
-        repo: https://github.com/purescript/purescript-strings.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - enums
-          - foldable-traversable
-          - gen
-          - integers
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-          - unsafe-coerce
-      strings-extra:
-        repo: https://github.com/purescript-contrib/purescript-strings-extra.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - maybe
-          - prelude
-          - strings
-          - unicode
-      stringutils:
-        repo: https://github.com/menelaos/purescript-stringutils.git
-        version: v0.0.12
-        dependencies:
-          - arrays
-          - integers
-          - maybe
-          - partial
-          - prelude
-          - strings
-      substitute:
-        repo: https://github.com/ursi/purescript-substitute.git
-        version: v0.2.3
-        dependencies:
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - prelude
-          - return
-          - strings
-      supply:
-        repo: https://github.com/ajnsit/purescript-supply.git
-        version: v0.2.0
-        dependencies:
-          - console
-          - control
-          - effect
-          - lazy
-          - prelude
-          - refs
-          - tuples
-      tailrec:
-        repo: https://github.com/purescript/purescript-tailrec.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - effect
-          - either
-          - identity
-          - maybe
-          - partial
-          - prelude
-          - refs
-      test-unit:
-        repo: https://github.com/bodil/purescript-test-unit.git
-        version: v17.0.0
-        dependencies:
-          - aff
-          - avar
-          - effect
-          - either
-          - free
-          - js-timers
-          - lists
-          - prelude
-          - quickcheck
-          - strings
-      thermite:
-        repo: https://github.com/paf31/purescript-thermite.git
-        version: v6.3.1
-        dependencies:
-          - aff
-          - coroutines
-          - freet
-          - profunctor-lenses
-          - react
-      thermite-dom:
-        repo: https://github.com/athanclark/purescript-thermite-dom.git
-        version: v0.3.1
-        dependencies:
-          - react
-          - react-dom
-          - thermite
-          - web-html
-      these:
-        repo: https://github.com/purescript-contrib/purescript-these.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - gen
-          - lists
-          - quickcheck
-          - quickcheck-laws
-          - tuples
-      transformers:
-        repo: https://github.com/purescript/purescript-transformers.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - distributive
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - identity
-          - lazy
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      tree-rose:
-        repo: https://github.com/jordanmartinez/purescript-tree-rose.git
-        version: v4.0.2
-        dependencies:
-          - control
-          - foldable-traversable
-          - free
-          - lists
-          - maybe
-          - prelude
-          - tailrec
-      tuples:
-        repo: https://github.com/purescript/purescript-tuples.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - invariant
-          - prelude
-      two-or-more:
-        repo: https://github.com/i-am-the-slime/purescript-two-or-more.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - foldable-traversable
-          - maybe
-          - partial
-          - prelude
-          - psci-support
-          - tuples
-      type-equality:
-        repo: https://github.com/purescript/purescript-type-equality.git
-        version: v4.0.1
-        dependencies: []
-      typelevel:
-        repo: https://github.com/bodil/purescript-typelevel.git
-        version: v6.0.0
-        dependencies:
-          - partial
-          - prelude
-          - tuples
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-lists:
-        repo: https://github.com/PureFunctor/purescript-typelevel-lists.git
-        version: v2.1.0
-        dependencies:
-          - prelude
-          - tuples
-          - typelevel-peano
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-peano:
-        repo: https://github.com/csicar/purescript-typelevel-peano.git
-        version: v1.0.1
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - prelude
-          - psci-support
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-prelude:
-        repo: https://github.com/purescript/purescript-typelevel-prelude.git
-        version: v7.0.0
-        dependencies:
-          - prelude
-          - type-equality
-      typelevel-rows:
-        repo: https://github.com/jordanmartinez/purescript-typelevel-rows.git
-        version: v0.1.0
-        dependencies:
-          - prelude
-      uint:
-        repo: https://github.com/purescript-contrib/purescript-uint.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - enums
-          - gen
-          - maybe
-          - numbers
-          - prelude
-      uncurried-transformers:
-        repo: https://github.com/PureFunctor/purescript-uncurried-transformers.git
-        version: v1.1.0
-        dependencies:
-          - control
-          - effect
-          - either
-          - functions
-          - identity
-          - prelude
-          - safe-coerce
-          - tailrec
-          - transformers
-          - tuples
-      undefined-is-not-a-problem:
-        repo: https://github.com/paluh/purescript-undefined-is-not-a-problem.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - assert
-          - effect
-          - either
-          - foreign
-          - maybe
-          - newtype
-          - prelude
-          - random
-          - tuples
-          - type-equality
-          - unsafe-coerce
-      unfoldable:
-        repo: https://github.com/purescript/purescript-unfoldable.git
-        version: v6.0.0
-        dependencies:
-          - foldable-traversable
-          - maybe
-          - partial
-          - prelude
-          - tuples
-      unicode:
-        repo: https://github.com/purescript-contrib/purescript-unicode.git
-        version: v6.0.0
-        dependencies:
-          - foldable-traversable
-          - maybe
-          - strings
-      unlift:
-        repo: https://github.com/tweag/purescript-unlift.git
-        version: v1.0.1
-        dependencies:
-          - aff
-          - effect
-          - either
-          - freet
-          - identity
-          - lists
-          - maybe
-          - monad-control
-          - prelude
-          - st
-          - transformers
-          - tuples
-      unsafe-coerce:
-        repo: https://github.com/purescript/purescript-unsafe-coerce.git
-        version: v6.0.0
-        dependencies: []
-      unsafe-reference:
-        repo: https://github.com/purescript-contrib/purescript-unsafe-reference.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-      uri:
-        repo: https://github.com/purescript-contrib/purescript-uri.git
-        version: v9.0.0
-        dependencies:
-          - arrays
-          - integers
-          - js-uri
-          - numbers
-          - parsing
-          - prelude
-          - profunctor-lenses
-          - these
-          - transformers
-          - unfoldable
-      validation:
-        repo: https://github.com/purescript/purescript-validation.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - newtype
-          - prelude
-      variant:
-        repo: https://github.com/natefaubion/purescript-variant.git
-        version: v8.0.0
-        dependencies:
-          - enums
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - record
-          - tuples
-          - unsafe-coerce
-      vectorfield:
-        repo: https://github.com/csicar/purescript-vectorfield.git
-        version: v1.0.1
-        dependencies:
-          - console
-          - effect
-          - group
-          - prelude
-          - psci-support
-      versions:
-        repo: https://github.com/hdgarrood/purescript-versions.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - either
-          - foldable-traversable
-          - functions
-          - integers
-          - lists
-          - maybe
-          - orders
-          - parsing
-          - partial
-          - strings
-      web-clipboard:
-        repo: https://github.com/purescript-web/purescript-web-clipboard.git
-        version: v4.0.0
-        dependencies:
-          - web-html
-      web-cssom:
-        repo: https://github.com/purescript-web/purescript-web-cssom.git
-        version: v2.0.0
-        dependencies:
-          - web-dom
-          - web-html
-          - web-uievents
-      web-dom:
-        repo: https://github.com/purescript-web/purescript-web-dom.git
-        version: v6.0.0
-        dependencies:
-          - web-events
-      web-dom-parser:
-        repo: https://github.com/purescript-web/purescript-web-dom-parser.git
-        version: v8.0.0
-        dependencies:
-          - effect
-          - partial
-          - prelude
-          - web-dom
-      web-dom-xpath:
-        repo: https://github.com/purescript-web/purescript-web-dom-xpath.git
-        version: v3.0.0
-        dependencies:
-          - web-dom
-      web-encoding:
-        repo: https://github.com/purescript-web/purescript-web-encoding.git
-        version: v3.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - newtype
-          - prelude
-      web-events:
-        repo: https://github.com/purescript-web/purescript-web-events.git
-        version: v4.0.0
-        dependencies:
-          - datetime
-          - enums
-          - foreign
-          - nullable
-      web-fetch:
-        repo: https://github.com/purescript-web/purescript-web-fetch.git
-        version: v3.0.0
-        dependencies:
-          - effect
-          - foreign-object
-          - http-methods
-          - prelude
-          - record
-          - typelevel-prelude
-          - web-file
-          - web-promise
-          - web-streams
-      web-file:
-        repo: https://github.com/purescript-web/purescript-web-file.git
-        version: v4.0.0
-        dependencies:
-          - foreign
-          - media-types
-          - web-dom
-      web-html:
-        repo: https://github.com/purescript-web/purescript-web-html.git
-        version: v4.0.0
-        dependencies:
-          - js-date
-          - web-dom
-          - web-file
-          - web-storage
-      web-page-visibility:
-        repo: https://git.sr.ht/~toastal/purescript-web-page-visibility
-        version: v2.0.0
-        dependencies:
-          - effect
-          - enums
-          - exceptions
-          - maybe
-          - prelude
-          - strings
-          - web-events
-          - web-html
-      web-pointerevents:
-        repo: https://github.com/purescript-web/purescript-web-pointerevents.git
-        version: v1.0.0
-        dependencies:
-          - effect
-          - maybe
-          - prelude
-          - web-dom
-          - web-uievents
-      web-promise:
-        repo: https://github.com/purescript-web/purescript-web-promise.git
-        version: v3.0.0
-        dependencies:
-          - effect
-          - exceptions
-          - foldable-traversable
-          - functions
-          - maybe
-          - prelude
-      web-socket:
-        repo: https://github.com/purescript-web/purescript-web-socket.git
-        version: v4.0.0
-        dependencies:
-          - arraybuffer-types
-          - web-file
-      web-storage:
-        repo: https://github.com/purescript-web/purescript-web-storage.git
-        version: v5.0.0
-        dependencies:
-          - nullable
-          - web-events
-      web-streams:
-        repo: https://github.com/purescript-web/purescript-web-streams.git
-        version: v3.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - exceptions
-          - nullable
-          - prelude
-          - tuples
-          - web-promise
-      web-touchevents:
-        repo: https://github.com/purescript-web/purescript-web-touchevents.git
-        version: v4.0.0
-        dependencies:
-          - web-uievents
-      web-uievents:
-        repo: https://github.com/purescript-web/purescript-web-uievents.git
-        version: v4.0.0
-        dependencies:
-          - web-html
-      web-workers:
-        repo: https://github.com/gbagan/purescript-web-workers.git
-        version: v1.1.0
-        dependencies:
-          - effect
-          - foreign
-          - maybe
-          - prelude
-          - unsafe-coerce
-          - web-events
-      web-xhr:
-        repo: https://github.com/purescript-web/purescript-web-xhr.git
-        version: v5.0.0
-        dependencies:
-          - arraybuffer-types
-          - datetime
-          - http-methods
-          - web-dom
-          - web-file
-          - web-html
-      yoga-fetch:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-fetch.git
-        version: v1.0.1
-        dependencies:
-          - aff
-          - aff-promise
-          - arraybuffer-types
-          - effect
-          - foreign
-          - foreign-object
-          - newtype
-          - prelude
-          - typelevel-prelude
-          - unsafe-coerce
-      yoga-json:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-json.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - identity
-          - lists
-          - maybe
-          - nullable
-          - partial
-          - prelude
-          - record
-          - transformers
-          - typelevel-prelude
-          - variant
-      yoga-postgres:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-postgres.git
-        version: v6.0.0
-        dependencies:
-          - aff
-          - arrays
-          - datetime
-          - effect
-          - either
-          - enums
-          - foldable-traversable
-          - foreign
-          - integers
-          - maybe
-          - nullable
-          - prelude
-          - transformers
-          - unsafe-coerce
+      abc-parser: 2.0.0
+      ace: 9.0.0
+      aff: 7.1.0
+      aff-bus: 6.0.0
+      aff-coroutines: 9.0.0
+      aff-promise: 4.0.0
+      aff-retry: 2.0.0
+      affjax: 13.0.0
+      affjax-node: 1.0.0
+      affjax-web: 1.0.0
+      ansi: 7.0.0
+      argonaut: 9.0.0
+      argonaut-aeson-generic: 0.4.1
+      argonaut-codecs: 9.1.0
+      argonaut-core: 7.0.0
+      argonaut-generic: 8.0.0
+      argonaut-traversals: 10.0.0
+      argparse-basic: 2.0.0
+      array-builder: 0.1.2
+      arraybuffer: 13.1.1
+      arraybuffer-builder: 3.1.0
+      arraybuffer-types: 3.0.2
+      arrays: 7.1.0
+      arrays-zipper: 2.0.1
+      ask: 1.0.0
+      assert: 6.0.0
+      avar: 5.0.0
+      b64: 0.0.8
+      barbies: 1.0.1
+      barlow-lens: 0.9.0
+      basic-auth: 3.0.1
+      bifunctors: 6.0.0
+      bigints: 7.0.1
+      bolson: 0.3.1
+      bower-json: 3.0.0
+      bucketchain: 1.0.1
+      bucketchain-basic-auth: 1.0.1
+      bucketchain-conditional: 1.0.1
+      bucketchain-cors: 1.0.1
+      bucketchain-csrf: 1.0.1
+      bucketchain-header-utils: 1.0.1
+      bucketchain-health: 1.0.1
+      bucketchain-history-api-fallback: 1.0.1
+      bucketchain-logger: 1.0.1
+      bucketchain-secure: 1.0.1
+      bucketchain-simple-api: 5.0.1
+      bucketchain-sslify: 1.0.1
+      bucketchain-static: 1.0.1
+      call-by-name: 4.0.1
+      canvas: 6.0.0
+      canvas-action: 9.0.0
+      cartesian: 1.0.6
+      catenable-lists: 7.0.0
+      channel: 1.0.0
+      checked-exceptions: 3.1.1
+      classless: 0.1.1
+      classless-arbitrary: 0.1.1
+      classless-decode-json: 0.1.1
+      classless-encode-json: 0.1.3
+      classnames: 2.0.0
+      codec: 6.0.0
+      codec-argonaut: 10.0.0
+      colors: 7.0.1
+      concur-core: 0.5.0
+      concur-react: 0.5.0
+      concurrent-queues: 3.0.0
+      console: 6.0.0
+      const: 6.0.0
+      contravariant: 6.0.0
+      control: 6.0.0
+      convertable-options: 1.0.0
+      coroutines: 7.0.0
+      crypto: 5.0.1
+      css: 6.0.0
+      datetime: 6.1.0
+      datetime-parsing: 0.2.0
+      debug: 6.0.2
+      decimals: 7.1.0
+      default-values: 1.0.1
+      deku: 0.9.9
+      deno: 0.0.5
+      dissect: 1.0.0
+      distributive: 6.0.0
+      dodo-printer: 2.2.1
+      dom-filereader: 7.0.0
+      dom-indexed: 11.0.0
+      dotenv: 3.0.0
+      droplet: 0.5.0
+      dynamic-buffer: 3.0.1
+      echarts-simple: 0.0.1
+      effect: 4.0.0
+      either: 6.1.0
+      elmish: 0.8.3
+      elmish-enzyme: 0.1.1
+      elmish-hooks: 0.9.1
+      elmish-html: 0.7.2
+      elmish-testing-library: 0.3.1
+      email-validate: 7.0.0
+      encoding: 0.0.8
+      enums: 6.0.1
+      error: 2.0.0
+      exceptions: 6.0.0
+      exists: 6.0.0
+      exitcodes: 4.0.0
+      expect-inferred: 3.0.0
+      fahrtwind: 2.0.0
+      fallback: 0.1.0
+      fast-vect: 1.1.0
+      fetch: 1.1.4
+      fetch-argonaut: 1.0.0
+      fetch-core: 4.0.4
+      fetch-yoga-json: 1.1.0
+      filterable: 5.0.0
+      fixed-points: 7.0.0
+      fixed-precision: 5.0.0
+      flame: 1.2.0
+      float32: 2.0.0
+      foldable-traversable: 6.0.0
+      foreign: 7.0.0
+      foreign-object: 4.1.0
+      foreign-readwrite: 3.4.0
+      fork: 6.0.0
+      form-urlencoded: 7.0.0
+      formatters: 7.0.0
+      framer-motion: 1.0.1
+      free: 7.0.0
+      freeap: 7.0.0
+      freer-free: 0.0.1
+      freet: 7.0.0
+      functions: 6.0.0
+      functor1: 3.0.0
+      functors: 5.0.0
+      fuzzy: 0.4.0
+      gen: 4.0.0
+      generate-values: 1.0.1
+      generic-router: 0.0.1
+      geometry-plane: 1.0.3
+      github-actions-toolkit: 0.5.0
+      grain: 3.0.0
+      grain-router: 3.0.0
+      grain-virtualized: 3.0.0
+      graphql-client: 9.3.2
+      graphs: 8.1.0
+      group: 4.1.1
+      halogen: 7.0.0
+      halogen-bootstrap5: 2.1.0
+      halogen-css: 10.0.0
+      halogen-echarts-simple: 0.0.4
+      halogen-formless: 4.0.2
+      halogen-hooks: 0.6.3
+      halogen-hooks-extra: 0.9.0
+      halogen-store: 0.5.4
+      halogen-storybook: 2.0.0
+      halogen-subscriptions: 2.0.0
+      halogen-svg-elems: 7.0.0
+      halogen-vdom: 8.0.0
+      halogen-vdom-string-renderer: 0.5.0
+      heckin: 2.0.1
+      heterogeneous: 0.6.0
+      homogeneous: 0.4.0
+      http-methods: 6.0.0
+      httpure: 0.16.0
+      httpurple: 3.0.1
+      httpurple-argonaut: 1.0.1
+      httpurple-yoga-json: 1.0.0
+      humdrum: 0.0.1
+      hyrule: 2.3.5
+      identity: 6.0.0
+      identy: 4.0.1
+      indexed-monad: 2.1.0
+      int64: 3.0.0
+      integers: 6.0.0
+      interpolate: 5.0.2
+      invariant: 6.0.0
+      jarilo: 1.0.1
+      jelly: 0.9.1
+      jelly-hooks: 0.3.1
+      jelly-router: 0.2.2
+      jelly-signal: 0.3.0
+      jest: 1.0.0
+      js-bigints: 1.2.0
+      js-date: 8.0.0
+      js-fileio: 3.0.0
+      js-promise: 1.0.0
+      js-promise-aff: 1.0.0
+      js-timers: 6.1.0
+      js-uri: 3.1.0
+      justifill: 0.5.0
+      jwt: 0.0.9
+      language-cst-parser: 0.12.1
+      lazy: 6.0.0
+      lazy-joe: 1.0.0
+      lcg: 4.0.0
+      leibniz: 5.0.0
+      linalg: 5.1.0
+      lists: 7.0.0
+      literals: 1.0.2
+      logging: 3.0.0
+      logging-journald: 0.4.0
+      machines: 7.0.0
+      marionette: 1.0.0
+      marionette-commander: 0.1.1
+      marionette-react-basic-hooks: 0.1.1
+      matrices: 5.0.1
+      matryoshka: 1.0.0
+      maybe: 6.0.0
+      mdast-util-from-markdown: 0.2.1
+      media-types: 6.0.0
+      midi: 4.0.0
+      milkis: 9.0.0
+      minibench: 4.0.1
+      mmorph: 7.0.0
+      monad-control: 5.0.0
+      monad-logger: 1.3.1
+      monad-loops: 0.5.0
+      monad-unlift: 1.0.1
+      monoid-extras: 0.0.1
+      monoidal: 0.16.0
+      morello: 0.4.0
+      mote: 3.0.0
+      motsunabe: 2.0.0
+      mysql: 6.0.1
+      n3: 0.1.0
+      nano-id: 1.1.0
+      naturals: 3.0.0
+      nested-functor: 0.2.1
+      newtype: 5.0.0
+      nextui: 0.1.0
+      node-buffer: 8.0.0
+      node-buffer-blob: 1.0.0
+      node-child-process: 9.0.0
+      node-fs: 8.1.1
+      node-fs-aff: 9.1.0
+      node-http: 8.0.0
+      node-net: 4.0.0
+      node-path: 5.0.0
+      node-process: 10.0.0
+      node-readline: 7.0.0
+      node-sqlite3: 8.0.0
+      node-streams: 7.0.0
+      node-streams-aff: 4.0.1
+      node-url: 6.0.0
+      nodemailer: 4.0.1
+      nonempty: 7.0.0
+      now: 6.0.0
+      npm-package-json: 2.0.0
+      nullable: 6.0.0
+      numbers: 9.0.0
+      object-maps: 0.1.1
+      ocarina: 1.5.2
+      open-folds: 6.3.0
+      open-memoize: 6.1.0
+      open-pairing: 6.1.0
+      options: 7.0.0
+      optparse: 5.0.0
+      ordered-collections: 3.0.0
+      ordered-set: 0.4.0
+      orders: 6.0.0
+      pairs: 9.0.0
+      parallel: 6.0.0
+      parsing: 10.2.0
+      parsing-dataview: 3.2.4
+      partial: 4.0.0
+      pathy: 9.0.0
+      pha: 0.9.0
+      phaser: 0.6.0
+      pipes: 8.0.0
+      pirates-charm: 0.0.1
+      point-free: 1.0.0
+      pointed-list: 0.5.1
+      polymorphic-vectors: 4.0.0
+      posix-types: 6.0.0
+      precise: 6.0.0
+      precise-datetime: 7.0.0
+      prelude: 6.0.1
+      prettier-printer: 3.0.0
+      profunctor: 6.0.0
+      profunctor-lenses: 8.0.0
+      protobuf: 4.2.0
+      ps-cst: 1.2.0
+      psa-utils: 8.0.0
+      psc-ide: 19.0.0
+      psci-support: 6.0.0
+      qualified-do: 2.2.0
+      quantities: 12.1.0
+      quickcheck: 8.0.1
+      quickcheck-combinators: 0.1.3
+      quickcheck-laws: 7.0.0
+      quickcheck-utf8: 0.0.0
+      random: 6.0.0
+      rationals: 5.0.1
+      rdf: 0.1.0
+      react: 10.0.1
+      react-aria: 0.2.0
+      react-basic: 17.0.0
+      react-basic-classic: 3.0.0
+      react-basic-dnd: 10.1.0
+      react-basic-dom: 6.0.0
+      react-basic-emotion: 7.1.0
+      react-basic-hooks: 8.1.2
+      react-basic-storybook: 2.0.0
+      react-dom: 8.0.0
+      react-halo: 3.0.0
+      react-icons: 1.0.8
+      react-testing-library: 4.0.1
+      react-virtuoso: 1.0.0
+      read: 1.0.1
+      record: 4.0.0
+      record-extra: 5.0.1
+      record-studio: 1.0.4
+      refs: 6.0.0
+      remotedata: 5.0.0
+      resource: 2.0.1
+      resourcet: 1.0.0
+      result: 1.0.3
+      return: 0.2.0
+      ring-modules: 5.0.1
+      rito: 0.3.2
+      routing: 11.0.0
+      routing-duplex: 0.7.0
+      run: 5.0.0
+      safe-coerce: 2.0.0
+      safely: 4.0.1
+      school-of-music: 1.3.0
+      selection-foldable: 0.2.0
+      semirings: 7.0.0
+      signal: 13.0.0
+      simple-emitter: 3.0.1
+      simple-i18n: 2.0.1
+      simple-json: 9.0.0
+      simple-jwt: 4.0.1
+      simple-ulid: 3.0.0
+      sized-matrices: 1.0.0
+      sized-vectors: 5.0.2
+      slug: 3.0.8
+      small-ffi: 4.0.1
+      soundfonts: 4.1.0
+      sparse-matrices: 1.2.1
+      sparse-polynomials: 1.0.5
+      spec: 7.2.0
+      spec-discovery: 8.0.1
+      spec-quickcheck: 5.0.0
+      splitmix: 2.1.0
+      ssrs: 1.0.0
+      st: 6.2.0
+      strictlypositiveint: 1.0.1
+      string-parsers: 8.0.0
+      strings: 6.0.1
+      strings-extra: 4.0.0
+      stringutils: 0.0.12
+      substitute: 0.2.3
+      sunde: 3.0.0
+      supply: 0.2.0
+      svg-parser: 3.0.0
+      systemd-journald: 0.3.0
+      tagged: 4.0.2
+      tailrec: 6.1.0
+      tecton: 0.1.6
+      tecton-halogen: 0.1.3
+      test-unit: 17.0.0
+      thermite: 6.3.1
+      thermite-dom: 0.3.1
+      these: 6.0.0
+      toppokki: 4.0.0
+      transformers: 6.0.0
+      tree-rose: 4.0.2
+      tuples: 7.0.0
+      two-or-more: 1.0.0
+      type-equality: 4.0.1
+      typelevel: 6.0.0
+      typelevel-lists: 2.1.0
+      typelevel-peano: 1.0.1
+      typelevel-prelude: 7.0.0
+      typelevel-rows: 0.1.0
+      uint: 7.0.0
+      ulid: 3.0.1
+      uncurried-transformers: 1.1.0
+      undefined: 2.0.0
+      undefined-is-not-a-problem: 1.1.0
+      unfoldable: 6.0.0
+      unicode: 6.0.0
+      unlift: 1.0.1
+      unordered-collections: 3.0.1
+      unsafe-coerce: 6.0.0
+      unsafe-reference: 5.0.0
+      untagged-to-tagged: 0.1.4
+      untagged-union: 1.0.0
+      uri: 9.0.0
+      uuid: 9.0.0
+      uuidv4: 1.0.0
+      validation: 6.0.0
+      variant: 8.0.0
+      vectorfield: 1.0.1
+      vectors: 2.1.0
+      versions: 7.0.0
+      visx: 0.0.2
+      web-clipboard: 5.0.0
+      web-cssom: 2.0.0
+      web-dom: 6.0.0
+      web-dom-parser: 8.0.0
+      web-dom-xpath: 3.0.0
+      web-encoding: 3.0.0
+      web-events: 4.0.0
+      web-fetch: 3.0.0
+      web-file: 4.0.0
+      web-html: 4.1.0
+      web-pointerevents: 1.0.0
+      web-proletarian: 1.0.0
+      web-promise: 3.1.0
+      web-resize-observer: 2.0.0
+      web-router: 1.0.0
+      web-socket: 4.0.0
+      web-storage: 5.0.0
+      web-streams: 3.0.0
+      web-touchevents: 4.0.0
+      web-uievents: 4.0.0
+      web-url: 2.0.0
+      web-workers: 1.1.0
+      web-xhr: 5.0.0
+      which: 2.0.0
+      yoga-fetch: 1.0.1
+      yoga-json: 4.0.1
+      yoga-om: 0.1.0
+      yoga-postgres: 6.0.0
+      yoga-tree: 1.0.0
   extra_packages: {}
 packages:
   aff:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-aff.git
-    rev: 2d44d9f9d0d6a416a4103fba2fb39e5160f80e36
+    type: registry
+    version: 7.1.0
+    integrity: sha256-7hOC6uQO9XBAI5FD8F33ChLjFAiZVfd4BJMqlMh7TNU=
     dependencies:
+      - arrays
+      - bifunctors
+      - control
       - datetime
       - effect
+      - either
       - exceptions
+      - foldable-traversable
       - functions
+      - maybe
+      - newtype
       - parallel
+      - prelude
+      - refs
+      - tailrec
       - transformers
       - unsafe-coerce
   aff-promise:
-    type: git
-    url: https://github.com/nwolverson/purescript-aff-promise.git
-    rev: 3aa74e68e3e4c3e38d821375703e0b2f49d831eb
+    type: registry
+    version: 4.0.0
+    integrity: sha256-Kq5EupbUpXeUXx4JqGQE7/RTTz/H6idzWhsocwlEFhM=
     dependencies:
       - aff
       - foreign
   arrays:
-    type: git
-    url: https://github.com/purescript/purescript-arrays.git
-    rev: d20bae2f76db6cf29b7b75e26e82b8a54c32295e
+    type: registry
+    version: 7.1.0
+    integrity: sha256-Rvb3AVLal0ZLpmpABgOPIUeYHa4M+c5GwcUP5rQ2trA=
     dependencies:
       - bifunctors
       - control
@@ -3562,15 +572,16 @@ packages:
       - nonempty
       - partial
       - prelude
+      - safe-coerce
       - st
       - tailrec
       - tuples
       - unfoldable
       - unsafe-coerce
   avar:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-avar.git
-    rev: d00f5784d9cc8f079babd62740f5c52b87e5caa5
+    type: registry
+    version: 5.0.0
+    integrity: sha256-e7hf0x4hEpcygXP0LtvfvAQ49Bbj2aWtZT3gqM///0A=
     dependencies:
       - aff
       - effect
@@ -3579,9 +590,9 @@ packages:
       - functions
       - maybe
   bifunctors:
-    type: git
-    url: https://github.com/purescript/purescript-bifunctors.git
-    rev: 16ba2fb6dd7f05528ebd9e2f9ca3a068b325e5b3
+    type: registry
+    version: 6.0.0
+    integrity: sha256-/gZwC9YhNxZNQpnHa5BIYerCGM2jeX9ukZiEvYxm5Nw=
     dependencies:
       - const
       - either
@@ -3589,9 +600,9 @@ packages:
       - prelude
       - tuples
   catenable-lists:
-    type: git
-    url: https://github.com/purescript/purescript-catenable-lists.git
-    rev: 09abe1f4888bc00841ad2b59e56a9e7ce7ebd4ab
+    type: registry
+    version: 7.0.0
+    integrity: sha256-76vYENhwF4BWTBsjeLuErCH2jqVT4M3R1HX+4RwSftA=
     dependencies:
       - control
       - foldable-traversable
@@ -3601,24 +612,24 @@ packages:
       - tuples
       - unfoldable
   console:
-    type: git
-    url: https://github.com/purescript/purescript-console.git
-    rev: 3b83d7b792d03872afeea5e62b4f686ab0f09842
+    type: registry
+    version: 6.0.0
+    integrity: sha256-gJpJ53fCDAL8BiCiJXH0HNAJ9K3gJtLo8GDaCK6hA5U=
     dependencies:
       - effect
       - prelude
   const:
-    type: git
-    url: https://github.com/purescript/purescript-const.git
-    rev: ab9570cf2b6e67f7e441178211db1231cfd75c37
+    type: registry
+    version: 6.0.0
+    integrity: sha256-tNrxDW8D8H4jdHE2HiPzpLy08zkzJMmGHdRqt5BQuTc=
     dependencies:
       - invariant
       - newtype
       - prelude
   contravariant:
-    type: git
-    url: https://github.com/purescript/purescript-contravariant.git
-    rev: 9ad3e105b8855bcc25f4e0893c784789d05a58de
+    type: registry
+    version: 6.0.0
+    integrity: sha256-TP+ooAp3vvmdjfQsQJSichF5B4BPDHp3wAJoWchip6c=
     dependencies:
       - const
       - either
@@ -3626,16 +637,16 @@ packages:
       - prelude
       - tuples
   control:
-    type: git
-    url: https://github.com/purescript/purescript-control.git
-    rev: a6033808790879a17b2729e73747a9ed3fb2264e
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sH7Pg9E96JCPF9PIA6oQ8+BjTyO/BH1ZuE/bOcyj4Jk=
     dependencies:
       - newtype
       - prelude
   datetime:
-    type: git
-    url: https://github.com/purescript/purescript-datetime.git
-    rev: a6a0cf1b0324964ad1854bc3377ed8766ba90e6f
+    type: registry
+    version: 6.1.0
+    integrity: sha256-g/5X5BBegQWLpI9IWD+sY6mcaYpzzlW5lz5NBzaMtyI=
     dependencies:
       - bifunctors
       - control
@@ -3654,9 +665,9 @@ packages:
       - prelude
       - tuples
   distributive:
-    type: git
-    url: https://github.com/purescript/purescript-distributive.git
-    rev: 6005e513642e855ebf6f884d24a35c2803ca252a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-HTDdmEnzigMl+02SJB88j+gAXDx9VKsbvR4MJGDPbOQ=
     dependencies:
       - identity
       - newtype
@@ -3664,24 +675,24 @@ packages:
       - tuples
       - type-equality
   effect:
-    type: git
-    url: https://github.com/purescript/purescript-effect.git
-    rev: a192ddb923027d426d6ea3d8deb030c9aa7c7dda
+    type: registry
+    version: 4.0.0
+    integrity: sha256-eBtZu+HZcMa5HilvI6kaDyVX3ji8p0W9MGKy2K4T6+M=
     dependencies:
       - prelude
   either:
-    type: git
-    url: https://github.com/purescript/purescript-either.git
-    rev: af655a04ed2fd694b6688af39ee20d7907ad0763
+    type: registry
+    version: 6.1.0
+    integrity: sha256-6hgTPisnMWVwQivOu2PKYcH8uqjEOOqDyaDQVUchTpY=
     dependencies:
       - control
       - invariant
       - maybe
       - prelude
   enums:
-    type: git
-    url: https://github.com/purescript/purescript-enums.git
-    rev: bae47961d401f9acf88da38f32e87403e5f0cf2f
+    type: registry
+    version: 6.0.1
+    integrity: sha256-HWaD73JFLorc4A6trKIRUeDMdzE+GpkJaEOM1nTNkC8=
     dependencies:
       - control
       - either
@@ -3694,24 +705,24 @@ packages:
       - tuples
       - unfoldable
   exceptions:
-    type: git
-    url: https://github.com/purescript/purescript-exceptions.git
-    rev: afab3c07c820bb49b6c5be50049db46a964a6161
+    type: registry
+    version: 6.0.0
+    integrity: sha256-y/xTAEIZIARCE+50/u1di0ncebJ+CIwNOLswyOWzMTw=
     dependencies:
       - effect
       - either
       - maybe
       - prelude
   exists:
-    type: git
-    url: https://github.com/purescript/purescript-exists.git
-    rev: f765b4ace7869c27b9c05949e18c843881f9173b
+    type: registry
+    version: 6.0.0
+    integrity: sha256-A0JQHpTfo1dNOj9U5/Fd3xndlRSE0g2IQWOGor2yXn8=
     dependencies:
       - unsafe-coerce
   foldable-traversable:
-    type: git
-    url: https://github.com/purescript/purescript-foldable-traversable.git
-    rev: b3926f870532d287ea59e2d5cd3873b81ef2a93a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-fLeqRYM4jUrZD5H4WqcwUgzU7XfYkzO4zhgtNc3jcWM=
     dependencies:
       - bifunctors
       - const
@@ -3725,9 +736,9 @@ packages:
       - prelude
       - tuples
   foreign:
-    type: git
-    url: https://github.com/purescript/purescript-foreign.git
-    rev: 2dd222d1ec7363fa0a0a7adb0d8eaf81bb7006dd
+    type: registry
+    version: 7.0.0
+    integrity: sha256-1ORiqoS3HW+qfwSZAppHPWy4/6AQysxZ2t29jcdUMNA=
     dependencies:
       - either
       - functions
@@ -3739,9 +750,9 @@ packages:
       - strings
       - transformers
   foreign-object:
-    type: git
-    url: https://github.com/purescript/purescript-foreign-object.git
-    rev: 28a635827a9a6c251df73f68874070d51fe9f756
+    type: registry
+    version: 4.1.0
+    integrity: sha256-q24okj6mT+yGHYQ+ei/pYPj5ih6sTbu7eDv/WU56JVo=
     dependencies:
       - arrays
       - foldable-traversable
@@ -3756,9 +767,9 @@ packages:
       - typelevel-prelude
       - unfoldable
   free:
-    type: git
-    url: https://github.com/purescript/purescript-free.git
-    rev: e2d8fa8023a864363857834e11393483bced5e38
+    type: registry
+    version: 7.0.0
+    integrity: sha256-72auTIZAG6fhz4F94rxyDwgfnHwp+/89rujZpZWrV0w=
     dependencies:
       - catenable-lists
       - control
@@ -3775,15 +786,15 @@ packages:
       - tuples
       - unsafe-coerce
   functions:
-    type: git
-    url: https://github.com/purescript/purescript-functions.git
-    rev: f626f20580483977c5b27a01aac6471e28aff367
+    type: registry
+    version: 6.0.0
+    integrity: sha256-adMyJNEnhGde2unHHAP79gPtlNjNqzgLB8arEOn9hLI=
     dependencies:
       - prelude
   functors:
-    type: git
-    url: https://github.com/purescript/purescript-functors.git
-    rev: 022ffd7a2a7ec12080314f3d217b400674a247b4
+    type: registry
+    version: 5.0.0
+    integrity: sha256-zfPWWYisbD84MqwpJSZFlvM6v86McM68ob8p9s27ywU=
     dependencies:
       - bifunctors
       - const
@@ -3799,9 +810,9 @@ packages:
       - tuples
       - unsafe-coerce
   gen:
-    type: git
-    url: https://github.com/purescript/purescript-gen.git
-    rev: 9fbcc2a1261c32e30d79c5418edef4d96fe76931
+    type: registry
+    version: 4.0.0
+    integrity: sha256-f7yzAXWwr+xnaqEOcvyO3ezKdoes8+WXWdXIHDBCAPI=
     dependencies:
       - either
       - foldable-traversable
@@ -3814,40 +825,40 @@ packages:
       - tuples
       - unfoldable
   identity:
-    type: git
-    url: https://github.com/purescript/purescript-identity.git
-    rev: ef6768f8a52ab0bc943a85f5761ba07c257f639f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-4wY0XZbAksjY6UAg99WkuKyJlQlWAfTi2ssadH0wVMY=
     dependencies:
       - control
       - invariant
       - newtype
       - prelude
   indexed-monad:
-    type: git
-    url: https://github.com/garyb/purescript-indexed-monad.git
-    rev: b95d33cea26bfbbdc17d8d80fb664df2ad79d28b
+    type: registry
+    version: 2.1.0
+    integrity: sha256-VtIx8bIYKg6uhLlsB4ZWpMqs0WoPtNYR6ad1FoBNlys=
     dependencies:
       - control
       - newtype
   integers:
-    type: git
-    url: https://github.com/purescript/purescript-integers.git
-    rev: 54d712b25c594833083d15dc9ff2418eb9c52822
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sf+sK26R1hzwl3NhXR7WAu9zCDjQnfoXwcyGoseX158=
     dependencies:
       - maybe
       - numbers
       - prelude
   invariant:
-    type: git
-    url: https://github.com/purescript/purescript-invariant.git
-    rev: 1d2a196d51e90623adb88496c2cfd759c6736894
+    type: registry
+    version: 6.0.0
+    integrity: sha256-RGWWyYrz0Hs1KjPDA+87Kia67ZFBhfJ5lMGOMCEFoLo=
     dependencies:
       - control
       - prelude
   js-date:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-js-date.git
-    rev: 1ea020316946cc4b87195bca9c54d0c16abaa490
+    type: registry
+    version: 8.0.0
+    integrity: sha256-6TVF4DWg5JL+jRAsoMssYw8rgOVALMUHT1CuNZt8NRo=
     dependencies:
       - datetime
       - effect
@@ -3856,24 +867,24 @@ packages:
       - integers
       - now
   js-timers:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-js-timers.git
-    rev: 7cb728b3e6dc29f355143617e6e9ac770ecd9273
+    type: registry
+    version: 6.1.0
+    integrity: sha256-znHWLSSOYw15P5DTcsAdal2lf7nGA2yayLdOZ2t5r7o=
     dependencies:
       - effect
   lazy:
-    type: git
-    url: https://github.com/purescript/purescript-lazy.git
-    rev: 48347841226b27af5205a1a8ec71e27a93ce86fd
+    type: registry
+    version: 6.0.0
+    integrity: sha256-lMsfFOnlqfe4KzRRiW8ot5ge6HtcU3Eyh2XkXcP5IgU=
     dependencies:
       - control
       - foldable-traversable
       - invariant
       - prelude
   lcg:
-    type: git
-    url: https://github.com/purescript/purescript-lcg.git
-    rev: 67c6c6483a563a59ae036d9dca0f1be2835326a5
+    type: registry
+    version: 4.0.0
+    integrity: sha256-h7ME5cthLfbgJOJdsZcSfFpwXsx4rf8YmhebU+3iSYg=
     dependencies:
       - effect
       - integers
@@ -3882,9 +893,9 @@ packages:
       - prelude
       - random
   lists:
-    type: git
-    url: https://github.com/purescript/purescript-lists.git
-    rev: b113451e5b41cad87d669a3165f955c71cd863e2
+    type: registry
+    version: 7.0.0
+    integrity: sha256-EKF15qYqucuXP2lT/xPxhqy58f0FFT6KHdIB/yBOayI=
     dependencies:
       - bifunctors
       - control
@@ -3899,32 +910,32 @@ packages:
       - tuples
       - unfoldable
   maybe:
-    type: git
-    url: https://github.com/purescript/purescript-maybe.git
-    rev: c6f98ac1088766287106c5d9c8e30e7648d36786
+    type: registry
+    version: 6.0.0
+    integrity: sha256-5cCIb0wPwbat2PRkQhUeZO0jcAmf8jCt2qE0wbC3v2Q=
     dependencies:
       - control
       - invariant
       - newtype
       - prelude
   media-types:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-media-types.git
-    rev: af853de226592f319a953637069a943dd261cba3
+    type: registry
+    version: 6.0.0
+    integrity: sha256-n/4FoGBasbVSYscGVRSyBunQ6CZbL3jsYL+Lp01mc9k=
     dependencies:
       - newtype
       - prelude
   newtype:
-    type: git
-    url: https://github.com/purescript/purescript-newtype.git
-    rev: 29d8e6dd77aec2c975c948364ec3faf26e14ee7b
+    type: registry
+    version: 5.0.0
+    integrity: sha256-gdrQu8oGe9eZE6L3wOI8ql/igOg+zEGB5ITh2g+uttw=
     dependencies:
       - prelude
       - safe-coerce
   nonempty:
-    type: git
-    url: https://github.com/purescript/purescript-nonempty.git
-    rev: 28150ecc7419238b187abd609a92a645273348bb
+    type: registry
+    version: 7.0.0
+    integrity: sha256-54ablJZUHGvvlTJzi3oXyPCuvY6zsrWJuH/dMJ/MFLs=
     dependencies:
       - control
       - foldable-traversable
@@ -3933,31 +944,31 @@ packages:
       - tuples
       - unfoldable
   now:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-now.git
-    rev: b5ffed2381e5fefc063f484e607e8499e79eaf32
+    type: registry
+    version: 6.0.0
+    integrity: sha256-xZ7x37ZMREfs6GCDw/h+FaKHV/3sPWmtqBZRGTxybQY=
     dependencies:
       - datetime
       - effect
   nullable:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-nullable.git
-    rev: 3202744c6c65e8d1fbba7f4256a1c482078e7fb5
+    type: registry
+    version: 6.0.0
+    integrity: sha256-yiGBVl3AD+Guy4kNWWeN+zl1gCiJK+oeIFtZtPCw4+o=
     dependencies:
       - effect
       - functions
       - maybe
   numbers:
-    type: git
-    url: https://github.com/purescript/purescript-numbers.git
-    rev: 2a53528f18f9415334bae28e7bb3cf3be86342c2
+    type: registry
+    version: 9.0.0
+    integrity: sha256-fDKXExFxMRFgy+v+kbjVbGBIOOQkWGnmm0vtnE3zWRE=
     dependencies:
       - functions
       - maybe
   ordered-collections:
-    type: git
-    url: https://github.com/purescript/purescript-ordered-collections.git
-    rev: 9826b7632d0d0a691173bde308a634195f42a419
+    type: registry
+    version: 3.0.0
+    integrity: sha256-R9WddNBRPkY37gw8XkDCLX2vJ5eI9qdaWDdCp61r2+M=
     dependencies:
       - arrays
       - foldable-traversable
@@ -3971,16 +982,16 @@ packages:
       - tuples
       - unfoldable
   orders:
-    type: git
-    url: https://github.com/purescript/purescript-orders.git
-    rev: f86db621ec5eef1274145f8b1fd8ebbfe0ed4a2c
+    type: registry
+    version: 6.0.0
+    integrity: sha256-nBA0g3/ai0euH8q9pSbGqk53W2q6agm/dECZTHcoink=
     dependencies:
       - newtype
       - prelude
   parallel:
-    type: git
-    url: https://github.com/purescript/purescript-parallel.git
-    rev: 85290dca837771ac4870071008c933d315ef678f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-VJbkGD0rAKX+NUEeBJbYJ78bEKaZbgow+QwQEfPB6ko=
     dependencies:
       - control
       - effect
@@ -3994,19 +1005,19 @@ packages:
       - refs
       - transformers
   partial:
-    type: git
-    url: https://github.com/purescript/purescript-partial.git
-    rev: 0fa0646f5ea1ec5f0c46dcbd770c705a6c9ad3ec
+    type: registry
+    version: 4.0.0
+    integrity: sha256-fwXerld6Xw1VkReh8yeQsdtLVrjfGiVuC5bA1Wyo/J4=
     dependencies: []
   prelude:
-    type: git
-    url: https://github.com/purescript/purescript-prelude.git
-    rev: 32787f4399c92459c41602131a5858559eb868c5
+    type: registry
+    version: 6.0.1
+    integrity: sha256-o8p6SLYmVPqzXZhQFd2hGAWEwBoXl1swxLG/scpJ0V0=
     dependencies: []
   profunctor:
-    type: git
-    url: https://github.com/purescript/purescript-profunctor.git
-    rev: 0a966a14e7b0c827d44657dc1710cdc712d2e034
+    type: registry
+    version: 6.0.0
+    integrity: sha256-99NzxFgTr4CGlCSRYG1kShL+JhYbihhHtbOk1/0R5zI=
     dependencies:
       - control
       - distributive
@@ -4017,9 +1028,9 @@ packages:
       - prelude
       - tuples
   quickcheck:
-    type: git
-    url: https://github.com/purescript/purescript-quickcheck.git
-    rev: bf5029f97e6c0d7552d3a08d2ab793a19e2c5e3d
+    type: registry
+    version: 8.0.1
+    integrity: sha256-ZvpccKQCvgslTXZCNmpYW4bUsFzhZd/kQUr2WmxFTGY=
     dependencies:
       - arrays
       - console
@@ -4049,25 +1060,26 @@ packages:
       - tuples
       - unfoldable
   random:
-    type: git
-    url: https://github.com/purescript/purescript-random.git
-    rev: 9540bc965a9596da02fefd9949418bb19c92533a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-CJ611a35MPCE7XQMp0rdC6MCn76znlhisiCRgboAG+Q=
     dependencies:
       - effect
       - integers
   react-basic:
-    type: git
-    url: https://github.com/lumihq/purescript-react-basic.git
-    rev: 821ac4cb55b5919cc6248b45139164ad1a560e3f
+    type: registry
+    version: 17.0.0
+    integrity: sha256-xE5sL14ITpSRCbAnWrp7KAfbzv+Ft0rSaAnjkqKcSVY=
     dependencies:
       - effect
       - prelude
       - record
   react-basic-dom:
-    type: git
-    url: https://github.com/lumihq/purescript-react-basic-dom.git
-    rev: 4ee3cd2ec6086aae1476d08f2348f7f9bce8feac
+    type: registry
+    version: 6.0.0
+    integrity: sha256-uEkFQTvDrKAor7g6WzPsrSrbUvq9sT7Dj7b8PPanSbY=
     dependencies:
+      - arrays
       - effect
       - foldable-traversable
       - foreign-object
@@ -4075,15 +1087,16 @@ packages:
       - nullable
       - prelude
       - react-basic
+      - record
       - unsafe-coerce
       - web-dom
       - web-events
       - web-file
       - web-html
   react-basic-hooks:
-    type: git
-    url: https://github.com/megamaddu/purescript-react-basic-hooks.git
-    rev: 50575f50a68dc8b756b378674dea5c568b8c109d
+    type: registry
+    version: 8.1.2
+    integrity: sha256-Tf/iOS6DXoA5WtAI4wAldUjgSqD9ofVPF13AqJerP6U=
     dependencies:
       - aff
       - aff-promise
@@ -4112,39 +1125,39 @@ packages:
       - unsafe-reference
       - web-html
   record:
-    type: git
-    url: https://github.com/purescript/purescript-record.git
-    rev: c89cd1ada6b636692571fc374196b1c39c4c9f70
+    type: registry
+    version: 4.0.0
+    integrity: sha256-Za5U85bTRJEfGK5Sk4hM41oXy84YQI0I8TL3WUn1Qzg=
     dependencies:
       - functions
       - prelude
       - unsafe-coerce
   refs:
-    type: git
-    url: https://github.com/purescript/purescript-refs.git
-    rev: f8e6216da4cb9309fde1f20cd6f69ac3a3b7f9e8
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Vgwne7jIbD3ZMoLNNETLT8Litw6lIYo3MfYNdtYWj9s=
     dependencies:
       - effect
       - prelude
   safe-coerce:
-    type: git
-    url: https://github.com/purescript/purescript-safe-coerce.git
-    rev: 7fa799ae80a38b8d948efcb52608e58e198b3da7
+    type: registry
+    version: 2.0.0
+    integrity: sha256-a1ibQkiUcbODbLE/WAq7Ttbbh9ex+x33VCQ7GngKudU=
     dependencies:
       - unsafe-coerce
   st:
-    type: git
-    url: https://github.com/purescript/purescript-st.git
-    rev: 2cc7ae1c3318a303378c4a9f3fa0f10ee7cc3589
+    type: registry
+    version: 6.2.0
+    integrity: sha256-z9X0WsOUlPwNx9GlCC+YccCyz8MejC8Wb0C4+9fiBRY=
     dependencies:
       - partial
       - prelude
       - tailrec
       - unsafe-coerce
   strings:
-    type: git
-    url: https://github.com/purescript/purescript-strings.git
-    rev: 4bc6954448d056f8aa7a659695a6ad60ad4fdf19
+    type: registry
+    version: 6.0.1
+    integrity: sha256-WssD3DbX4OPzxSdjvRMX0yvc9+pS7n5gyPv5I2Trb7k=
     dependencies:
       - arrays
       - control
@@ -4163,9 +1176,9 @@ packages:
       - unfoldable
       - unsafe-coerce
   tailrec:
-    type: git
-    url: https://github.com/purescript/purescript-tailrec.git
-    rev: 5e2104aa734b31a17074cc805bf087d72b65afd1
+    type: registry
+    version: 6.1.0
+    integrity: sha256-Xx19ECVDRrDWpz9D2GxQHHV89vd61dnXxQm0IcYQHGk=
     dependencies:
       - bifunctors
       - effect
@@ -4176,9 +1189,9 @@ packages:
       - prelude
       - refs
   test-unit:
-    type: git
-    url: https://github.com/bodil/purescript-test-unit.git
-    rev: 3112d7ebe06d467238058a6384dc75ffd960d335
+    type: registry
+    version: 17.0.0
+    integrity: sha256-aITJ2KngFFjASmG0JjnjybaKWl9dn7Hf2B3Wk4engNs=
     dependencies:
       - aff
       - avar
@@ -4191,9 +1204,9 @@ packages:
       - quickcheck
       - strings
   transformers:
-    type: git
-    url: https://github.com/purescript/purescript-transformers.git
-    rev: be72ab52357d9a665cbf93d73ba1c07c4b0957ee
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Pzw40HjthX77tdPAYzjx43LK3X5Bb7ZspYAp27wksFA=
     dependencies:
       - control
       - distributive
@@ -4210,29 +1223,29 @@ packages:
       - tuples
       - unfoldable
   tuples:
-    type: git
-    url: https://github.com/purescript/purescript-tuples.git
-    rev: 4f52da2729b448c8564369378f1232d8d2dc1d8b
+    type: registry
+    version: 7.0.0
+    integrity: sha256-1rXgTomes9105BjgXqIw0FL6Fz1lqqUTLWOumhWec1M=
     dependencies:
       - control
       - invariant
       - prelude
   type-equality:
-    type: git
-    url: https://github.com/purescript/purescript-type-equality.git
-    rev: 0525b7d39e0fbd81b4209518139fb8ab02695774
+    type: registry
+    version: 4.0.1
+    integrity: sha256-Hs9D6Y71zFi/b+qu5NSbuadUQXe5iv5iWx0226vOHUw=
     dependencies: []
   typelevel-prelude:
-    type: git
-    url: https://github.com/purescript/purescript-typelevel-prelude.git
-    rev: dca2fe3c8cfd5527d4fe70c4bedfda30148405bf
+    type: registry
+    version: 7.0.0
+    integrity: sha256-uFF2ph+vHcQpfPuPf2a3ukJDFmLhApmkpTMviHIWgJM=
     dependencies:
       - prelude
       - type-equality
   unfoldable:
-    type: git
-    url: https://github.com/purescript/purescript-unfoldable.git
-    rev: 493dfe04ed590e20d8f69079df2f58486882748d
+    type: registry
+    version: 6.0.0
+    integrity: sha256-JtikvJdktRap7vr/K4ITlxUX1QexpnqBq0G/InLr6eg=
     dependencies:
       - foldable-traversable
       - maybe
@@ -4240,20 +1253,20 @@ packages:
       - prelude
       - tuples
   unsafe-coerce:
-    type: git
-    url: https://github.com/purescript/purescript-unsafe-coerce.git
-    rev: ab956f82e66e633f647fb3098e8ddd3ec58d689f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-IqIYW4Vkevn8sI+6aUwRGvd87tVL36BBeOr0cGAE7t0=
     dependencies: []
   unsafe-reference:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-unsafe-reference.git
-    rev: 058e23b8b9adcf776a910f9934ff515ddee73af5
+    type: registry
+    version: 5.0.0
+    integrity: sha256-zU7BhfJU14nXQRZG9iADsp0mSiKhz07OcKyjRB2YT+Y=
     dependencies:
       - prelude
   validation:
-    type: git
-    url: https://github.com/purescript/purescript-validation.git
-    rev: a3d9ec2176a7a808d70a01fa7e6f16d10e05429a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-kfFailaIW4spGxbRk4261z/RGT0Sb7Dx5f3qihy0MTw=
     dependencies:
       - bifunctors
       - control
@@ -4262,41 +1275,41 @@ packages:
       - newtype
       - prelude
   web-dom:
-    type: git
-    url: https://github.com/purescript-web/purescript-web-dom.git
-    rev: 568a1ee158b29e6e739e7a9aaed3e35ca4c4305a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-1kSKWFDI4LupdmpjK01b1MMxDFW7jvatEgPgVmCmSBQ=
     dependencies:
       - web-events
   web-events:
-    type: git
-    url: https://github.com/purescript-web/purescript-web-events.git
-    rev: 2124356117be7b764a2f3948032255ac4dab7051
+    type: registry
+    version: 4.0.0
+    integrity: sha256-YDt8b6u1tzGtnWyNRodne57iO8FNSGPaTCVzBUyUn4k=
     dependencies:
       - datetime
       - enums
       - foreign
       - nullable
   web-file:
-    type: git
-    url: https://github.com/purescript-web/purescript-web-file.git
-    rev: 023786ae62bbb8bf58156dd7f02011fa38221ef1
+    type: registry
+    version: 4.0.0
+    integrity: sha256-1h5jPBkvjY71jLEdwVadXCx86/2inNoMBO//Rd3eCSU=
     dependencies:
       - foreign
       - media-types
       - web-dom
   web-html:
-    type: git
-    url: https://github.com/purescript-web/purescript-web-html.git
-    rev: be189cf91b9a19cf493637423522e2fe4a0088cc
+    type: registry
+    version: 4.1.0
+    integrity: sha256-ByqS/h1/yG+hjCOnOQp7L1QpIWzQENNKB1kaHtpEhlE=
     dependencies:
       - js-date
       - web-dom
       - web-file
       - web-storage
   web-storage:
-    type: git
-    url: https://github.com/purescript-web/purescript-web-storage.git
-    rev: 6b74461e136755db70c271dc898d51776363d7e2
+    type: registry
+    version: 5.0.0
+    integrity: sha256-q+6lxcnfWxus0/nDeFVtF1V+tLehZvvXQ0cduYPLksY=
     dependencies:
       - nullable
       - web-events

--- a/exercises/chapter8/spago.yaml
+++ b/exercises/chapter8/spago.yaml
@@ -27,4 +27,4 @@ package:
 workspace:
   extraPackages: {}
   packageSet:
-    url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
+    registry: 10.0.0

--- a/exercises/chapter8/spago.yaml
+++ b/exercises/chapter8/spago.yaml
@@ -1,0 +1,30 @@
+package:
+  dependencies:
+    - arrays
+    - console
+    - control
+    - effect
+    - either
+    - exceptions
+    - foldable-traversable
+    - integers
+    - lists
+    - maybe
+    - numbers
+    - prelude
+    - random
+    - react-basic
+    - react-basic-dom
+    - react-basic-hooks
+    - st
+    - strings
+    - test-unit
+    - tuples
+    - validation
+    - web-dom
+    - web-html
+  name: my-project
+workspace:
+  extraPackages: {}
+  packageSet:
+    url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json

--- a/exercises/chapter9/spago.lock
+++ b/exercises/chapter9/spago.lock
@@ -1,0 +1,4362 @@
+workspace:
+  packages:
+    my-project:
+      path: ./
+      dependencies:
+        - aff
+        - affjax
+        - affjax-node
+        - arrays
+        - bifunctors
+        - console
+        - effect
+        - either
+        - exceptions
+        - foldable-traversable
+        - functions
+        - maybe
+        - node-buffer
+        - node-fs-aff
+        - node-path
+        - ordered-collections
+        - parallel
+        - prelude
+        - strings
+        - test-unit
+      test_dependencies: []
+      build_plan:
+        - aff
+        - affjax
+        - affjax-node
+        - argonaut-core
+        - arraybuffer-types
+        - arrays
+        - avar
+        - bifunctors
+        - catenable-lists
+        - console
+        - const
+        - contravariant
+        - control
+        - datetime
+        - distributive
+        - effect
+        - either
+        - enums
+        - exceptions
+        - exists
+        - foldable-traversable
+        - foreign
+        - foreign-object
+        - form-urlencoded
+        - free
+        - functions
+        - functors
+        - gen
+        - http-methods
+        - identity
+        - integers
+        - invariant
+        - js-date
+        - js-timers
+        - js-uri
+        - lazy
+        - lcg
+        - lists
+        - maybe
+        - media-types
+        - newtype
+        - node-buffer
+        - node-fs
+        - node-fs-aff
+        - node-path
+        - node-streams
+        - nonempty
+        - now
+        - nullable
+        - numbers
+        - ordered-collections
+        - orders
+        - parallel
+        - partial
+        - prelude
+        - profunctor
+        - quickcheck
+        - random
+        - record
+        - refs
+        - safe-coerce
+        - st
+        - strings
+        - tailrec
+        - test-unit
+        - transformers
+        - tuples
+        - type-equality
+        - typelevel-prelude
+        - unfoldable
+        - unsafe-coerce
+        - web-dom
+        - web-events
+        - web-file
+        - web-html
+        - web-storage
+        - web-xhr
+  package_set:
+    address:
+      url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
+    compiler: ">=0.15.0 <0.16.0"
+    content:
+      ace:
+        repo: https://github.com/purescript-contrib/purescript-ace.git
+        version: v9.0.0
+        dependencies:
+          - arrays
+          - effect
+          - foreign
+          - nullable
+          - prelude
+          - web-html
+          - web-uievents
+      aff:
+        repo: https://github.com/purescript-contrib/purescript-aff.git
+        version: v7.0.0
+        dependencies:
+          - datetime
+          - effect
+          - exceptions
+          - functions
+          - parallel
+          - transformers
+          - unsafe-coerce
+      aff-bus:
+        repo: https://github.com/purescript-contrib/purescript-aff-bus.git
+        version: v6.0.0
+        dependencies:
+          - aff
+          - avar
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - lists
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+      aff-coroutines:
+        repo: https://github.com/purescript-contrib/purescript-aff-coroutines.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - avar
+          - coroutines
+          - effect
+      aff-promise:
+        repo: https://github.com/nwolverson/purescript-aff-promise.git
+        version: v4.0.0
+        dependencies:
+          - aff
+          - foreign
+      aff-retry:
+        repo: https://github.com/Unisay/purescript-aff-retry.git
+        version: v2.0.0
+        dependencies:
+          - aff
+          - arrays
+          - datetime
+          - effect
+          - either
+          - exceptions
+          - integers
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - random
+          - transformers
+      affjax:
+        repo: https://github.com/purescript-contrib/purescript-affjax.git
+        version: v13.0.0
+        dependencies:
+          - aff
+          - argonaut-core
+          - arraybuffer-types
+          - foreign
+          - form-urlencoded
+          - http-methods
+          - integers
+          - media-types
+          - nullable
+          - refs
+          - unsafe-coerce
+          - web-xhr
+      affjax-node:
+        repo: https://github.com/purescript-contrib/purescript-affjax-node.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - affjax
+          - either
+          - maybe
+          - prelude
+      affjax-web:
+        repo: https://github.com/purescript-contrib/purescript-affjax-web.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - affjax
+          - either
+          - maybe
+          - prelude
+      ansi:
+        repo: https://github.com/hdgarrood/purescript-ansi.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - lists
+          - strings
+      argonaut:
+        repo: https://github.com/purescript-contrib/purescript-argonaut.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - argonaut-traversals
+      argonaut-codecs:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-codecs.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-core
+          - arrays
+          - effect
+          - foreign-object
+          - identity
+          - integers
+          - maybe
+          - nonempty
+          - ordered-collections
+          - prelude
+          - record
+      argonaut-core:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-core.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - foreign-object
+          - functions
+          - gen
+          - maybe
+          - nonempty
+          - prelude
+          - strings
+          - tailrec
+      argonaut-generic:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-generic.git
+        version: v8.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - prelude
+          - record
+      argonaut-traversals:
+        repo: https://github.com/purescript-contrib/purescript-argonaut-traversals.git
+        version: v10.0.0
+        dependencies:
+          - argonaut-codecs
+          - argonaut-core
+          - profunctor-lenses
+      argparse-basic:
+        repo: https://github.com/natefaubion/purescript-argparse-basic.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - record
+          - strings
+          - tuples
+          - unfoldable
+      arraybuffer:
+        repo: https://github.com/purescript-contrib/purescript-arraybuffer.git
+        version: v13.0.0
+        dependencies:
+          - arraybuffer-types
+          - arrays
+          - effect
+          - float32
+          - functions
+          - gen
+          - maybe
+          - nullable
+          - prelude
+          - tailrec
+          - uint
+          - unfoldable
+      arraybuffer-builder:
+        repo: https://github.com/jamesdbrock/purescript-arraybuffer-builder.git
+        version: v3.0.1
+        dependencies:
+          - arraybuffer
+          - arraybuffer-types
+          - effect
+          - float32
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - transformers
+          - uint
+      arraybuffer-types:
+        repo: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
+        version: v3.0.2
+        dependencies: []
+      arrays:
+        repo: https://github.com/purescript/purescript-arrays.git
+        version: v7.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - foldable-traversable
+          - maybe
+          - nonempty
+          - partial
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - unfoldable
+          - unsafe-coerce
+      arrays-zipper:
+        repo: https://github.com/JordanMartinez/purescript-arrays-zipper.git
+        version: v2.0.1
+        dependencies:
+          - arrays
+          - control
+          - quickcheck
+      ask:
+        repo: https://github.com/Mateiadrielrafael/purescript-ask.git
+        version: v1.0.0
+        dependencies:
+          - unsafe-coerce
+      assert:
+        repo: https://github.com/purescript/purescript-assert.git
+        version: v6.0.0
+        dependencies:
+          - console
+          - effect
+          - prelude
+      avar:
+        repo: https://github.com/purescript-contrib/purescript-avar.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - exceptions
+          - functions
+          - maybe
+      b64:
+        repo: https://github.com/menelaos/purescript-b64.git
+        version: v0.0.8
+        dependencies:
+          - arraybuffer-types
+          - either
+          - encoding
+          - enums
+          - exceptions
+          - functions
+          - partial
+          - prelude
+          - strings
+      barlow-lens:
+        repo: https://github.com/sigma-andex/purescript-barlow-lens.git
+        version: v0.9.0
+        dependencies:
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - profunctor-lenses
+          - tuples
+          - typelevel-prelude
+      bifunctors:
+        repo: https://github.com/purescript/purescript-bifunctors.git
+        version: v6.0.0
+        dependencies:
+          - const
+          - either
+          - newtype
+          - prelude
+          - tuples
+      bigints:
+        repo: https://github.com/sharkdp/purescript-bigints.git
+        version: v7.0.1
+        dependencies:
+          - integers
+          - maybe
+          - strings
+      bower-json:
+        repo: https://github.com/klntsky/purescript-bower-json.git
+        version: v3.0.0
+        dependencies:
+          - argonaut-codecs
+          - arrays
+          - either
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - newtype
+          - prelude
+          - tuples
+      call-by-name:
+        repo: https://github.com/natefaubion/purescript-call-by-name.git
+        version: v4.0.1
+        dependencies:
+          - control
+          - either
+          - lazy
+          - maybe
+          - unsafe-coerce
+      canvas:
+        repo: https://github.com/purescript-web/purescript-canvas.git
+        version: v6.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - exceptions
+          - functions
+          - maybe
+      canvas-action:
+        repo: https://github.com/artemisSystem/purescript-canvas-action.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - arrays
+          - canvas
+          - colors
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - maybe
+          - numbers
+          - polymorphic-vectors
+          - prelude
+          - refs
+          - run
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-html
+      cartesian:
+        repo: https://github.com/Ebmtranceboy/purescript-cartesian.git
+        version: v1.0.6
+        dependencies:
+          - console
+          - effect
+          - integers
+          - psci-support
+      catenable-lists:
+        repo: https://github.com/purescript/purescript-catenable-lists.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - lists
+          - maybe
+          - prelude
+          - tuples
+          - unfoldable
+      channel:
+        repo: https://github.com/ConnorDillon/purescript-channel.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - assert
+          - avar
+          - console
+          - contravariant
+          - control
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - lazy
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      checked-exceptions:
+        repo: https://github.com/natefaubion/purescript-checked-exceptions.git
+        version: v3.1.1
+        dependencies:
+          - prelude
+          - transformers
+          - variant
+      codec:
+        repo: https://github.com/garyb/purescript-codec.git
+        version: v5.0.0
+        dependencies:
+          - profunctor
+          - transformers
+      codec-argonaut:
+        repo: https://github.com/garyb/purescript-codec-argonaut.git
+        version: v9.0.0
+        dependencies:
+          - argonaut-core
+          - codec
+          - ordered-collections
+          - type-equality
+          - variant
+      colors:
+        repo: https://github.com/purescript-contrib/purescript-colors.git
+        version: v7.0.1
+        dependencies:
+          - arrays
+          - integers
+          - lists
+          - numbers
+          - partial
+          - strings
+      concurrent-queues:
+        repo: https://github.com/purescript-contrib/purescript-concurrent-queues.git
+        version: v3.0.0
+        dependencies:
+          - aff
+          - avar
+          - effect
+      console:
+        repo: https://github.com/purescript/purescript-console.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - prelude
+      const:
+        repo: https://github.com/purescript/purescript-const.git
+        version: v6.0.0
+        dependencies:
+          - invariant
+          - newtype
+          - prelude
+      contravariant:
+        repo: https://github.com/purescript/purescript-contravariant.git
+        version: v6.0.0
+        dependencies:
+          - const
+          - either
+          - newtype
+          - prelude
+          - tuples
+      control:
+        repo: https://github.com/purescript/purescript-control.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      convertable-options:
+        repo: https://github.com/natefaubion/purescript-convertable-options.git
+        version: v1.0.0
+        dependencies:
+          - console
+          - effect
+          - maybe
+          - record
+      coroutines:
+        repo: https://github.com/purescript-contrib/purescript-coroutines.git
+        version: v7.0.0
+        dependencies:
+          - freet
+          - parallel
+          - profunctor
+      css:
+        repo: https://github.com/purescript-contrib/purescript-css.git
+        version: v6.0.0
+        dependencies:
+          - colors
+          - console
+          - effect
+          - nonempty
+          - profunctor
+          - strings
+          - these
+          - transformers
+      datetime:
+        repo: https://github.com/purescript/purescript-datetime.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - either
+          - enums
+          - foldable-traversable
+          - functions
+          - gen
+          - integers
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - ordered-collections
+          - partial
+          - prelude
+          - tuples
+      datetime-parsing:
+        repo: https://github.com/flounders/purescript-datetime-parsing.git
+        version: v0.2.0
+        dependencies:
+          - arrays
+          - datetime
+          - either
+          - enums
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - numbers
+          - parsing
+          - prelude
+          - strings
+          - unicode
+      debug:
+        repo: https://github.com/garyb/purescript-debug.git
+        version: v6.0.0
+        dependencies:
+          - functions
+          - prelude
+      decimals:
+        repo: https://github.com/sharkdp/purescript-decimals.git
+        version: v7.0.0
+        dependencies:
+          - maybe
+      dissect:
+        repo: https://github.com/PureFunctor/purescript-dissect.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - foreign-object
+          - functors
+          - newtype
+          - partial
+          - prelude
+          - tailrec
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - variant
+      distributive:
+        repo: https://github.com/purescript/purescript-distributive.git
+        version: v6.0.0
+        dependencies:
+          - identity
+          - newtype
+          - prelude
+          - tuples
+          - type-equality
+      dodo-printer:
+        repo: https://github.com/natefaubion/purescript-dodo-printer.git
+        version: v2.2.0
+        dependencies:
+          - aff
+          - ansi
+          - avar
+          - console
+          - effect
+          - foldable-traversable
+          - lists
+          - maybe
+          - minibench
+          - node-child-process
+          - node-fs-aff
+          - node-process
+          - psci-support
+          - strings
+      dom-indexed:
+        repo: https://github.com/purescript-halogen/purescript-dom-indexed.git
+        version: v11.0.0
+        dependencies:
+          - media-types
+          - prelude
+          - web-clipboard
+          - web-pointerevents
+          - web-touchevents
+      droplet:
+        repo: https://github.com/easafe/purescript-droplet.git
+        version: v0.4.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - bigints
+          - datetime
+          - debug
+          - effect
+          - either
+          - enums
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - integers
+          - maybe
+          - newtype
+          - nullable
+          - ordered-collections
+          - partial
+          - prelude
+          - profunctor
+          - record
+          - spec
+          - strings
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+      dynamic-buffer:
+        repo: https://github.com/kritzcreek/purescript-dynamic-buffer.git
+        version: v3.0.1
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - refs
+      effect:
+        repo: https://github.com/purescript/purescript-effect.git
+        version: v4.0.0
+        dependencies:
+          - prelude
+      either:
+        repo: https://github.com/purescript/purescript-either.git
+        version: v6.1.0
+        dependencies:
+          - control
+          - invariant
+          - maybe
+          - prelude
+      elmish:
+        repo: https://github.com/collegevine/purescript-elmish.git
+        version: v0.8.1
+        dependencies:
+          - aff
+          - argonaut-core
+          - arrays
+          - bifunctors
+          - console
+          - debug
+          - effect
+          - either
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - functions
+          - integers
+          - js-date
+          - maybe
+          - nullable
+          - partial
+          - prelude
+          - refs
+          - typelevel-prelude
+          - undefined-is-not-a-problem
+          - unsafe-coerce
+          - web-dom
+          - web-html
+      elmish-enzyme:
+        repo: https://github.com/collegevine/purescript-elmish-enzyme.git
+        version: v0.1.1
+        dependencies:
+          - aff
+          - aff-promise
+          - arrays
+          - console
+          - debug
+          - effect
+          - elmish
+          - foldable-traversable
+          - foreign
+          - functions
+          - prelude
+          - transformers
+          - unsafe-coerce
+      elmish-hooks:
+        repo: https://github.com/collegevine/purescript-elmish-hooks.git
+        version: v0.8.2
+        dependencies:
+          - aff
+          - debug
+          - elmish
+          - maybe
+          - prelude
+          - tuples
+          - undefined-is-not-a-problem
+      elmish-html:
+        repo: https://github.com/collegevine/purescript-elmish-html.git
+        version: v0.7.1
+        dependencies:
+          - effect
+          - elmish
+          - foreign
+          - foreign-object
+          - prelude
+          - record
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-html
+      email-validate:
+        repo: https://github.com/cdepillabout/purescript-email-validate.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - string-parsers
+          - transformers
+      encoding:
+        repo: https://github.com/menelaos/purescript-encoding.git
+        version: v0.0.8
+        dependencies:
+          - arraybuffer-types
+          - either
+          - exceptions
+          - functions
+          - prelude
+      enums:
+        repo: https://github.com/purescript/purescript-enums.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - either
+          - gen
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tuples
+          - unfoldable
+      exceptions:
+        repo: https://github.com/purescript/purescript-exceptions.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - either
+          - maybe
+          - prelude
+      exists:
+        repo: https://github.com/purescript/purescript-exists.git
+        version: v6.0.0
+        dependencies:
+          - unsafe-coerce
+      exitcodes:
+        repo: https://github.com/Risto-Stevcev/purescript-exitcodes.git
+        version: v4.0.0
+        dependencies:
+          - enums
+      expect-inferred:
+        repo: https://github.com/justinwoo/purescript-expect-inferred.git
+        version: v3.0.0
+        dependencies:
+          - prelude
+          - typelevel-prelude
+      fast-vect:
+        repo: https://github.com/sigma-andex/purescript-fast-vect.git
+        version: v0.7.0
+        dependencies:
+          - arrays
+          - filterable
+          - foldable-traversable
+          - lists
+          - maybe
+          - ordered-collections
+          - prelude
+          - profunctor
+          - tuples
+          - unfoldable
+      filterable:
+        repo: https://github.com/purescript/purescript-filterable.git
+        version: v5.0.0
+        dependencies:
+          - arrays
+          - either
+          - foldable-traversable
+          - identity
+          - lists
+          - ordered-collections
+      fixed-points:
+        repo: https://github.com/purescript-contrib/purescript-fixed-points.git
+        version: v7.0.0
+        dependencies:
+          - exists
+          - newtype
+          - prelude
+          - transformers
+      fixed-precision:
+        repo: https://github.com/lumihq/purescript-fixed-precision.git
+        version: v5.0.0
+        dependencies:
+          - arrays
+          - bigints
+          - control
+          - integers
+          - maybe
+          - numbers
+          - partial
+          - prelude
+          - strings
+      flame:
+        repo: https://github.com/easafe/purescript-flame.git
+        version: v1.2.0
+        dependencies:
+          - aff
+          - argonaut-codecs
+          - argonaut-core
+          - argonaut-generic
+          - arrays
+          - bifunctors
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - maybe
+          - newtype
+          - nullable
+          - partial
+          - prelude
+          - random
+          - refs
+          - spec
+          - strings
+          - tuples
+          - typelevel-prelude
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-html
+          - web-uievents
+      float32:
+        repo: https://github.com/purescript-contrib/purescript-float32.git
+        version: v2.0.0
+        dependencies:
+          - gen
+          - maybe
+          - prelude
+      foldable-traversable:
+        repo: https://github.com/purescript/purescript-foldable-traversable.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - const
+          - control
+          - either
+          - functors
+          - identity
+          - maybe
+          - newtype
+          - orders
+          - prelude
+          - tuples
+      foreign:
+        repo: https://github.com/purescript/purescript-foreign.git
+        version: v7.0.0
+        dependencies:
+          - either
+          - functions
+          - identity
+          - integers
+          - lists
+          - maybe
+          - prelude
+          - strings
+          - transformers
+      foreign-object:
+        repo: https://github.com/purescript/purescript-foreign-object.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - functions
+          - gen
+          - lists
+          - maybe
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - typelevel-prelude
+          - unfoldable
+      foreign-readwrite:
+        repo: https://github.com/artemisSystem/purescript-foreign-readwrite.git
+        version: v3.0.0
+        dependencies:
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - prelude
+          - record
+          - safe-coerce
+          - transformers
+          - unsafe-coerce
+      fork:
+        repo: https://github.com/purescript-contrib/purescript-fork.git
+        version: v6.0.0
+        dependencies:
+          - aff
+      form-urlencoded:
+        repo: https://github.com/purescript-contrib/purescript-form-urlencoded.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - js-uri
+          - maybe
+          - newtype
+          - prelude
+          - strings
+          - tuples
+      formatters:
+        repo: https://github.com/purescript-contrib/purescript-formatters.git
+        version: v7.0.0
+        dependencies:
+          - datetime
+          - fixed-points
+          - lists
+          - numbers
+          - parsing
+          - prelude
+          - transformers
+      free:
+        repo: https://github.com/purescript/purescript-free.git
+        version: v7.0.0
+        dependencies:
+          - catenable-lists
+          - control
+          - distributive
+          - either
+          - exists
+          - foldable-traversable
+          - invariant
+          - lazy
+          - maybe
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+      freeap:
+        repo: https://github.com/ethul/purescript-freeap.git
+        version: v7.0.0
+        dependencies:
+          - const
+          - exists
+          - gen
+          - lists
+      freet:
+        repo: https://github.com/purescript-contrib/purescript-freet.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - bifunctors
+          - effect
+          - either
+          - exists
+          - free
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      functions:
+        repo: https://github.com/purescript/purescript-functions.git
+        version: v6.0.0
+        dependencies:
+          - prelude
+      functors:
+        repo: https://github.com/purescript/purescript-functors.git
+        version: v5.0.0
+        dependencies:
+          - bifunctors
+          - const
+          - contravariant
+          - control
+          - distributive
+          - either
+          - invariant
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - tuples
+          - unsafe-coerce
+      fuzzy:
+        repo: https://github.com/citizennet/purescript-fuzzy.git
+        version: v0.4.0
+        dependencies:
+          - foldable-traversable
+          - foreign-object
+          - newtype
+          - ordered-collections
+          - prelude
+          - rationals
+          - strings
+          - tuples
+      gen:
+        repo: https://github.com/purescript/purescript-gen.git
+        version: v4.0.0
+        dependencies:
+          - either
+          - foldable-traversable
+          - identity
+          - maybe
+          - newtype
+          - nonempty
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      generate-values:
+        repo: https://github.com/jordanmartinez/purescript-generate-values.git
+        version: v1.0.1
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - enums
+          - foldable-traversable
+          - gen
+          - identity
+          - integers
+          - lcg
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - partial
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      geometry-plane:
+        repo: https://github.com/Ebmtranceboy/purescript-geometry-plane.git
+        version: v1.0.3
+        dependencies:
+          - console
+          - effect
+          - psci-support
+          - sparse-polynomials
+      github-actions-toolkit:
+        repo: https://github.com/purescript-contrib/purescript-github-actions-toolkit.git
+        version: v0.5.0
+        dependencies:
+          - aff
+          - aff-promise
+          - effect
+          - foreign-object
+          - node-buffer
+          - node-path
+          - node-streams
+          - nullable
+          - transformers
+      graphs:
+        repo: https://github.com/purescript/purescript-graphs.git
+        version: v8.0.0
+        dependencies:
+          - catenable-lists
+          - ordered-collections
+      group:
+        repo: https://github.com/morganthomas/purescript-group.git
+        version: v4.1.1
+        dependencies:
+          - lists
+      halogen:
+        repo: https://github.com/purescript-halogen/purescript-halogen.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - avar
+          - console
+          - const
+          - dom-indexed
+          - effect
+          - foreign
+          - fork
+          - free
+          - freeap
+          - halogen-subscriptions
+          - halogen-vdom
+          - media-types
+          - nullable
+          - ordered-collections
+          - parallel
+          - profunctor
+          - transformers
+          - unsafe-coerce
+          - unsafe-reference
+          - web-file
+          - web-uievents
+      halogen-css:
+        repo: https://github.com/purescript-halogen/purescript-halogen-css.git
+        version: v10.0.0
+        dependencies:
+          - css
+          - halogen
+      halogen-formless:
+        repo: https://github.com/thomashoneyman/purescript-halogen-formless.git
+        version: v4.0.0
+        dependencies:
+          - convertable-options
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - halogen
+          - heterogeneous
+          - maybe
+          - prelude
+          - record
+          - safe-coerce
+          - type-equality
+          - unsafe-coerce
+          - unsafe-reference
+          - variant
+          - web-events
+          - web-uievents
+      halogen-hooks:
+        repo: https://github.com/thomashoneyman/purescript-halogen-hooks.git
+        version: v0.6.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - effect
+          - exceptions
+          - foldable-traversable
+          - foreign-object
+          - free
+          - freeap
+          - halogen
+          - halogen-subscriptions
+          - maybe
+          - newtype
+          - ordered-collections
+          - parallel
+          - partial
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+          - unsafe-reference
+          - web-dom
+          - web-html
+      halogen-hooks-extra:
+        repo: https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git
+        version: v0.9.0
+        dependencies:
+          - halogen-hooks
+      halogen-store:
+        repo: https://github.com/thomashoneyman/purescript-halogen-store.git
+        version: v0.5.0
+        dependencies:
+          - aff
+          - distributive
+          - effect
+          - fork
+          - halogen
+          - halogen-hooks
+          - halogen-subscriptions
+          - maybe
+          - prelude
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-reference
+      halogen-storybook:
+        repo: https://github.com/rnons/purescript-halogen-storybook.git
+        version: v2.0.0
+        dependencies:
+          - foreign-object
+          - halogen
+          - prelude
+          - routing
+      halogen-subscriptions:
+        repo: https://github.com/purescript-halogen/purescript-halogen-subscriptions.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - effect
+          - foldable-traversable
+          - functors
+          - refs
+          - safe-coerce
+          - unsafe-reference
+      halogen-svg-elems:
+        repo: https://github.com/JordanMartinez/purescript-halogen-svg-elems.git
+        version: v6.0.0
+        dependencies:
+          - halogen
+      halogen-vdom:
+        repo: https://github.com/purescript-halogen/purescript-halogen-vdom.git
+        version: v8.0.0
+        dependencies:
+          - bifunctors
+          - effect
+          - foreign
+          - foreign-object
+          - maybe
+          - prelude
+          - refs
+          - tuples
+          - unsafe-coerce
+          - web-html
+      halogen-vdom-string-renderer:
+        repo: https://github.com/purescript-halogen/purescript-halogen-vdom-string-renderer.git
+        version: v0.5.0
+        dependencies:
+          - foreign
+          - halogen-vdom
+          - ordered-collections
+          - prelude
+      heckin:
+        repo: https://github.com/maxdeviant/purescript-heckin.git
+        version: v2.0.1
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - maybe
+          - prelude
+          - strings
+          - transformers
+          - tuples
+          - unicode
+      heterogeneous:
+        repo: https://github.com/natefaubion/purescript-heterogeneous.git
+        version: v0.6.0
+        dependencies:
+          - either
+          - functors
+          - prelude
+          - record
+          - tuples
+          - variant
+      heterogeneous-extrablatt:
+        repo: https://github.com/sigma-andex/purescript-heterogeneous-extrablatt.git
+        version: v0.2.1
+        dependencies:
+          - heterogeneous
+          - prelude
+          - record
+      http-methods:
+        repo: https://github.com/purescript-contrib/purescript-http-methods.git
+        version: v6.0.0
+        dependencies:
+          - either
+          - prelude
+          - strings
+      httpure:
+        repo: https://github.com/citizennet/purescript-httpure.git
+        version: v0.15.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - js-uri
+          - maybe
+          - newtype
+          - node-buffer
+          - node-fs
+          - node-http
+          - node-streams
+          - options
+          - ordered-collections
+          - prelude
+          - refs
+          - strings
+          - tuples
+          - type-equality
+      httpurple:
+        repo: https://github.com/sigma-andex/purescript-httpurple.git
+        version: v1.3.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - foreign-object
+          - js-uri
+          - justifill
+          - maybe
+          - newtype
+          - node-buffer
+          - node-fs
+          - node-http
+          - node-net
+          - node-process
+          - node-streams
+          - options
+          - ordered-collections
+          - posix-types
+          - prelude
+          - profunctor
+          - record
+          - refs
+          - routing-duplex
+          - strings
+          - transformers
+          - tuples
+          - type-equality
+          - typelevel-prelude
+      httpurple-argonaut:
+        repo: https://github.com/sigma-andex/purescript-httpurple-argonaut.git
+        version: v1.0.1
+        dependencies:
+          - argonaut
+          - console
+          - effect
+          - either
+          - httpurple
+          - prelude
+      httpurple-yoga-json:
+        repo: https://github.com/sigma-andex/purescript-httpurple-yoga-json.git
+        version: v1.0.0
+        dependencies:
+          - console
+          - effect
+          - either
+          - foreign
+          - httpurple
+          - lists
+          - prelude
+          - yoga-json
+      identity:
+        repo: https://github.com/purescript/purescript-identity.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - invariant
+          - newtype
+          - prelude
+      indexed-monad:
+        repo: https://github.com/garyb/purescript-indexed-monad.git
+        version: v2.1.0
+        dependencies:
+          - control
+          - newtype
+      int64:
+        repo: https://github.com/purescript-contrib/purescript-int64.git
+        version: v2.0.0
+        dependencies:
+          - effect
+          - foreign
+          - functions
+          - integers
+          - maybe
+          - nullable
+          - prelude
+          - quickcheck
+      integers:
+        repo: https://github.com/purescript/purescript-integers.git
+        version: v6.0.0
+        dependencies:
+          - maybe
+          - numbers
+          - prelude
+      interpolate:
+        repo: https://github.com/jordanmartinez/purescript-interpolate.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+      invariant:
+        repo: https://github.com/purescript/purescript-invariant.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - prelude
+      js-date:
+        repo: https://github.com/purescript-contrib/purescript-js-date.git
+        version: v8.0.0
+        dependencies:
+          - datetime
+          - effect
+          - exceptions
+          - foreign
+          - integers
+          - now
+      js-fileio:
+        repo: https://github.com/newlandsvalley/purescript-js-fileio.git
+        version: v3.0.0
+        dependencies:
+          - aff
+          - effect
+          - prelude
+      js-timers:
+        repo: https://github.com/purescript-contrib/purescript-js-timers.git
+        version: v6.1.0
+        dependencies:
+          - effect
+      js-uri:
+        repo: https://github.com/purescript-contrib/purescript-js-uri.git
+        version: v3.0.0
+        dependencies:
+          - functions
+          - maybe
+      justifill:
+        repo: https://github.com/i-am-the-slime/purescript-justifill.git
+        version: v0.5.0
+        dependencies:
+          - maybe
+          - prelude
+          - record
+          - typelevel-prelude
+      jwt:
+        repo: https://github.com/menelaos/purescript-jwt.git
+        version: v0.0.9
+        dependencies:
+          - argonaut-core
+          - arrays
+          - b64
+          - either
+          - exceptions
+          - prelude
+          - profunctor-lenses
+          - strings
+      language-cst-parser:
+        repo: https://github.com/natefaubion/purescript-language-cst-parser.git
+        version: v0.12.0
+        dependencies:
+          - arrays
+          - const
+          - control
+          - either
+          - foldable-traversable
+          - free
+          - functions
+          - functors
+          - identity
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - ordered-collections
+          - partial
+          - prelude
+          - st
+          - strings
+          - transformers
+          - tuples
+          - typelevel-prelude
+          - unfoldable
+          - unsafe-coerce
+      lazy:
+        repo: https://github.com/purescript/purescript-lazy.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - invariant
+          - prelude
+      lcg:
+        repo: https://github.com/purescript/purescript-lcg.git
+        version: v4.0.0
+        dependencies:
+          - effect
+          - integers
+          - maybe
+          - partial
+          - prelude
+          - random
+      leibniz:
+        repo: https://github.com/paf31/purescript-leibniz.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+          - unsafe-coerce
+      linalg:
+        repo: https://github.com/gbagan/purescript-linalg.git
+        version: v5.1.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - functions
+          - maybe
+          - prelude
+          - tuples
+      lists:
+        repo: https://github.com/purescript/purescript-lists.git
+        version: v7.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - foldable-traversable
+          - lazy
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      logging:
+        repo: https://github.com/rightfold/purescript-logging.git
+        version: v3.0.0
+        dependencies:
+          - console
+          - contravariant
+          - effect
+          - either
+          - prelude
+          - transformers
+          - tuples
+      machines:
+        repo: https://github.com/purescript-contrib/purescript-machines.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - lists
+          - maybe
+          - prelude
+          - profunctor
+          - tuples
+          - unfoldable
+      matrices:
+        repo: https://github.com/kRITZCREEK/purescript-matrices.git
+        version: v5.0.1
+        dependencies:
+          - arrays
+          - strings
+      matryoshka:
+        repo: https://github.com/purescript-contrib/purescript-matryoshka.git
+        version: v1.0.0
+        dependencies:
+          - fixed-points
+          - free
+          - prelude
+          - profunctor
+          - transformers
+      maybe:
+        repo: https://github.com/purescript/purescript-maybe.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - invariant
+          - newtype
+          - prelude
+      media-types:
+        repo: https://github.com/purescript-contrib/purescript-media-types.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      metadata:
+        repo: https://github.com/purescript/purescript-metadata.git
+        version: v0.15.0
+        dependencies: []
+      midi:
+        repo: https://github.com/newlandsvalley/purescript-midi.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - integers
+          - lists
+          - maybe
+          - ordered-collections
+          - prelude
+          - signal
+          - string-parsers
+          - strings
+          - tuples
+          - unfoldable
+      minibench:
+        repo: https://github.com/purescript/purescript-minibench.git
+        version: v4.0.0
+        dependencies:
+          - console
+          - effect
+          - integers
+          - numbers
+          - partial
+          - prelude
+          - refs
+      mmorph:
+        repo: https://github.com/Thimoteus/purescript-mmorph.git
+        version: v7.0.0
+        dependencies:
+          - free
+          - functors
+          - transformers
+      monad-control:
+        repo: https://github.com/athanclark/purescript-monad-control.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - freet
+          - identity
+          - lists
+      monad-logger:
+        repo: https://github.com/cprussin/purescript-monad-logger.git
+        version: v1.3.1
+        dependencies:
+          - aff
+          - ansi
+          - argonaut
+          - arrays
+          - console
+          - control
+          - effect
+          - foldable-traversable
+          - foreign-object
+          - integers
+          - js-date
+          - maybe
+          - newtype
+          - ordered-collections
+          - prelude
+          - strings
+          - transformers
+          - tuples
+      monad-loops:
+        repo: https://github.com/mlang/purescript-monad-loops.git
+        version: v0.5.0
+        dependencies:
+          - lists
+          - maybe
+          - prelude
+          - tailrec
+          - tuples
+      monad-unlift:
+        repo: https://github.com/athanclark/purescript-monad-unlift.git
+        version: v1.0.1
+        dependencies:
+          - monad-control
+      monoidal:
+        repo: https://github.com/mcneissue/purescript-monoidal.git
+        version: v0.16.0
+        dependencies:
+          - either
+          - profunctor
+          - these
+          - tuples
+      morello:
+        repo: https://github.com/sigma-andex/purescript-morello.git
+        version: v0.3.2
+        dependencies:
+          - arrays
+          - barlow-lens
+          - foldable-traversable
+          - heterogeneous
+          - heterogeneous-extrablatt
+          - newtype
+          - prelude
+          - profunctor
+          - profunctor-lenses
+          - record
+          - tuples
+          - typelevel-prelude
+          - validation
+      motsunabe:
+        repo: https://github.com/justinwoo/purescript-motsunabe.git
+        version: v2.0.0
+        dependencies:
+          - lists
+          - strings
+      nano-id:
+        repo: https://github.com/eikooc/nano-id.git
+        version: v1.1.0
+        dependencies:
+          - aff
+          - effect
+          - lists
+          - maybe
+          - prelude
+          - random
+          - spec
+          - strings
+          - stringutils
+      naturals:
+        repo: https://github.com/LiamGoodacre/purescript-naturals.git
+        version: v3.0.0
+        dependencies:
+          - enums
+          - maybe
+          - prelude
+      nested-functor:
+        repo: https://github.com/acple/purescript-nested-functor.git
+        version: v0.2.1
+        dependencies:
+          - prelude
+          - type-equality
+      newtype:
+        repo: https://github.com/purescript/purescript-newtype.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+          - safe-coerce
+      node-buffer:
+        repo: https://github.com/purescript-node/purescript-node-buffer.git
+        version: v8.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - maybe
+          - st
+          - unsafe-coerce
+      node-buffer-blob:
+        repo: https://github.com/purescript-node/purescript-node-buffer-blob.git
+        version: v1.0.0
+        dependencies:
+          - aff-promise
+          - arraybuffer-types
+          - arrays
+          - console
+          - effect
+          - maybe
+          - media-types
+          - newtype
+          - node-buffer
+          - nullable
+          - prelude
+          - web-streams
+      node-child-process:
+        repo: https://github.com/purescript-node/purescript-node-child-process.git
+        version: v9.0.0
+        dependencies:
+          - exceptions
+          - foreign
+          - foreign-object
+          - functions
+          - node-fs
+          - node-streams
+          - nullable
+          - posix-types
+          - unsafe-coerce
+      node-fs:
+        repo: https://github.com/purescript-node/purescript-node-fs.git
+        version: v8.0.0
+        dependencies:
+          - datetime
+          - effect
+          - either
+          - enums
+          - exceptions
+          - functions
+          - integers
+          - js-date
+          - maybe
+          - node-buffer
+          - node-path
+          - node-streams
+          - nullable
+          - partial
+          - prelude
+          - strings
+          - unsafe-coerce
+      node-fs-aff:
+        repo: https://github.com/purescript-node/purescript-node-fs-aff.git
+        version: v9.0.0
+        dependencies:
+          - aff
+          - either
+          - node-fs
+          - node-path
+      node-http:
+        repo: https://github.com/purescript-node/purescript-node-http.git
+        version: v8.0.0
+        dependencies:
+          - arraybuffer-types
+          - contravariant
+          - effect
+          - foreign
+          - foreign-object
+          - maybe
+          - node-buffer
+          - node-net
+          - node-streams
+          - node-url
+          - nullable
+          - options
+          - prelude
+          - unsafe-coerce
+      node-net:
+        repo: https://github.com/purescript-node/purescript-node-net.git
+        version: v4.0.0
+        dependencies:
+          - effect
+          - either
+          - exceptions
+          - foreign
+          - maybe
+          - node-buffer
+          - node-fs
+          - nullable
+          - options
+          - prelude
+          - transformers
+      node-path:
+        repo: https://github.com/purescript-node/purescript-node-path.git
+        version: v5.0.0
+        dependencies:
+          - effect
+      node-process:
+        repo: https://github.com/purescript-node/purescript-node-process.git
+        version: v10.0.0
+        dependencies:
+          - effect
+          - foreign-object
+          - maybe
+          - node-streams
+          - posix-types
+          - prelude
+          - unsafe-coerce
+      node-readline:
+        repo: https://github.com/purescript-node/purescript-node-readline.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - foreign
+          - node-process
+          - node-streams
+          - options
+          - prelude
+      node-streams:
+        repo: https://github.com/purescript-node/purescript-node-streams.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - either
+          - exceptions
+          - node-buffer
+          - nullable
+          - prelude
+      node-streams-aff:
+        repo: https://github.com/jamesdbrock/purescript-node-streams-aff.git
+        version: v2.0.0
+        dependencies:
+          - aff
+          - arrays
+          - effect
+          - either
+          - exceptions
+          - maybe
+          - node-buffer
+          - node-streams
+          - prelude
+          - st
+          - tuples
+      node-url:
+        repo: https://github.com/purescript-node/purescript-node-url.git
+        version: v6.0.0
+        dependencies:
+          - nullable
+      nonempty:
+        repo: https://github.com/purescript/purescript-nonempty.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - foldable-traversable
+          - maybe
+          - prelude
+          - tuples
+          - unfoldable
+      now:
+        repo: https://github.com/purescript-contrib/purescript-now.git
+        version: v6.0.0
+        dependencies:
+          - datetime
+          - effect
+      npm-package-json:
+        repo: https://github.com/maxdeviant/purescript-npm-package-json.git
+        version: v2.0.0
+        dependencies:
+          - argonaut
+          - control
+          - either
+          - foreign-object
+          - maybe
+          - ordered-collections
+          - prelude
+      nullable:
+        repo: https://github.com/purescript-contrib/purescript-nullable.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - functions
+          - maybe
+      numbers:
+        repo: https://github.com/purescript/purescript-numbers.git
+        version: v9.0.0
+        dependencies:
+          - functions
+          - maybe
+      open-folds:
+        repo: https://github.com/purescript-open-community/purescript-open-folds.git
+        version: v6.3.0
+        dependencies:
+          - bifunctors
+          - console
+          - control
+          - distributive
+          - effect
+          - either
+          - foldable-traversable
+          - identity
+          - invariant
+          - maybe
+          - newtype
+          - ordered-collections
+          - prelude
+          - profunctor
+          - psci-support
+          - tuples
+      open-memoize:
+        repo: https://github.com/purescript-open-community/purescript-open-memoize.git
+        version: v6.1.0
+        dependencies:
+          - console
+          - effect
+          - either
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - psci-support
+          - strings
+          - tuples
+      open-pairing:
+        repo: https://github.com/purescript-open-community/purescript-open-pairing.git
+        version: v6.1.0
+        dependencies:
+          - console
+          - control
+          - effect
+          - either
+          - free
+          - functors
+          - identity
+          - newtype
+          - prelude
+          - psci-support
+          - transformers
+          - tuples
+      options:
+        repo: https://github.com/purescript-contrib/purescript-options.git
+        version: v7.0.0
+        dependencies:
+          - contravariant
+          - foreign
+          - foreign-object
+          - maybe
+          - tuples
+      optparse:
+        repo: https://github.com/f-o-a-m/purescript-optparse.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - console
+          - control
+          - effect
+          - either
+          - enums
+          - exists
+          - exitcodes
+          - foldable-traversable
+          - free
+          - gen
+          - integers
+          - lazy
+          - lists
+          - maybe
+          - newtype
+          - node-buffer
+          - node-process
+          - node-streams
+          - nonempty
+          - numbers
+          - open-memoize
+          - partial
+          - prelude
+          - quickcheck
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+      ordered-collections:
+        repo: https://github.com/purescript/purescript-ordered-collections.git
+        version: v3.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - gen
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - st
+          - tailrec
+          - tuples
+          - unfoldable
+      ordered-set:
+        repo: https://github.com/flip111/purescript-ordered-set.git
+        version: v0.4.0
+        dependencies:
+          - argonaut-codecs
+          - arrays
+          - partial
+          - prelude
+          - unfoldable
+      orders:
+        repo: https://github.com/purescript/purescript-orders.git
+        version: v6.0.0
+        dependencies:
+          - newtype
+          - prelude
+      pairs:
+        repo: https://github.com/sharkdp/purescript-pairs.git
+        version: v9.0.0
+        dependencies:
+          - console
+          - distributive
+          - foldable-traversable
+          - quickcheck
+      parallel:
+        repo: https://github.com/purescript/purescript-parallel.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - functors
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - refs
+          - transformers
+      parsing:
+        repo: https://github.com/purescript-contrib/purescript-parsing.git
+        version: v9.1.0
+        dependencies:
+          - arrays
+          - either
+          - foldable-traversable
+          - identity
+          - integers
+          - lists
+          - maybe
+          - nullable
+          - prelude
+          - strings
+          - transformers
+          - unicode
+      parsing-dataview:
+        repo: https://github.com/jamesdbrock/purescript-parsing-dataview.git
+        version: v3.1.0
+        dependencies:
+          - arraybuffer
+          - arraybuffer-types
+          - effect
+          - float32
+          - maybe
+          - parsing
+          - prelude
+          - transformers
+          - tuples
+          - uint
+      partial:
+        repo: https://github.com/purescript/purescript-partial.git
+        version: v4.0.0
+        dependencies: []
+      pathy:
+        repo: https://github.com/purescript-contrib/purescript-pathy.git
+        version: v9.0.0
+        dependencies:
+          - console
+          - exceptions
+          - lists
+          - partial
+          - profunctor
+          - strings
+          - transformers
+          - typelevel-prelude
+          - unsafe-coerce
+      pha:
+        repo: https://github.com/gbagan/purescript-pha.git
+        version: v0.9.0
+        dependencies:
+          - aff
+          - arrays
+          - bifunctors
+          - datetime
+          - effect
+          - foldable-traversable
+          - free
+          - integers
+          - maybe
+          - prelude
+          - profunctor-lenses
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+          - unsafe-coerce
+          - unsafe-reference
+          - web-dom
+          - web-events
+          - web-html
+          - web-pointerevents
+          - web-uievents
+      phaser:
+        repo: https://github.com/lfarroco/purescript-phaser.git
+        version: v0.6.0
+        dependencies:
+          - canvas
+          - console
+          - effect
+          - maybe
+          - nullable
+          - options
+          - prelude
+          - web-html
+      pipes:
+        repo: https://github.com/felixschl/purescript-pipes.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - lists
+          - mmorph
+          - prelude
+          - tailrec
+          - transformers
+          - tuples
+      point-free:
+        repo: https://github.com/ursi/purescript-point-free.git
+        version: v1.0.0
+        dependencies:
+          - prelude
+      polymorphic-vectors:
+        repo: https://github.com/artemisSystem/purescript-polymorphic-vectors.git
+        version: v4.0.0
+        dependencies:
+          - distributive
+          - foldable-traversable
+          - numbers
+          - prelude
+          - record
+          - safe-coerce
+          - type-equality
+          - typelevel-prelude
+      posix-types:
+        repo: https://github.com/purescript-node/purescript-posix-types.git
+        version: v6.0.0
+        dependencies:
+          - maybe
+          - prelude
+      precise:
+        repo: https://github.com/purescript-contrib/purescript-precise.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - exceptions
+          - gen
+          - integers
+          - lists
+          - numbers
+          - prelude
+          - strings
+      precise-datetime:
+        repo: https://github.com/awakesecurity/purescript-precise-datetime.git
+        version: v7.0.0
+        dependencies:
+          - arrays
+          - datetime
+          - decimals
+          - either
+          - enums
+          - foldable-traversable
+          - formatters
+          - integers
+          - js-date
+          - lists
+          - maybe
+          - newtype
+          - numbers
+          - prelude
+          - strings
+          - tuples
+          - unicode
+      prelude:
+        repo: https://github.com/purescript/purescript-prelude.git
+        version: v6.0.0
+        dependencies: []
+      prettier-printer:
+        repo: https://github.com/paulyoung/purescript-prettier-printer.git
+        version: v3.0.0
+        dependencies:
+          - console
+          - lists
+          - prelude
+          - strings
+          - tuples
+      profunctor:
+        repo: https://github.com/purescript/purescript-profunctor.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - distributive
+          - either
+          - exists
+          - invariant
+          - newtype
+          - prelude
+          - tuples
+      profunctor-lenses:
+        repo: https://github.com/purescript-contrib/purescript-profunctor-lenses.git
+        version: v8.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - const
+          - control
+          - distributive
+          - either
+          - foldable-traversable
+          - foreign-object
+          - functors
+          - identity
+          - lists
+          - maybe
+          - newtype
+          - ordered-collections
+          - partial
+          - prelude
+          - profunctor
+          - record
+          - transformers
+          - tuples
+      protobuf:
+        repo: https://github.com/xc-jp/purescript-protobuf.git
+        version: v4.0.0
+        dependencies:
+          - arraybuffer
+          - arraybuffer-builder
+          - arraybuffer-types
+          - arrays
+          - control
+          - effect
+          - either
+          - enums
+          - exceptions
+          - float32
+          - foldable-traversable
+          - functions
+          - int64
+          - maybe
+          - newtype
+          - parsing
+          - parsing-dataview
+          - prelude
+          - record
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+          - uint
+          - web-encoding
+      ps-cst:
+        repo: https://github.com/purescript-codegen/purescript-ps-cst.git
+        version: v1.2.0
+        dependencies:
+          - ansi
+          - console
+          - dodo-printer
+          - effect
+          - node-fs-aff
+          - node-path
+          - psci-support
+          - record
+          - strings
+      psa-utils:
+        repo: https://github.com/natefaubion/purescript-psa-utils.git
+        version: v8.0.0
+        dependencies:
+          - ansi
+          - argonaut-codecs
+          - argonaut-core
+          - arrays
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - maybe
+          - node-path
+          - ordered-collections
+          - prelude
+          - strings
+          - tuples
+          - unsafe-coerce
+      psc-ide:
+        repo: https://github.com/kRITZCREEK/purescript-psc-ide.git
+        version: v19.0.0
+        dependencies:
+          - aff
+          - argonaut
+          - arrays
+          - console
+          - maybe
+          - node-child-process
+          - node-fs
+          - parallel
+          - random
+      psci-support:
+        repo: https://github.com/purescript/purescript-psci-support.git
+        version: v6.0.0
+        dependencies:
+          - console
+          - effect
+          - prelude
+      qualified-do:
+        repo: https://github.com/artemisSystem/purescript-qualified-do.git
+        version: v2.2.0
+        dependencies:
+          - arrays
+          - control
+          - foldable-traversable
+          - parallel
+          - prelude
+          - unfoldable
+      quantities:
+        repo: https://github.com/sharkdp/purescript-quantities.git
+        version: v12.0.1
+        dependencies:
+          - decimals
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - newtype
+          - nonempty
+          - numbers
+          - pairs
+          - prelude
+          - tuples
+      quickcheck:
+        repo: https://github.com/purescript/purescript-quickcheck.git
+        version: v8.0.1
+        dependencies:
+          - arrays
+          - console
+          - control
+          - effect
+          - either
+          - enums
+          - exceptions
+          - foldable-traversable
+          - gen
+          - identity
+          - integers
+          - lazy
+          - lcg
+          - lists
+          - maybe
+          - newtype
+          - nonempty
+          - numbers
+          - partial
+          - prelude
+          - record
+          - st
+          - strings
+          - tailrec
+          - transformers
+          - tuples
+          - unfoldable
+      quickcheck-combinators:
+        repo: https://github.com/athanclark/purescript-quickcheck-combinators.git
+        version: v0.1.3
+        dependencies:
+          - quickcheck
+          - typelevel
+      quickcheck-laws:
+        repo: https://github.com/purescript-contrib/purescript-quickcheck-laws.git
+        version: v7.0.0
+        dependencies:
+          - enums
+          - quickcheck
+      quickcheck-utf8:
+        repo: https://github.com/openchronology/purescript-quickcheck-utf8.git
+        version: v0.0.0
+        dependencies:
+          - quickcheck
+      quotient:
+        repo: https://github.com/rightfold/purescript-quotient.git
+        version: v3.0.0
+        dependencies:
+          - prelude
+          - quickcheck
+      random:
+        repo: https://github.com/purescript/purescript-random.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - integers
+      rationals:
+        repo: https://github.com/anttih/purescript-rationals.git
+        version: v5.0.0
+        dependencies:
+          - integers
+          - prelude
+      react:
+        repo: https://github.com/purescript-contrib/purescript-react.git
+        version: v10.0.1
+        dependencies:
+          - effect
+          - exceptions
+          - maybe
+          - nullable
+          - prelude
+          - typelevel-prelude
+          - unsafe-coerce
+      react-basic:
+        repo: https://github.com/lumihq/purescript-react-basic.git
+        version: v17.0.0
+        dependencies:
+          - effect
+          - prelude
+          - record
+      react-basic-dom:
+        repo: https://github.com/lumihq/purescript-react-basic-dom.git
+        version: v5.0.0
+        dependencies:
+          - effect
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - nullable
+          - prelude
+          - react-basic
+          - unsafe-coerce
+          - web-dom
+          - web-events
+          - web-file
+          - web-html
+      react-basic-hooks:
+        repo: https://github.com/megamaddu/purescript-react-basic-hooks.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - aff-promise
+          - bifunctors
+          - console
+          - control
+          - datetime
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - functions
+          - indexed-monad
+          - integers
+          - maybe
+          - newtype
+          - now
+          - nullable
+          - ordered-collections
+          - prelude
+          - react-basic
+          - refs
+          - tuples
+          - type-equality
+          - unsafe-coerce
+          - unsafe-reference
+          - web-html
+      react-dom:
+        repo: https://github.com/purescript-contrib/purescript-react-dom.git
+        version: v8.0.0
+        dependencies:
+          - effect
+          - react
+          - web-dom
+      read:
+        repo: https://github.com/truqu/purescript-read.git
+        version: v1.0.1
+        dependencies:
+          - maybe
+          - prelude
+          - strings
+      record:
+        repo: https://github.com/purescript/purescript-record.git
+        version: v4.0.0
+        dependencies:
+          - functions
+          - prelude
+          - unsafe-coerce
+      refined:
+        repo: https://github.com/danieljharvey/purescript-refined.git
+        version: v1.0.0
+        dependencies:
+          - argonaut
+          - effect
+          - prelude
+          - quickcheck
+          - typelevel
+      refs:
+        repo: https://github.com/purescript/purescript-refs.git
+        version: v6.0.0
+        dependencies:
+          - effect
+          - prelude
+      remotedata:
+        repo: https://github.com/krisajenkins/purescript-remotedata.git
+        version: v5.0.0
+        dependencies:
+          - bifunctors
+          - either
+          - profunctor-lenses
+      resource:
+        repo: https://github.com/joneshf/purescript-resource.git
+        version: v2.0.1
+        dependencies:
+          - aff
+          - console
+          - control
+          - effect
+          - newtype
+          - prelude
+          - psci-support
+          - refs
+      resourcet:
+        repo: https://github.com/robertdp/purescript-resourcet.git
+        version: v1.0.0
+        dependencies:
+          - aff
+          - effect
+          - foldable-traversable
+          - maybe
+          - ordered-collections
+          - parallel
+          - refs
+          - tailrec
+          - transformers
+          - tuples
+      result:
+        repo: https://github.com/ad-si/purescript-result.git
+        version: v1.0.3
+        dependencies:
+          - either
+          - foldable-traversable
+          - prelude
+      return:
+        repo: https://github.com/ursi/purescript-return.git
+        version: v0.2.0
+        dependencies:
+          - foldable-traversable
+          - point-free
+          - prelude
+      ring-modules:
+        repo: https://github.com/f-o-a-m/purescript-ring-modules.git
+        version: v5.0.1
+        dependencies:
+          - prelude
+      routing:
+        repo: https://github.com/purescript-contrib/purescript-routing.git
+        version: v11.0.0
+        dependencies:
+          - aff
+          - console
+          - control
+          - effect
+          - either
+          - foldable-traversable
+          - integers
+          - js-uri
+          - lists
+          - maybe
+          - numbers
+          - partial
+          - prelude
+          - semirings
+          - tuples
+          - validation
+          - web-html
+      routing-duplex:
+        repo: https://github.com/natefaubion/purescript-routing-duplex.git
+        version: v0.6.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - js-uri
+          - lazy
+          - numbers
+          - prelude
+          - profunctor
+          - record
+          - strings
+          - typelevel-prelude
+      run:
+        repo: https://github.com/natefaubion/purescript-run.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - free
+          - maybe
+          - newtype
+          - prelude
+          - profunctor
+          - tailrec
+          - tuples
+          - type-equality
+          - typelevel-prelude
+          - unsafe-coerce
+          - variant
+      safe-coerce:
+        repo: https://github.com/purescript/purescript-safe-coerce.git
+        version: v2.0.0
+        dependencies:
+          - unsafe-coerce
+      safely:
+        repo: https://github.com/paf31/purescript-safely.git
+        version: v4.0.1
+        dependencies:
+          - freet
+          - lists
+      selection-foldable:
+        repo: https://github.com/jamieyung/purescript-selection-foldable.git
+        version: v0.2.0
+        dependencies:
+          - filterable
+          - foldable-traversable
+          - maybe
+          - prelude
+      semirings:
+        repo: https://github.com/purescript/purescript-semirings.git
+        version: v7.0.0
+        dependencies:
+          - foldable-traversable
+          - lists
+          - newtype
+          - prelude
+      signal:
+        repo: https://github.com/bodil/purescript-signal.git
+        version: v13.0.0
+        dependencies:
+          - aff
+          - effect
+          - either
+          - foldable-traversable
+          - maybe
+          - prelude
+      simple-emitter:
+        repo: https://github.com/oreshinya/purescript-simple-emitter.git
+        version: v2.0.0
+        dependencies:
+          - ordered-collections
+          - refs
+      sized-matrices:
+        repo: https://github.com/csicar/purescript-sized-matrices.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - distributive
+          - foldable-traversable
+          - maybe
+          - prelude
+          - sized-vectors
+          - strings
+          - typelevel
+          - unfoldable
+          - vectorfield
+      sized-vectors:
+        repo: https://github.com/bodil/purescript-sized-vectors.git
+        version: v5.0.2
+        dependencies:
+          - argonaut
+          - arrays
+          - distributive
+          - foldable-traversable
+          - maybe
+          - prelude
+          - quickcheck
+          - typelevel
+          - unfoldable
+      slug:
+        repo: https://github.com/thomashoneyman/purescript-slug.git
+        version: v3.0.1
+        dependencies:
+          - argonaut-codecs
+          - maybe
+          - prelude
+          - strings
+          - unicode
+      soundfonts:
+        repo: https://github.com/newlandsvalley/purescript-soundfonts.git
+        version: v4.1.0
+        dependencies:
+          - aff
+          - affjax
+          - affjax-web
+          - argonaut-core
+          - arraybuffer-types
+          - arrays
+          - b64
+          - bifunctors
+          - console
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign-object
+          - http-methods
+          - integers
+          - lists
+          - maybe
+          - midi
+          - ordered-collections
+          - parallel
+          - partial
+          - prelude
+          - strings
+          - transformers
+          - tuples
+      sparse-matrices:
+        repo: https://github.com/Ebmtranceboy/purescript-sparse-matrices.git
+        version: v1.2.1
+        dependencies:
+          - console
+          - effect
+          - prelude
+          - sparse-polynomials
+      sparse-polynomials:
+        repo: https://github.com/Ebmtranceboy/purescript-sparse-polynomials.git
+        version: v1.0.5
+        dependencies:
+          - cartesian
+          - console
+          - effect
+          - ordered-collections
+          - prelude
+          - rationals
+          - tuples
+      spec:
+        repo: https://github.com/purescript-spec/purescript-spec.git
+        version: v7.0.0
+        dependencies:
+          - aff
+          - ansi
+          - avar
+          - console
+          - exceptions
+          - foldable-traversable
+          - fork
+          - now
+          - pipes
+          - prelude
+          - strings
+          - transformers
+      spec-discovery:
+        repo: https://github.com/purescript-spec/purescript-spec-discovery.git
+        version: v8.0.0
+        dependencies:
+          - aff
+          - aff-promise
+          - arrays
+          - console
+          - effect
+          - foldable-traversable
+          - node-fs
+          - prelude
+          - spec
+      spec-quickcheck:
+        repo: https://github.com/purescript-spec/purescript-spec-quickcheck.git
+        version: v5.0.0
+        dependencies:
+          - aff
+          - prelude
+          - quickcheck
+          - random
+          - spec
+      ssrs:
+        repo: https://github.com/PureFunctor/purescript-ssrs.git
+        version: v1.0.0
+        dependencies:
+          - dissect
+          - either
+          - fixed-points
+          - free
+          - lists
+          - prelude
+          - safe-coerce
+          - tailrec
+          - tuples
+          - variant
+      st:
+        repo: https://github.com/purescript/purescript-st.git
+        version: v6.0.0
+        dependencies:
+          - partial
+          - prelude
+          - tailrec
+          - unsafe-coerce
+      strictlypositiveint:
+        repo: https://github.com/jamieyung/purescript-strictlypositiveint.git
+        version: v1.0.1
+        dependencies:
+          - prelude
+      string-parsers:
+        repo: https://github.com/purescript-contrib/purescript-string-parsers.git
+        version: v8.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - lists
+          - maybe
+          - prelude
+          - strings
+          - tailrec
+      strings:
+        repo: https://github.com/purescript/purescript-strings.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - control
+          - either
+          - enums
+          - foldable-traversable
+          - gen
+          - integers
+          - maybe
+          - newtype
+          - nonempty
+          - partial
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+          - unsafe-coerce
+      strings-extra:
+        repo: https://github.com/purescript-contrib/purescript-strings-extra.git
+        version: v4.0.0
+        dependencies:
+          - arrays
+          - foldable-traversable
+          - maybe
+          - prelude
+          - strings
+          - unicode
+      stringutils:
+        repo: https://github.com/menelaos/purescript-stringutils.git
+        version: v0.0.12
+        dependencies:
+          - arrays
+          - integers
+          - maybe
+          - partial
+          - prelude
+          - strings
+      substitute:
+        repo: https://github.com/ursi/purescript-substitute.git
+        version: v0.2.3
+        dependencies:
+          - foldable-traversable
+          - foreign-object
+          - maybe
+          - prelude
+          - return
+          - strings
+      supply:
+        repo: https://github.com/ajnsit/purescript-supply.git
+        version: v0.2.0
+        dependencies:
+          - console
+          - control
+          - effect
+          - lazy
+          - prelude
+          - refs
+          - tuples
+      tailrec:
+        repo: https://github.com/purescript/purescript-tailrec.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - effect
+          - either
+          - identity
+          - maybe
+          - partial
+          - prelude
+          - refs
+      test-unit:
+        repo: https://github.com/bodil/purescript-test-unit.git
+        version: v17.0.0
+        dependencies:
+          - aff
+          - avar
+          - effect
+          - either
+          - free
+          - js-timers
+          - lists
+          - prelude
+          - quickcheck
+          - strings
+      thermite:
+        repo: https://github.com/paf31/purescript-thermite.git
+        version: v6.3.1
+        dependencies:
+          - aff
+          - coroutines
+          - freet
+          - profunctor-lenses
+          - react
+      thermite-dom:
+        repo: https://github.com/athanclark/purescript-thermite-dom.git
+        version: v0.3.1
+        dependencies:
+          - react
+          - react-dom
+          - thermite
+          - web-html
+      these:
+        repo: https://github.com/purescript-contrib/purescript-these.git
+        version: v6.0.0
+        dependencies:
+          - arrays
+          - gen
+          - lists
+          - quickcheck
+          - quickcheck-laws
+          - tuples
+      transformers:
+        repo: https://github.com/purescript/purescript-transformers.git
+        version: v6.0.0
+        dependencies:
+          - control
+          - distributive
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - identity
+          - lazy
+          - maybe
+          - newtype
+          - prelude
+          - tailrec
+          - tuples
+          - unfoldable
+      tree-rose:
+        repo: https://github.com/jordanmartinez/purescript-tree-rose.git
+        version: v4.0.2
+        dependencies:
+          - control
+          - foldable-traversable
+          - free
+          - lists
+          - maybe
+          - prelude
+          - tailrec
+      tuples:
+        repo: https://github.com/purescript/purescript-tuples.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - invariant
+          - prelude
+      two-or-more:
+        repo: https://github.com/i-am-the-slime/purescript-two-or-more.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - foldable-traversable
+          - maybe
+          - partial
+          - prelude
+          - psci-support
+          - tuples
+      type-equality:
+        repo: https://github.com/purescript/purescript-type-equality.git
+        version: v4.0.1
+        dependencies: []
+      typelevel:
+        repo: https://github.com/bodil/purescript-typelevel.git
+        version: v6.0.0
+        dependencies:
+          - partial
+          - prelude
+          - tuples
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-lists:
+        repo: https://github.com/PureFunctor/purescript-typelevel-lists.git
+        version: v2.1.0
+        dependencies:
+          - prelude
+          - tuples
+          - typelevel-peano
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-peano:
+        repo: https://github.com/csicar/purescript-typelevel-peano.git
+        version: v1.0.1
+        dependencies:
+          - arrays
+          - console
+          - effect
+          - prelude
+          - psci-support
+          - typelevel-prelude
+          - unsafe-coerce
+      typelevel-prelude:
+        repo: https://github.com/purescript/purescript-typelevel-prelude.git
+        version: v7.0.0
+        dependencies:
+          - prelude
+          - type-equality
+      typelevel-rows:
+        repo: https://github.com/jordanmartinez/purescript-typelevel-rows.git
+        version: v0.1.0
+        dependencies:
+          - prelude
+      uint:
+        repo: https://github.com/purescript-contrib/purescript-uint.git
+        version: v7.0.0
+        dependencies:
+          - effect
+          - enums
+          - gen
+          - maybe
+          - numbers
+          - prelude
+      uncurried-transformers:
+        repo: https://github.com/PureFunctor/purescript-uncurried-transformers.git
+        version: v1.1.0
+        dependencies:
+          - control
+          - effect
+          - either
+          - functions
+          - identity
+          - prelude
+          - safe-coerce
+          - tailrec
+          - transformers
+          - tuples
+      undefined-is-not-a-problem:
+        repo: https://github.com/paluh/purescript-undefined-is-not-a-problem.git
+        version: v1.0.0
+        dependencies:
+          - arrays
+          - assert
+          - effect
+          - either
+          - foreign
+          - maybe
+          - newtype
+          - prelude
+          - random
+          - tuples
+          - type-equality
+          - unsafe-coerce
+      unfoldable:
+        repo: https://github.com/purescript/purescript-unfoldable.git
+        version: v6.0.0
+        dependencies:
+          - foldable-traversable
+          - maybe
+          - partial
+          - prelude
+          - tuples
+      unicode:
+        repo: https://github.com/purescript-contrib/purescript-unicode.git
+        version: v6.0.0
+        dependencies:
+          - foldable-traversable
+          - maybe
+          - strings
+      unlift:
+        repo: https://github.com/tweag/purescript-unlift.git
+        version: v1.0.1
+        dependencies:
+          - aff
+          - effect
+          - either
+          - freet
+          - identity
+          - lists
+          - maybe
+          - monad-control
+          - prelude
+          - st
+          - transformers
+          - tuples
+      unsafe-coerce:
+        repo: https://github.com/purescript/purescript-unsafe-coerce.git
+        version: v6.0.0
+        dependencies: []
+      unsafe-reference:
+        repo: https://github.com/purescript-contrib/purescript-unsafe-reference.git
+        version: v5.0.0
+        dependencies:
+          - prelude
+      uri:
+        repo: https://github.com/purescript-contrib/purescript-uri.git
+        version: v9.0.0
+        dependencies:
+          - arrays
+          - integers
+          - js-uri
+          - numbers
+          - parsing
+          - prelude
+          - profunctor-lenses
+          - these
+          - transformers
+          - unfoldable
+      validation:
+        repo: https://github.com/purescript/purescript-validation.git
+        version: v6.0.0
+        dependencies:
+          - bifunctors
+          - control
+          - either
+          - foldable-traversable
+          - newtype
+          - prelude
+      variant:
+        repo: https://github.com/natefaubion/purescript-variant.git
+        version: v8.0.0
+        dependencies:
+          - enums
+          - lists
+          - maybe
+          - partial
+          - prelude
+          - record
+          - tuples
+          - unsafe-coerce
+      vectorfield:
+        repo: https://github.com/csicar/purescript-vectorfield.git
+        version: v1.0.1
+        dependencies:
+          - console
+          - effect
+          - group
+          - prelude
+          - psci-support
+      versions:
+        repo: https://github.com/hdgarrood/purescript-versions.git
+        version: v7.0.0
+        dependencies:
+          - control
+          - either
+          - foldable-traversable
+          - functions
+          - integers
+          - lists
+          - maybe
+          - orders
+          - parsing
+          - partial
+          - strings
+      web-clipboard:
+        repo: https://github.com/purescript-web/purescript-web-clipboard.git
+        version: v4.0.0
+        dependencies:
+          - web-html
+      web-cssom:
+        repo: https://github.com/purescript-web/purescript-web-cssom.git
+        version: v2.0.0
+        dependencies:
+          - web-dom
+          - web-html
+          - web-uievents
+      web-dom:
+        repo: https://github.com/purescript-web/purescript-web-dom.git
+        version: v6.0.0
+        dependencies:
+          - web-events
+      web-dom-parser:
+        repo: https://github.com/purescript-web/purescript-web-dom-parser.git
+        version: v8.0.0
+        dependencies:
+          - effect
+          - partial
+          - prelude
+          - web-dom
+      web-dom-xpath:
+        repo: https://github.com/purescript-web/purescript-web-dom-xpath.git
+        version: v3.0.0
+        dependencies:
+          - web-dom
+      web-encoding:
+        repo: https://github.com/purescript-web/purescript-web-encoding.git
+        version: v3.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - newtype
+          - prelude
+      web-events:
+        repo: https://github.com/purescript-web/purescript-web-events.git
+        version: v4.0.0
+        dependencies:
+          - datetime
+          - enums
+          - foreign
+          - nullable
+      web-fetch:
+        repo: https://github.com/purescript-web/purescript-web-fetch.git
+        version: v3.0.0
+        dependencies:
+          - effect
+          - foreign-object
+          - http-methods
+          - prelude
+          - record
+          - typelevel-prelude
+          - web-file
+          - web-promise
+          - web-streams
+      web-file:
+        repo: https://github.com/purescript-web/purescript-web-file.git
+        version: v4.0.0
+        dependencies:
+          - foreign
+          - media-types
+          - web-dom
+      web-html:
+        repo: https://github.com/purescript-web/purescript-web-html.git
+        version: v4.0.0
+        dependencies:
+          - js-date
+          - web-dom
+          - web-file
+          - web-storage
+      web-page-visibility:
+        repo: https://git.sr.ht/~toastal/purescript-web-page-visibility
+        version: v2.0.0
+        dependencies:
+          - effect
+          - enums
+          - exceptions
+          - maybe
+          - prelude
+          - strings
+          - web-events
+          - web-html
+      web-pointerevents:
+        repo: https://github.com/purescript-web/purescript-web-pointerevents.git
+        version: v1.0.0
+        dependencies:
+          - effect
+          - maybe
+          - prelude
+          - web-dom
+          - web-uievents
+      web-promise:
+        repo: https://github.com/purescript-web/purescript-web-promise.git
+        version: v3.0.0
+        dependencies:
+          - effect
+          - exceptions
+          - foldable-traversable
+          - functions
+          - maybe
+          - prelude
+      web-socket:
+        repo: https://github.com/purescript-web/purescript-web-socket.git
+        version: v4.0.0
+        dependencies:
+          - arraybuffer-types
+          - web-file
+      web-storage:
+        repo: https://github.com/purescript-web/purescript-web-storage.git
+        version: v5.0.0
+        dependencies:
+          - nullable
+          - web-events
+      web-streams:
+        repo: https://github.com/purescript-web/purescript-web-streams.git
+        version: v3.0.0
+        dependencies:
+          - arraybuffer-types
+          - effect
+          - exceptions
+          - nullable
+          - prelude
+          - tuples
+          - web-promise
+      web-touchevents:
+        repo: https://github.com/purescript-web/purescript-web-touchevents.git
+        version: v4.0.0
+        dependencies:
+          - web-uievents
+      web-uievents:
+        repo: https://github.com/purescript-web/purescript-web-uievents.git
+        version: v4.0.0
+        dependencies:
+          - web-html
+      web-workers:
+        repo: https://github.com/gbagan/purescript-web-workers.git
+        version: v1.1.0
+        dependencies:
+          - effect
+          - foreign
+          - maybe
+          - prelude
+          - unsafe-coerce
+          - web-events
+      web-xhr:
+        repo: https://github.com/purescript-web/purescript-web-xhr.git
+        version: v5.0.0
+        dependencies:
+          - arraybuffer-types
+          - datetime
+          - http-methods
+          - web-dom
+          - web-file
+          - web-html
+      yoga-fetch:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-fetch.git
+        version: v1.0.1
+        dependencies:
+          - aff
+          - aff-promise
+          - arraybuffer-types
+          - effect
+          - foreign
+          - foreign-object
+          - newtype
+          - prelude
+          - typelevel-prelude
+          - unsafe-coerce
+      yoga-json:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-json.git
+        version: v2.0.0
+        dependencies:
+          - arrays
+          - bifunctors
+          - control
+          - effect
+          - either
+          - exceptions
+          - foldable-traversable
+          - foreign
+          - foreign-object
+          - identity
+          - lists
+          - maybe
+          - nullable
+          - partial
+          - prelude
+          - record
+          - transformers
+          - typelevel-prelude
+          - variant
+      yoga-postgres:
+        repo: https://github.com/rowtype-yoga/purescript-yoga-postgres.git
+        version: v6.0.0
+        dependencies:
+          - aff
+          - arrays
+          - datetime
+          - effect
+          - either
+          - enums
+          - foldable-traversable
+          - foreign
+          - integers
+          - maybe
+          - nullable
+          - prelude
+          - transformers
+          - unsafe-coerce
+  extra_packages: {}
+packages:
+  aff:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-aff.git
+    rev: 2d44d9f9d0d6a416a4103fba2fb39e5160f80e36
+    dependencies:
+      - datetime
+      - effect
+      - exceptions
+      - functions
+      - parallel
+      - transformers
+      - unsafe-coerce
+  affjax:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-affjax.git
+    rev: 87a8ffce89a476c1425370eb4b2b7e15408e0d1c
+    dependencies:
+      - aff
+      - argonaut-core
+      - arraybuffer-types
+      - foreign
+      - form-urlencoded
+      - http-methods
+      - integers
+      - media-types
+      - nullable
+      - refs
+      - unsafe-coerce
+      - web-xhr
+  affjax-node:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-affjax-node.git
+    rev: e34901bab82cc741dd62511b4185b75dd7f315d3
+    dependencies:
+      - aff
+      - affjax
+      - either
+      - maybe
+      - prelude
+  argonaut-core:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-argonaut-core.git
+    rev: 68da81dd80ec36d3b013eff46dc067a972c22e5d
+    dependencies:
+      - arrays
+      - control
+      - either
+      - foreign-object
+      - functions
+      - gen
+      - maybe
+      - nonempty
+      - prelude
+      - strings
+      - tailrec
+  arraybuffer-types:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
+    rev: 9b0b7a0f9ee034e039f3d3a2a9c3f74eb7c9264a
+    dependencies: []
+  arrays:
+    type: git
+    url: https://github.com/purescript/purescript-arrays.git
+    rev: d20bae2f76db6cf29b7b75e26e82b8a54c32295e
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - maybe
+      - nonempty
+      - partial
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  avar:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-avar.git
+    rev: d00f5784d9cc8f079babd62740f5c52b87e5caa5
+    dependencies:
+      - aff
+      - effect
+      - either
+      - exceptions
+      - functions
+      - maybe
+  bifunctors:
+    type: git
+    url: https://github.com/purescript/purescript-bifunctors.git
+    rev: 16ba2fb6dd7f05528ebd9e2f9ca3a068b325e5b3
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  catenable-lists:
+    type: git
+    url: https://github.com/purescript/purescript-catenable-lists.git
+    rev: 09abe1f4888bc00841ad2b59e56a9e7ce7ebd4ab
+    dependencies:
+      - control
+      - foldable-traversable
+      - lists
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  console:
+    type: git
+    url: https://github.com/purescript/purescript-console.git
+    rev: 3b83d7b792d03872afeea5e62b4f686ab0f09842
+    dependencies:
+      - effect
+      - prelude
+  const:
+    type: git
+    url: https://github.com/purescript/purescript-const.git
+    rev: ab9570cf2b6e67f7e441178211db1231cfd75c37
+    dependencies:
+      - invariant
+      - newtype
+      - prelude
+  contravariant:
+    type: git
+    url: https://github.com/purescript/purescript-contravariant.git
+    rev: 9ad3e105b8855bcc25f4e0893c784789d05a58de
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  control:
+    type: git
+    url: https://github.com/purescript/purescript-control.git
+    rev: a6033808790879a17b2729e73747a9ed3fb2264e
+    dependencies:
+      - newtype
+      - prelude
+  datetime:
+    type: git
+    url: https://github.com/purescript/purescript-datetime.git
+    rev: a6a0cf1b0324964ad1854bc3377ed8766ba90e6f
+    dependencies:
+      - bifunctors
+      - control
+      - either
+      - enums
+      - foldable-traversable
+      - functions
+      - gen
+      - integers
+      - lists
+      - maybe
+      - newtype
+      - numbers
+      - ordered-collections
+      - partial
+      - prelude
+      - tuples
+  distributive:
+    type: git
+    url: https://github.com/purescript/purescript-distributive.git
+    rev: 6005e513642e855ebf6f884d24a35c2803ca252a
+    dependencies:
+      - identity
+      - newtype
+      - prelude
+      - tuples
+      - type-equality
+  effect:
+    type: git
+    url: https://github.com/purescript/purescript-effect.git
+    rev: a192ddb923027d426d6ea3d8deb030c9aa7c7dda
+    dependencies:
+      - prelude
+  either:
+    type: git
+    url: https://github.com/purescript/purescript-either.git
+    rev: af655a04ed2fd694b6688af39ee20d7907ad0763
+    dependencies:
+      - control
+      - invariant
+      - maybe
+      - prelude
+  enums:
+    type: git
+    url: https://github.com/purescript/purescript-enums.git
+    rev: bae47961d401f9acf88da38f32e87403e5f0cf2f
+    dependencies:
+      - control
+      - either
+      - gen
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tuples
+      - unfoldable
+  exceptions:
+    type: git
+    url: https://github.com/purescript/purescript-exceptions.git
+    rev: afab3c07c820bb49b6c5be50049db46a964a6161
+    dependencies:
+      - effect
+      - either
+      - maybe
+      - prelude
+  exists:
+    type: git
+    url: https://github.com/purescript/purescript-exists.git
+    rev: f765b4ace7869c27b9c05949e18c843881f9173b
+    dependencies:
+      - unsafe-coerce
+  foldable-traversable:
+    type: git
+    url: https://github.com/purescript/purescript-foldable-traversable.git
+    rev: b3926f870532d287ea59e2d5cd3873b81ef2a93a
+    dependencies:
+      - bifunctors
+      - const
+      - control
+      - either
+      - functors
+      - identity
+      - maybe
+      - newtype
+      - orders
+      - prelude
+      - tuples
+  foreign:
+    type: git
+    url: https://github.com/purescript/purescript-foreign.git
+    rev: 2dd222d1ec7363fa0a0a7adb0d8eaf81bb7006dd
+    dependencies:
+      - either
+      - functions
+      - identity
+      - integers
+      - lists
+      - maybe
+      - prelude
+      - strings
+      - transformers
+  foreign-object:
+    type: git
+    url: https://github.com/purescript/purescript-foreign-object.git
+    rev: 28a635827a9a6c251df73f68874070d51fe9f756
+    dependencies:
+      - arrays
+      - foldable-traversable
+      - functions
+      - gen
+      - lists
+      - maybe
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - typelevel-prelude
+      - unfoldable
+  form-urlencoded:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-form-urlencoded.git
+    rev: e0e3eebc76f62f2594a0e823e8d6241ca00b2459
+    dependencies:
+      - foldable-traversable
+      - js-uri
+      - maybe
+      - newtype
+      - prelude
+      - strings
+      - tuples
+  free:
+    type: git
+    url: https://github.com/purescript/purescript-free.git
+    rev: e2d8fa8023a864363857834e11393483bced5e38
+    dependencies:
+      - catenable-lists
+      - control
+      - distributive
+      - either
+      - exists
+      - foldable-traversable
+      - invariant
+      - lazy
+      - maybe
+      - prelude
+      - tailrec
+      - transformers
+      - tuples
+      - unsafe-coerce
+  functions:
+    type: git
+    url: https://github.com/purescript/purescript-functions.git
+    rev: f626f20580483977c5b27a01aac6471e28aff367
+    dependencies:
+      - prelude
+  functors:
+    type: git
+    url: https://github.com/purescript/purescript-functors.git
+    rev: 022ffd7a2a7ec12080314f3d217b400674a247b4
+    dependencies:
+      - bifunctors
+      - const
+      - contravariant
+      - control
+      - distributive
+      - either
+      - invariant
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - tuples
+      - unsafe-coerce
+  gen:
+    type: git
+    url: https://github.com/purescript/purescript-gen.git
+    rev: 9fbcc2a1261c32e30d79c5418edef4d96fe76931
+    dependencies:
+      - either
+      - foldable-traversable
+      - identity
+      - maybe
+      - newtype
+      - nonempty
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  http-methods:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-http-methods.git
+    rev: 99b48d54b978e4e6438d850015d59e57ac64824e
+    dependencies:
+      - either
+      - prelude
+      - strings
+  identity:
+    type: git
+    url: https://github.com/purescript/purescript-identity.git
+    rev: ef6768f8a52ab0bc943a85f5761ba07c257f639f
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  integers:
+    type: git
+    url: https://github.com/purescript/purescript-integers.git
+    rev: 54d712b25c594833083d15dc9ff2418eb9c52822
+    dependencies:
+      - maybe
+      - numbers
+      - prelude
+  invariant:
+    type: git
+    url: https://github.com/purescript/purescript-invariant.git
+    rev: 1d2a196d51e90623adb88496c2cfd759c6736894
+    dependencies:
+      - control
+      - prelude
+  js-date:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-js-date.git
+    rev: 1ea020316946cc4b87195bca9c54d0c16abaa490
+    dependencies:
+      - datetime
+      - effect
+      - exceptions
+      - foreign
+      - integers
+      - now
+  js-timers:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-js-timers.git
+    rev: 7cb728b3e6dc29f355143617e6e9ac770ecd9273
+    dependencies:
+      - effect
+  js-uri:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-js-uri.git
+    rev: ac659740288de7c5e64166dbfda9d4985c5044b7
+    dependencies:
+      - functions
+      - maybe
+  lazy:
+    type: git
+    url: https://github.com/purescript/purescript-lazy.git
+    rev: 48347841226b27af5205a1a8ec71e27a93ce86fd
+    dependencies:
+      - control
+      - foldable-traversable
+      - invariant
+      - prelude
+  lcg:
+    type: git
+    url: https://github.com/purescript/purescript-lcg.git
+    rev: 67c6c6483a563a59ae036d9dca0f1be2835326a5
+    dependencies:
+      - effect
+      - integers
+      - maybe
+      - partial
+      - prelude
+      - random
+  lists:
+    type: git
+    url: https://github.com/purescript/purescript-lists.git
+    rev: b113451e5b41cad87d669a3165f955c71cd863e2
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - lazy
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  maybe:
+    type: git
+    url: https://github.com/purescript/purescript-maybe.git
+    rev: c6f98ac1088766287106c5d9c8e30e7648d36786
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  media-types:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-media-types.git
+    rev: af853de226592f319a953637069a943dd261cba3
+    dependencies:
+      - newtype
+      - prelude
+  newtype:
+    type: git
+    url: https://github.com/purescript/purescript-newtype.git
+    rev: 29d8e6dd77aec2c975c948364ec3faf26e14ee7b
+    dependencies:
+      - prelude
+      - safe-coerce
+  node-buffer:
+    type: git
+    url: https://github.com/purescript-node/purescript-node-buffer.git
+    rev: 7be7bd082b7d3e15de2ed5a626d43af746bdb35e
+    dependencies:
+      - arraybuffer-types
+      - effect
+      - maybe
+      - st
+      - unsafe-coerce
+  node-fs:
+    type: git
+    url: https://github.com/purescript-node/purescript-node-fs.git
+    rev: 7dfc7cad919cec097d40c8fce611338715969f75
+    dependencies:
+      - datetime
+      - effect
+      - either
+      - enums
+      - exceptions
+      - functions
+      - integers
+      - js-date
+      - maybe
+      - node-buffer
+      - node-path
+      - node-streams
+      - nullable
+      - partial
+      - prelude
+      - strings
+      - unsafe-coerce
+  node-fs-aff:
+    type: git
+    url: https://github.com/purescript-node/purescript-node-fs-aff.git
+    rev: a6acd335f5b3e4b8c6df9bb0784f0e06eef0075e
+    dependencies:
+      - aff
+      - either
+      - node-fs
+      - node-path
+  node-path:
+    type: git
+    url: https://github.com/purescript-node/purescript-node-path.git
+    rev: d5f08cfde829b831408c4c6587cec83f2cd6a58e
+    dependencies:
+      - effect
+  node-streams:
+    type: git
+    url: https://github.com/purescript-node/purescript-node-streams.git
+    rev: 8395652f9f347101fe042f58726edc592ae5086c
+    dependencies:
+      - effect
+      - either
+      - exceptions
+      - node-buffer
+      - nullable
+      - prelude
+  nonempty:
+    type: git
+    url: https://github.com/purescript/purescript-nonempty.git
+    rev: 28150ecc7419238b187abd609a92a645273348bb
+    dependencies:
+      - control
+      - foldable-traversable
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  now:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-now.git
+    rev: b5ffed2381e5fefc063f484e607e8499e79eaf32
+    dependencies:
+      - datetime
+      - effect
+  nullable:
+    type: git
+    url: https://github.com/purescript-contrib/purescript-nullable.git
+    rev: 3202744c6c65e8d1fbba7f4256a1c482078e7fb5
+    dependencies:
+      - effect
+      - functions
+      - maybe
+  numbers:
+    type: git
+    url: https://github.com/purescript/purescript-numbers.git
+    rev: 2a53528f18f9415334bae28e7bb3cf3be86342c2
+    dependencies:
+      - functions
+      - maybe
+  ordered-collections:
+    type: git
+    url: https://github.com/purescript/purescript-ordered-collections.git
+    rev: 9826b7632d0d0a691173bde308a634195f42a419
+    dependencies:
+      - arrays
+      - foldable-traversable
+      - gen
+      - lists
+      - maybe
+      - partial
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+  orders:
+    type: git
+    url: https://github.com/purescript/purescript-orders.git
+    rev: f86db621ec5eef1274145f8b1fd8ebbfe0ed4a2c
+    dependencies:
+      - newtype
+      - prelude
+  parallel:
+    type: git
+    url: https://github.com/purescript/purescript-parallel.git
+    rev: 85290dca837771ac4870071008c933d315ef678f
+    dependencies:
+      - control
+      - effect
+      - either
+      - foldable-traversable
+      - functors
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - refs
+      - transformers
+  partial:
+    type: git
+    url: https://github.com/purescript/purescript-partial.git
+    rev: 0fa0646f5ea1ec5f0c46dcbd770c705a6c9ad3ec
+    dependencies: []
+  prelude:
+    type: git
+    url: https://github.com/purescript/purescript-prelude.git
+    rev: 32787f4399c92459c41602131a5858559eb868c5
+    dependencies: []
+  profunctor:
+    type: git
+    url: https://github.com/purescript/purescript-profunctor.git
+    rev: 0a966a14e7b0c827d44657dc1710cdc712d2e034
+    dependencies:
+      - control
+      - distributive
+      - either
+      - exists
+      - invariant
+      - newtype
+      - prelude
+      - tuples
+  quickcheck:
+    type: git
+    url: https://github.com/purescript/purescript-quickcheck.git
+    rev: bf5029f97e6c0d7552d3a08d2ab793a19e2c5e3d
+    dependencies:
+      - arrays
+      - console
+      - control
+      - effect
+      - either
+      - enums
+      - exceptions
+      - foldable-traversable
+      - gen
+      - identity
+      - integers
+      - lazy
+      - lcg
+      - lists
+      - maybe
+      - newtype
+      - nonempty
+      - numbers
+      - partial
+      - prelude
+      - record
+      - st
+      - strings
+      - tailrec
+      - transformers
+      - tuples
+      - unfoldable
+  random:
+    type: git
+    url: https://github.com/purescript/purescript-random.git
+    rev: 9540bc965a9596da02fefd9949418bb19c92533a
+    dependencies:
+      - effect
+      - integers
+  record:
+    type: git
+    url: https://github.com/purescript/purescript-record.git
+    rev: c89cd1ada6b636692571fc374196b1c39c4c9f70
+    dependencies:
+      - functions
+      - prelude
+      - unsafe-coerce
+  refs:
+    type: git
+    url: https://github.com/purescript/purescript-refs.git
+    rev: f8e6216da4cb9309fde1f20cd6f69ac3a3b7f9e8
+    dependencies:
+      - effect
+      - prelude
+  safe-coerce:
+    type: git
+    url: https://github.com/purescript/purescript-safe-coerce.git
+    rev: 7fa799ae80a38b8d948efcb52608e58e198b3da7
+    dependencies:
+      - unsafe-coerce
+  st:
+    type: git
+    url: https://github.com/purescript/purescript-st.git
+    rev: 2cc7ae1c3318a303378c4a9f3fa0f10ee7cc3589
+    dependencies:
+      - partial
+      - prelude
+      - tailrec
+      - unsafe-coerce
+  strings:
+    type: git
+    url: https://github.com/purescript/purescript-strings.git
+    rev: 4bc6954448d056f8aa7a659695a6ad60ad4fdf19
+    dependencies:
+      - arrays
+      - control
+      - either
+      - enums
+      - foldable-traversable
+      - gen
+      - integers
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  tailrec:
+    type: git
+    url: https://github.com/purescript/purescript-tailrec.git
+    rev: 5e2104aa734b31a17074cc805bf087d72b65afd1
+    dependencies:
+      - bifunctors
+      - effect
+      - either
+      - identity
+      - maybe
+      - partial
+      - prelude
+      - refs
+  test-unit:
+    type: git
+    url: https://github.com/bodil/purescript-test-unit.git
+    rev: 3112d7ebe06d467238058a6384dc75ffd960d335
+    dependencies:
+      - aff
+      - avar
+      - effect
+      - either
+      - free
+      - js-timers
+      - lists
+      - prelude
+      - quickcheck
+      - strings
+  transformers:
+    type: git
+    url: https://github.com/purescript/purescript-transformers.git
+    rev: be72ab52357d9a665cbf93d73ba1c07c4b0957ee
+    dependencies:
+      - control
+      - distributive
+      - effect
+      - either
+      - exceptions
+      - foldable-traversable
+      - identity
+      - lazy
+      - maybe
+      - newtype
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  tuples:
+    type: git
+    url: https://github.com/purescript/purescript-tuples.git
+    rev: 4f52da2729b448c8564369378f1232d8d2dc1d8b
+    dependencies:
+      - control
+      - invariant
+      - prelude
+  type-equality:
+    type: git
+    url: https://github.com/purescript/purescript-type-equality.git
+    rev: 0525b7d39e0fbd81b4209518139fb8ab02695774
+    dependencies: []
+  typelevel-prelude:
+    type: git
+    url: https://github.com/purescript/purescript-typelevel-prelude.git
+    rev: dca2fe3c8cfd5527d4fe70c4bedfda30148405bf
+    dependencies:
+      - prelude
+      - type-equality
+  unfoldable:
+    type: git
+    url: https://github.com/purescript/purescript-unfoldable.git
+    rev: 493dfe04ed590e20d8f69079df2f58486882748d
+    dependencies:
+      - foldable-traversable
+      - maybe
+      - partial
+      - prelude
+      - tuples
+  unsafe-coerce:
+    type: git
+    url: https://github.com/purescript/purescript-unsafe-coerce.git
+    rev: ab956f82e66e633f647fb3098e8ddd3ec58d689f
+    dependencies: []
+  web-dom:
+    type: git
+    url: https://github.com/purescript-web/purescript-web-dom.git
+    rev: 568a1ee158b29e6e739e7a9aaed3e35ca4c4305a
+    dependencies:
+      - web-events
+  web-events:
+    type: git
+    url: https://github.com/purescript-web/purescript-web-events.git
+    rev: 2124356117be7b764a2f3948032255ac4dab7051
+    dependencies:
+      - datetime
+      - enums
+      - foreign
+      - nullable
+  web-file:
+    type: git
+    url: https://github.com/purescript-web/purescript-web-file.git
+    rev: 023786ae62bbb8bf58156dd7f02011fa38221ef1
+    dependencies:
+      - foreign
+      - media-types
+      - web-dom
+  web-html:
+    type: git
+    url: https://github.com/purescript-web/purescript-web-html.git
+    rev: be189cf91b9a19cf493637423522e2fe4a0088cc
+    dependencies:
+      - js-date
+      - web-dom
+      - web-file
+      - web-storage
+  web-storage:
+    type: git
+    url: https://github.com/purescript-web/purescript-web-storage.git
+    rev: 6b74461e136755db70c271dc898d51776363d7e2
+    dependencies:
+      - nullable
+      - web-events
+  web-xhr:
+    type: git
+    url: https://github.com/purescript-web/purescript-web-xhr.git
+    rev: 476122fe3ad19031aeb69186209b480e2fc9ef25
+    dependencies:
+      - arraybuffer-types
+      - datetime
+      - http-methods
+      - web-dom
+      - web-file
+      - web-html

--- a/exercises/chapter9/spago.lock
+++ b/exercises/chapter9/spago.lock
@@ -104,3452 +104,462 @@ workspace:
         - web-xhr
   package_set:
     address:
-      url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
-    compiler: ">=0.15.0 <0.16.0"
+      registry: 10.0.0
+    compiler: ">=0.15.4 <0.16.0"
     content:
-      ace:
-        repo: https://github.com/purescript-contrib/purescript-ace.git
-        version: v9.0.0
-        dependencies:
-          - arrays
-          - effect
-          - foreign
-          - nullable
-          - prelude
-          - web-html
-          - web-uievents
-      aff:
-        repo: https://github.com/purescript-contrib/purescript-aff.git
-        version: v7.0.0
-        dependencies:
-          - datetime
-          - effect
-          - exceptions
-          - functions
-          - parallel
-          - transformers
-          - unsafe-coerce
-      aff-bus:
-        repo: https://github.com/purescript-contrib/purescript-aff-bus.git
-        version: v6.0.0
-        dependencies:
-          - aff
-          - avar
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - lists
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-      aff-coroutines:
-        repo: https://github.com/purescript-contrib/purescript-aff-coroutines.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - avar
-          - coroutines
-          - effect
-      aff-promise:
-        repo: https://github.com/nwolverson/purescript-aff-promise.git
-        version: v4.0.0
-        dependencies:
-          - aff
-          - foreign
-      aff-retry:
-        repo: https://github.com/Unisay/purescript-aff-retry.git
-        version: v2.0.0
-        dependencies:
-          - aff
-          - arrays
-          - datetime
-          - effect
-          - either
-          - exceptions
-          - integers
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - random
-          - transformers
-      affjax:
-        repo: https://github.com/purescript-contrib/purescript-affjax.git
-        version: v13.0.0
-        dependencies:
-          - aff
-          - argonaut-core
-          - arraybuffer-types
-          - foreign
-          - form-urlencoded
-          - http-methods
-          - integers
-          - media-types
-          - nullable
-          - refs
-          - unsafe-coerce
-          - web-xhr
-      affjax-node:
-        repo: https://github.com/purescript-contrib/purescript-affjax-node.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - affjax
-          - either
-          - maybe
-          - prelude
-      affjax-web:
-        repo: https://github.com/purescript-contrib/purescript-affjax-web.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - affjax
-          - either
-          - maybe
-          - prelude
-      ansi:
-        repo: https://github.com/hdgarrood/purescript-ansi.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - lists
-          - strings
-      argonaut:
-        repo: https://github.com/purescript-contrib/purescript-argonaut.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - argonaut-traversals
-      argonaut-codecs:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-codecs.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-core
-          - arrays
-          - effect
-          - foreign-object
-          - identity
-          - integers
-          - maybe
-          - nonempty
-          - ordered-collections
-          - prelude
-          - record
-      argonaut-core:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-core.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - foreign-object
-          - functions
-          - gen
-          - maybe
-          - nonempty
-          - prelude
-          - strings
-          - tailrec
-      argonaut-generic:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-generic.git
-        version: v8.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - prelude
-          - record
-      argonaut-traversals:
-        repo: https://github.com/purescript-contrib/purescript-argonaut-traversals.git
-        version: v10.0.0
-        dependencies:
-          - argonaut-codecs
-          - argonaut-core
-          - profunctor-lenses
-      argparse-basic:
-        repo: https://github.com/natefaubion/purescript-argparse-basic.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - record
-          - strings
-          - tuples
-          - unfoldable
-      arraybuffer:
-        repo: https://github.com/purescript-contrib/purescript-arraybuffer.git
-        version: v13.0.0
-        dependencies:
-          - arraybuffer-types
-          - arrays
-          - effect
-          - float32
-          - functions
-          - gen
-          - maybe
-          - nullable
-          - prelude
-          - tailrec
-          - uint
-          - unfoldable
-      arraybuffer-builder:
-        repo: https://github.com/jamesdbrock/purescript-arraybuffer-builder.git
-        version: v3.0.1
-        dependencies:
-          - arraybuffer
-          - arraybuffer-types
-          - effect
-          - float32
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - transformers
-          - uint
-      arraybuffer-types:
-        repo: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
-        version: v3.0.2
-        dependencies: []
-      arrays:
-        repo: https://github.com/purescript/purescript-arrays.git
-        version: v7.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - foldable-traversable
-          - maybe
-          - nonempty
-          - partial
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - unfoldable
-          - unsafe-coerce
-      arrays-zipper:
-        repo: https://github.com/JordanMartinez/purescript-arrays-zipper.git
-        version: v2.0.1
-        dependencies:
-          - arrays
-          - control
-          - quickcheck
-      ask:
-        repo: https://github.com/Mateiadrielrafael/purescript-ask.git
-        version: v1.0.0
-        dependencies:
-          - unsafe-coerce
-      assert:
-        repo: https://github.com/purescript/purescript-assert.git
-        version: v6.0.0
-        dependencies:
-          - console
-          - effect
-          - prelude
-      avar:
-        repo: https://github.com/purescript-contrib/purescript-avar.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - exceptions
-          - functions
-          - maybe
-      b64:
-        repo: https://github.com/menelaos/purescript-b64.git
-        version: v0.0.8
-        dependencies:
-          - arraybuffer-types
-          - either
-          - encoding
-          - enums
-          - exceptions
-          - functions
-          - partial
-          - prelude
-          - strings
-      barlow-lens:
-        repo: https://github.com/sigma-andex/purescript-barlow-lens.git
-        version: v0.9.0
-        dependencies:
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - profunctor-lenses
-          - tuples
-          - typelevel-prelude
-      bifunctors:
-        repo: https://github.com/purescript/purescript-bifunctors.git
-        version: v6.0.0
-        dependencies:
-          - const
-          - either
-          - newtype
-          - prelude
-          - tuples
-      bigints:
-        repo: https://github.com/sharkdp/purescript-bigints.git
-        version: v7.0.1
-        dependencies:
-          - integers
-          - maybe
-          - strings
-      bower-json:
-        repo: https://github.com/klntsky/purescript-bower-json.git
-        version: v3.0.0
-        dependencies:
-          - argonaut-codecs
-          - arrays
-          - either
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - newtype
-          - prelude
-          - tuples
-      call-by-name:
-        repo: https://github.com/natefaubion/purescript-call-by-name.git
-        version: v4.0.1
-        dependencies:
-          - control
-          - either
-          - lazy
-          - maybe
-          - unsafe-coerce
-      canvas:
-        repo: https://github.com/purescript-web/purescript-canvas.git
-        version: v6.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - exceptions
-          - functions
-          - maybe
-      canvas-action:
-        repo: https://github.com/artemisSystem/purescript-canvas-action.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - arrays
-          - canvas
-          - colors
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - maybe
-          - numbers
-          - polymorphic-vectors
-          - prelude
-          - refs
-          - run
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-html
-      cartesian:
-        repo: https://github.com/Ebmtranceboy/purescript-cartesian.git
-        version: v1.0.6
-        dependencies:
-          - console
-          - effect
-          - integers
-          - psci-support
-      catenable-lists:
-        repo: https://github.com/purescript/purescript-catenable-lists.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - lists
-          - maybe
-          - prelude
-          - tuples
-          - unfoldable
-      channel:
-        repo: https://github.com/ConnorDillon/purescript-channel.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - assert
-          - avar
-          - console
-          - contravariant
-          - control
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - lazy
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      checked-exceptions:
-        repo: https://github.com/natefaubion/purescript-checked-exceptions.git
-        version: v3.1.1
-        dependencies:
-          - prelude
-          - transformers
-          - variant
-      codec:
-        repo: https://github.com/garyb/purescript-codec.git
-        version: v5.0.0
-        dependencies:
-          - profunctor
-          - transformers
-      codec-argonaut:
-        repo: https://github.com/garyb/purescript-codec-argonaut.git
-        version: v9.0.0
-        dependencies:
-          - argonaut-core
-          - codec
-          - ordered-collections
-          - type-equality
-          - variant
-      colors:
-        repo: https://github.com/purescript-contrib/purescript-colors.git
-        version: v7.0.1
-        dependencies:
-          - arrays
-          - integers
-          - lists
-          - numbers
-          - partial
-          - strings
-      concurrent-queues:
-        repo: https://github.com/purescript-contrib/purescript-concurrent-queues.git
-        version: v3.0.0
-        dependencies:
-          - aff
-          - avar
-          - effect
-      console:
-        repo: https://github.com/purescript/purescript-console.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - prelude
-      const:
-        repo: https://github.com/purescript/purescript-const.git
-        version: v6.0.0
-        dependencies:
-          - invariant
-          - newtype
-          - prelude
-      contravariant:
-        repo: https://github.com/purescript/purescript-contravariant.git
-        version: v6.0.0
-        dependencies:
-          - const
-          - either
-          - newtype
-          - prelude
-          - tuples
-      control:
-        repo: https://github.com/purescript/purescript-control.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      convertable-options:
-        repo: https://github.com/natefaubion/purescript-convertable-options.git
-        version: v1.0.0
-        dependencies:
-          - console
-          - effect
-          - maybe
-          - record
-      coroutines:
-        repo: https://github.com/purescript-contrib/purescript-coroutines.git
-        version: v7.0.0
-        dependencies:
-          - freet
-          - parallel
-          - profunctor
-      css:
-        repo: https://github.com/purescript-contrib/purescript-css.git
-        version: v6.0.0
-        dependencies:
-          - colors
-          - console
-          - effect
-          - nonempty
-          - profunctor
-          - strings
-          - these
-          - transformers
-      datetime:
-        repo: https://github.com/purescript/purescript-datetime.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - either
-          - enums
-          - foldable-traversable
-          - functions
-          - gen
-          - integers
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - ordered-collections
-          - partial
-          - prelude
-          - tuples
-      datetime-parsing:
-        repo: https://github.com/flounders/purescript-datetime-parsing.git
-        version: v0.2.0
-        dependencies:
-          - arrays
-          - datetime
-          - either
-          - enums
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - numbers
-          - parsing
-          - prelude
-          - strings
-          - unicode
-      debug:
-        repo: https://github.com/garyb/purescript-debug.git
-        version: v6.0.0
-        dependencies:
-          - functions
-          - prelude
-      decimals:
-        repo: https://github.com/sharkdp/purescript-decimals.git
-        version: v7.0.0
-        dependencies:
-          - maybe
-      dissect:
-        repo: https://github.com/PureFunctor/purescript-dissect.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - foreign-object
-          - functors
-          - newtype
-          - partial
-          - prelude
-          - tailrec
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - variant
-      distributive:
-        repo: https://github.com/purescript/purescript-distributive.git
-        version: v6.0.0
-        dependencies:
-          - identity
-          - newtype
-          - prelude
-          - tuples
-          - type-equality
-      dodo-printer:
-        repo: https://github.com/natefaubion/purescript-dodo-printer.git
-        version: v2.2.0
-        dependencies:
-          - aff
-          - ansi
-          - avar
-          - console
-          - effect
-          - foldable-traversable
-          - lists
-          - maybe
-          - minibench
-          - node-child-process
-          - node-fs-aff
-          - node-process
-          - psci-support
-          - strings
-      dom-indexed:
-        repo: https://github.com/purescript-halogen/purescript-dom-indexed.git
-        version: v11.0.0
-        dependencies:
-          - media-types
-          - prelude
-          - web-clipboard
-          - web-pointerevents
-          - web-touchevents
-      droplet:
-        repo: https://github.com/easafe/purescript-droplet.git
-        version: v0.4.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - bigints
-          - datetime
-          - debug
-          - effect
-          - either
-          - enums
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - integers
-          - maybe
-          - newtype
-          - nullable
-          - ordered-collections
-          - partial
-          - prelude
-          - profunctor
-          - record
-          - spec
-          - strings
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-      dynamic-buffer:
-        repo: https://github.com/kritzcreek/purescript-dynamic-buffer.git
-        version: v3.0.1
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - refs
-      effect:
-        repo: https://github.com/purescript/purescript-effect.git
-        version: v4.0.0
-        dependencies:
-          - prelude
-      either:
-        repo: https://github.com/purescript/purescript-either.git
-        version: v6.1.0
-        dependencies:
-          - control
-          - invariant
-          - maybe
-          - prelude
-      elmish:
-        repo: https://github.com/collegevine/purescript-elmish.git
-        version: v0.8.1
-        dependencies:
-          - aff
-          - argonaut-core
-          - arrays
-          - bifunctors
-          - console
-          - debug
-          - effect
-          - either
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - functions
-          - integers
-          - js-date
-          - maybe
-          - nullable
-          - partial
-          - prelude
-          - refs
-          - typelevel-prelude
-          - undefined-is-not-a-problem
-          - unsafe-coerce
-          - web-dom
-          - web-html
-      elmish-enzyme:
-        repo: https://github.com/collegevine/purescript-elmish-enzyme.git
-        version: v0.1.1
-        dependencies:
-          - aff
-          - aff-promise
-          - arrays
-          - console
-          - debug
-          - effect
-          - elmish
-          - foldable-traversable
-          - foreign
-          - functions
-          - prelude
-          - transformers
-          - unsafe-coerce
-      elmish-hooks:
-        repo: https://github.com/collegevine/purescript-elmish-hooks.git
-        version: v0.8.2
-        dependencies:
-          - aff
-          - debug
-          - elmish
-          - maybe
-          - prelude
-          - tuples
-          - undefined-is-not-a-problem
-      elmish-html:
-        repo: https://github.com/collegevine/purescript-elmish-html.git
-        version: v0.7.1
-        dependencies:
-          - effect
-          - elmish
-          - foreign
-          - foreign-object
-          - prelude
-          - record
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-html
-      email-validate:
-        repo: https://github.com/cdepillabout/purescript-email-validate.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - string-parsers
-          - transformers
-      encoding:
-        repo: https://github.com/menelaos/purescript-encoding.git
-        version: v0.0.8
-        dependencies:
-          - arraybuffer-types
-          - either
-          - exceptions
-          - functions
-          - prelude
-      enums:
-        repo: https://github.com/purescript/purescript-enums.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - either
-          - gen
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tuples
-          - unfoldable
-      exceptions:
-        repo: https://github.com/purescript/purescript-exceptions.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - either
-          - maybe
-          - prelude
-      exists:
-        repo: https://github.com/purescript/purescript-exists.git
-        version: v6.0.0
-        dependencies:
-          - unsafe-coerce
-      exitcodes:
-        repo: https://github.com/Risto-Stevcev/purescript-exitcodes.git
-        version: v4.0.0
-        dependencies:
-          - enums
-      expect-inferred:
-        repo: https://github.com/justinwoo/purescript-expect-inferred.git
-        version: v3.0.0
-        dependencies:
-          - prelude
-          - typelevel-prelude
-      fast-vect:
-        repo: https://github.com/sigma-andex/purescript-fast-vect.git
-        version: v0.7.0
-        dependencies:
-          - arrays
-          - filterable
-          - foldable-traversable
-          - lists
-          - maybe
-          - ordered-collections
-          - prelude
-          - profunctor
-          - tuples
-          - unfoldable
-      filterable:
-        repo: https://github.com/purescript/purescript-filterable.git
-        version: v5.0.0
-        dependencies:
-          - arrays
-          - either
-          - foldable-traversable
-          - identity
-          - lists
-          - ordered-collections
-      fixed-points:
-        repo: https://github.com/purescript-contrib/purescript-fixed-points.git
-        version: v7.0.0
-        dependencies:
-          - exists
-          - newtype
-          - prelude
-          - transformers
-      fixed-precision:
-        repo: https://github.com/lumihq/purescript-fixed-precision.git
-        version: v5.0.0
-        dependencies:
-          - arrays
-          - bigints
-          - control
-          - integers
-          - maybe
-          - numbers
-          - partial
-          - prelude
-          - strings
-      flame:
-        repo: https://github.com/easafe/purescript-flame.git
-        version: v1.2.0
-        dependencies:
-          - aff
-          - argonaut-codecs
-          - argonaut-core
-          - argonaut-generic
-          - arrays
-          - bifunctors
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - maybe
-          - newtype
-          - nullable
-          - partial
-          - prelude
-          - random
-          - refs
-          - spec
-          - strings
-          - tuples
-          - typelevel-prelude
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-html
-          - web-uievents
-      float32:
-        repo: https://github.com/purescript-contrib/purescript-float32.git
-        version: v2.0.0
-        dependencies:
-          - gen
-          - maybe
-          - prelude
-      foldable-traversable:
-        repo: https://github.com/purescript/purescript-foldable-traversable.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - const
-          - control
-          - either
-          - functors
-          - identity
-          - maybe
-          - newtype
-          - orders
-          - prelude
-          - tuples
-      foreign:
-        repo: https://github.com/purescript/purescript-foreign.git
-        version: v7.0.0
-        dependencies:
-          - either
-          - functions
-          - identity
-          - integers
-          - lists
-          - maybe
-          - prelude
-          - strings
-          - transformers
-      foreign-object:
-        repo: https://github.com/purescript/purescript-foreign-object.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - functions
-          - gen
-          - lists
-          - maybe
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - typelevel-prelude
-          - unfoldable
-      foreign-readwrite:
-        repo: https://github.com/artemisSystem/purescript-foreign-readwrite.git
-        version: v3.0.0
-        dependencies:
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - prelude
-          - record
-          - safe-coerce
-          - transformers
-          - unsafe-coerce
-      fork:
-        repo: https://github.com/purescript-contrib/purescript-fork.git
-        version: v6.0.0
-        dependencies:
-          - aff
-      form-urlencoded:
-        repo: https://github.com/purescript-contrib/purescript-form-urlencoded.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - js-uri
-          - maybe
-          - newtype
-          - prelude
-          - strings
-          - tuples
-      formatters:
-        repo: https://github.com/purescript-contrib/purescript-formatters.git
-        version: v7.0.0
-        dependencies:
-          - datetime
-          - fixed-points
-          - lists
-          - numbers
-          - parsing
-          - prelude
-          - transformers
-      free:
-        repo: https://github.com/purescript/purescript-free.git
-        version: v7.0.0
-        dependencies:
-          - catenable-lists
-          - control
-          - distributive
-          - either
-          - exists
-          - foldable-traversable
-          - invariant
-          - lazy
-          - maybe
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-      freeap:
-        repo: https://github.com/ethul/purescript-freeap.git
-        version: v7.0.0
-        dependencies:
-          - const
-          - exists
-          - gen
-          - lists
-      freet:
-        repo: https://github.com/purescript-contrib/purescript-freet.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - bifunctors
-          - effect
-          - either
-          - exists
-          - free
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      functions:
-        repo: https://github.com/purescript/purescript-functions.git
-        version: v6.0.0
-        dependencies:
-          - prelude
-      functors:
-        repo: https://github.com/purescript/purescript-functors.git
-        version: v5.0.0
-        dependencies:
-          - bifunctors
-          - const
-          - contravariant
-          - control
-          - distributive
-          - either
-          - invariant
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - tuples
-          - unsafe-coerce
-      fuzzy:
-        repo: https://github.com/citizennet/purescript-fuzzy.git
-        version: v0.4.0
-        dependencies:
-          - foldable-traversable
-          - foreign-object
-          - newtype
-          - ordered-collections
-          - prelude
-          - rationals
-          - strings
-          - tuples
-      gen:
-        repo: https://github.com/purescript/purescript-gen.git
-        version: v4.0.0
-        dependencies:
-          - either
-          - foldable-traversable
-          - identity
-          - maybe
-          - newtype
-          - nonempty
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      generate-values:
-        repo: https://github.com/jordanmartinez/purescript-generate-values.git
-        version: v1.0.1
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - enums
-          - foldable-traversable
-          - gen
-          - identity
-          - integers
-          - lcg
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - partial
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      geometry-plane:
-        repo: https://github.com/Ebmtranceboy/purescript-geometry-plane.git
-        version: v1.0.3
-        dependencies:
-          - console
-          - effect
-          - psci-support
-          - sparse-polynomials
-      github-actions-toolkit:
-        repo: https://github.com/purescript-contrib/purescript-github-actions-toolkit.git
-        version: v0.5.0
-        dependencies:
-          - aff
-          - aff-promise
-          - effect
-          - foreign-object
-          - node-buffer
-          - node-path
-          - node-streams
-          - nullable
-          - transformers
-      graphs:
-        repo: https://github.com/purescript/purescript-graphs.git
-        version: v8.0.0
-        dependencies:
-          - catenable-lists
-          - ordered-collections
-      group:
-        repo: https://github.com/morganthomas/purescript-group.git
-        version: v4.1.1
-        dependencies:
-          - lists
-      halogen:
-        repo: https://github.com/purescript-halogen/purescript-halogen.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - avar
-          - console
-          - const
-          - dom-indexed
-          - effect
-          - foreign
-          - fork
-          - free
-          - freeap
-          - halogen-subscriptions
-          - halogen-vdom
-          - media-types
-          - nullable
-          - ordered-collections
-          - parallel
-          - profunctor
-          - transformers
-          - unsafe-coerce
-          - unsafe-reference
-          - web-file
-          - web-uievents
-      halogen-css:
-        repo: https://github.com/purescript-halogen/purescript-halogen-css.git
-        version: v10.0.0
-        dependencies:
-          - css
-          - halogen
-      halogen-formless:
-        repo: https://github.com/thomashoneyman/purescript-halogen-formless.git
-        version: v4.0.0
-        dependencies:
-          - convertable-options
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - halogen
-          - heterogeneous
-          - maybe
-          - prelude
-          - record
-          - safe-coerce
-          - type-equality
-          - unsafe-coerce
-          - unsafe-reference
-          - variant
-          - web-events
-          - web-uievents
-      halogen-hooks:
-        repo: https://github.com/thomashoneyman/purescript-halogen-hooks.git
-        version: v0.6.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - effect
-          - exceptions
-          - foldable-traversable
-          - foreign-object
-          - free
-          - freeap
-          - halogen
-          - halogen-subscriptions
-          - maybe
-          - newtype
-          - ordered-collections
-          - parallel
-          - partial
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-          - unsafe-reference
-          - web-dom
-          - web-html
-      halogen-hooks-extra:
-        repo: https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git
-        version: v0.9.0
-        dependencies:
-          - halogen-hooks
-      halogen-store:
-        repo: https://github.com/thomashoneyman/purescript-halogen-store.git
-        version: v0.5.0
-        dependencies:
-          - aff
-          - distributive
-          - effect
-          - fork
-          - halogen
-          - halogen-hooks
-          - halogen-subscriptions
-          - maybe
-          - prelude
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-reference
-      halogen-storybook:
-        repo: https://github.com/rnons/purescript-halogen-storybook.git
-        version: v2.0.0
-        dependencies:
-          - foreign-object
-          - halogen
-          - prelude
-          - routing
-      halogen-subscriptions:
-        repo: https://github.com/purescript-halogen/purescript-halogen-subscriptions.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - effect
-          - foldable-traversable
-          - functors
-          - refs
-          - safe-coerce
-          - unsafe-reference
-      halogen-svg-elems:
-        repo: https://github.com/JordanMartinez/purescript-halogen-svg-elems.git
-        version: v6.0.0
-        dependencies:
-          - halogen
-      halogen-vdom:
-        repo: https://github.com/purescript-halogen/purescript-halogen-vdom.git
-        version: v8.0.0
-        dependencies:
-          - bifunctors
-          - effect
-          - foreign
-          - foreign-object
-          - maybe
-          - prelude
-          - refs
-          - tuples
-          - unsafe-coerce
-          - web-html
-      halogen-vdom-string-renderer:
-        repo: https://github.com/purescript-halogen/purescript-halogen-vdom-string-renderer.git
-        version: v0.5.0
-        dependencies:
-          - foreign
-          - halogen-vdom
-          - ordered-collections
-          - prelude
-      heckin:
-        repo: https://github.com/maxdeviant/purescript-heckin.git
-        version: v2.0.1
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - maybe
-          - prelude
-          - strings
-          - transformers
-          - tuples
-          - unicode
-      heterogeneous:
-        repo: https://github.com/natefaubion/purescript-heterogeneous.git
-        version: v0.6.0
-        dependencies:
-          - either
-          - functors
-          - prelude
-          - record
-          - tuples
-          - variant
-      heterogeneous-extrablatt:
-        repo: https://github.com/sigma-andex/purescript-heterogeneous-extrablatt.git
-        version: v0.2.1
-        dependencies:
-          - heterogeneous
-          - prelude
-          - record
-      http-methods:
-        repo: https://github.com/purescript-contrib/purescript-http-methods.git
-        version: v6.0.0
-        dependencies:
-          - either
-          - prelude
-          - strings
-      httpure:
-        repo: https://github.com/citizennet/purescript-httpure.git
-        version: v0.15.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - js-uri
-          - maybe
-          - newtype
-          - node-buffer
-          - node-fs
-          - node-http
-          - node-streams
-          - options
-          - ordered-collections
-          - prelude
-          - refs
-          - strings
-          - tuples
-          - type-equality
-      httpurple:
-        repo: https://github.com/sigma-andex/purescript-httpurple.git
-        version: v1.3.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - foreign-object
-          - js-uri
-          - justifill
-          - maybe
-          - newtype
-          - node-buffer
-          - node-fs
-          - node-http
-          - node-net
-          - node-process
-          - node-streams
-          - options
-          - ordered-collections
-          - posix-types
-          - prelude
-          - profunctor
-          - record
-          - refs
-          - routing-duplex
-          - strings
-          - transformers
-          - tuples
-          - type-equality
-          - typelevel-prelude
-      httpurple-argonaut:
-        repo: https://github.com/sigma-andex/purescript-httpurple-argonaut.git
-        version: v1.0.1
-        dependencies:
-          - argonaut
-          - console
-          - effect
-          - either
-          - httpurple
-          - prelude
-      httpurple-yoga-json:
-        repo: https://github.com/sigma-andex/purescript-httpurple-yoga-json.git
-        version: v1.0.0
-        dependencies:
-          - console
-          - effect
-          - either
-          - foreign
-          - httpurple
-          - lists
-          - prelude
-          - yoga-json
-      identity:
-        repo: https://github.com/purescript/purescript-identity.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - invariant
-          - newtype
-          - prelude
-      indexed-monad:
-        repo: https://github.com/garyb/purescript-indexed-monad.git
-        version: v2.1.0
-        dependencies:
-          - control
-          - newtype
-      int64:
-        repo: https://github.com/purescript-contrib/purescript-int64.git
-        version: v2.0.0
-        dependencies:
-          - effect
-          - foreign
-          - functions
-          - integers
-          - maybe
-          - nullable
-          - prelude
-          - quickcheck
-      integers:
-        repo: https://github.com/purescript/purescript-integers.git
-        version: v6.0.0
-        dependencies:
-          - maybe
-          - numbers
-          - prelude
-      interpolate:
-        repo: https://github.com/jordanmartinez/purescript-interpolate.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-      invariant:
-        repo: https://github.com/purescript/purescript-invariant.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - prelude
-      js-date:
-        repo: https://github.com/purescript-contrib/purescript-js-date.git
-        version: v8.0.0
-        dependencies:
-          - datetime
-          - effect
-          - exceptions
-          - foreign
-          - integers
-          - now
-      js-fileio:
-        repo: https://github.com/newlandsvalley/purescript-js-fileio.git
-        version: v3.0.0
-        dependencies:
-          - aff
-          - effect
-          - prelude
-      js-timers:
-        repo: https://github.com/purescript-contrib/purescript-js-timers.git
-        version: v6.1.0
-        dependencies:
-          - effect
-      js-uri:
-        repo: https://github.com/purescript-contrib/purescript-js-uri.git
-        version: v3.0.0
-        dependencies:
-          - functions
-          - maybe
-      justifill:
-        repo: https://github.com/i-am-the-slime/purescript-justifill.git
-        version: v0.5.0
-        dependencies:
-          - maybe
-          - prelude
-          - record
-          - typelevel-prelude
-      jwt:
-        repo: https://github.com/menelaos/purescript-jwt.git
-        version: v0.0.9
-        dependencies:
-          - argonaut-core
-          - arrays
-          - b64
-          - either
-          - exceptions
-          - prelude
-          - profunctor-lenses
-          - strings
-      language-cst-parser:
-        repo: https://github.com/natefaubion/purescript-language-cst-parser.git
-        version: v0.12.0
-        dependencies:
-          - arrays
-          - const
-          - control
-          - either
-          - foldable-traversable
-          - free
-          - functions
-          - functors
-          - identity
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - ordered-collections
-          - partial
-          - prelude
-          - st
-          - strings
-          - transformers
-          - tuples
-          - typelevel-prelude
-          - unfoldable
-          - unsafe-coerce
-      lazy:
-        repo: https://github.com/purescript/purescript-lazy.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - invariant
-          - prelude
-      lcg:
-        repo: https://github.com/purescript/purescript-lcg.git
-        version: v4.0.0
-        dependencies:
-          - effect
-          - integers
-          - maybe
-          - partial
-          - prelude
-          - random
-      leibniz:
-        repo: https://github.com/paf31/purescript-leibniz.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-          - unsafe-coerce
-      linalg:
-        repo: https://github.com/gbagan/purescript-linalg.git
-        version: v5.1.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - functions
-          - maybe
-          - prelude
-          - tuples
-      lists:
-        repo: https://github.com/purescript/purescript-lists.git
-        version: v7.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - foldable-traversable
-          - lazy
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      logging:
-        repo: https://github.com/rightfold/purescript-logging.git
-        version: v3.0.0
-        dependencies:
-          - console
-          - contravariant
-          - effect
-          - either
-          - prelude
-          - transformers
-          - tuples
-      machines:
-        repo: https://github.com/purescript-contrib/purescript-machines.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - lists
-          - maybe
-          - prelude
-          - profunctor
-          - tuples
-          - unfoldable
-      matrices:
-        repo: https://github.com/kRITZCREEK/purescript-matrices.git
-        version: v5.0.1
-        dependencies:
-          - arrays
-          - strings
-      matryoshka:
-        repo: https://github.com/purescript-contrib/purescript-matryoshka.git
-        version: v1.0.0
-        dependencies:
-          - fixed-points
-          - free
-          - prelude
-          - profunctor
-          - transformers
-      maybe:
-        repo: https://github.com/purescript/purescript-maybe.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - invariant
-          - newtype
-          - prelude
-      media-types:
-        repo: https://github.com/purescript-contrib/purescript-media-types.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      metadata:
-        repo: https://github.com/purescript/purescript-metadata.git
-        version: v0.15.0
-        dependencies: []
-      midi:
-        repo: https://github.com/newlandsvalley/purescript-midi.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - integers
-          - lists
-          - maybe
-          - ordered-collections
-          - prelude
-          - signal
-          - string-parsers
-          - strings
-          - tuples
-          - unfoldable
-      minibench:
-        repo: https://github.com/purescript/purescript-minibench.git
-        version: v4.0.0
-        dependencies:
-          - console
-          - effect
-          - integers
-          - numbers
-          - partial
-          - prelude
-          - refs
-      mmorph:
-        repo: https://github.com/Thimoteus/purescript-mmorph.git
-        version: v7.0.0
-        dependencies:
-          - free
-          - functors
-          - transformers
-      monad-control:
-        repo: https://github.com/athanclark/purescript-monad-control.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - freet
-          - identity
-          - lists
-      monad-logger:
-        repo: https://github.com/cprussin/purescript-monad-logger.git
-        version: v1.3.1
-        dependencies:
-          - aff
-          - ansi
-          - argonaut
-          - arrays
-          - console
-          - control
-          - effect
-          - foldable-traversable
-          - foreign-object
-          - integers
-          - js-date
-          - maybe
-          - newtype
-          - ordered-collections
-          - prelude
-          - strings
-          - transformers
-          - tuples
-      monad-loops:
-        repo: https://github.com/mlang/purescript-monad-loops.git
-        version: v0.5.0
-        dependencies:
-          - lists
-          - maybe
-          - prelude
-          - tailrec
-          - tuples
-      monad-unlift:
-        repo: https://github.com/athanclark/purescript-monad-unlift.git
-        version: v1.0.1
-        dependencies:
-          - monad-control
-      monoidal:
-        repo: https://github.com/mcneissue/purescript-monoidal.git
-        version: v0.16.0
-        dependencies:
-          - either
-          - profunctor
-          - these
-          - tuples
-      morello:
-        repo: https://github.com/sigma-andex/purescript-morello.git
-        version: v0.3.2
-        dependencies:
-          - arrays
-          - barlow-lens
-          - foldable-traversable
-          - heterogeneous
-          - heterogeneous-extrablatt
-          - newtype
-          - prelude
-          - profunctor
-          - profunctor-lenses
-          - record
-          - tuples
-          - typelevel-prelude
-          - validation
-      motsunabe:
-        repo: https://github.com/justinwoo/purescript-motsunabe.git
-        version: v2.0.0
-        dependencies:
-          - lists
-          - strings
-      nano-id:
-        repo: https://github.com/eikooc/nano-id.git
-        version: v1.1.0
-        dependencies:
-          - aff
-          - effect
-          - lists
-          - maybe
-          - prelude
-          - random
-          - spec
-          - strings
-          - stringutils
-      naturals:
-        repo: https://github.com/LiamGoodacre/purescript-naturals.git
-        version: v3.0.0
-        dependencies:
-          - enums
-          - maybe
-          - prelude
-      nested-functor:
-        repo: https://github.com/acple/purescript-nested-functor.git
-        version: v0.2.1
-        dependencies:
-          - prelude
-          - type-equality
-      newtype:
-        repo: https://github.com/purescript/purescript-newtype.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-          - safe-coerce
-      node-buffer:
-        repo: https://github.com/purescript-node/purescript-node-buffer.git
-        version: v8.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - maybe
-          - st
-          - unsafe-coerce
-      node-buffer-blob:
-        repo: https://github.com/purescript-node/purescript-node-buffer-blob.git
-        version: v1.0.0
-        dependencies:
-          - aff-promise
-          - arraybuffer-types
-          - arrays
-          - console
-          - effect
-          - maybe
-          - media-types
-          - newtype
-          - node-buffer
-          - nullable
-          - prelude
-          - web-streams
-      node-child-process:
-        repo: https://github.com/purescript-node/purescript-node-child-process.git
-        version: v9.0.0
-        dependencies:
-          - exceptions
-          - foreign
-          - foreign-object
-          - functions
-          - node-fs
-          - node-streams
-          - nullable
-          - posix-types
-          - unsafe-coerce
-      node-fs:
-        repo: https://github.com/purescript-node/purescript-node-fs.git
-        version: v8.0.0
-        dependencies:
-          - datetime
-          - effect
-          - either
-          - enums
-          - exceptions
-          - functions
-          - integers
-          - js-date
-          - maybe
-          - node-buffer
-          - node-path
-          - node-streams
-          - nullable
-          - partial
-          - prelude
-          - strings
-          - unsafe-coerce
-      node-fs-aff:
-        repo: https://github.com/purescript-node/purescript-node-fs-aff.git
-        version: v9.0.0
-        dependencies:
-          - aff
-          - either
-          - node-fs
-          - node-path
-      node-http:
-        repo: https://github.com/purescript-node/purescript-node-http.git
-        version: v8.0.0
-        dependencies:
-          - arraybuffer-types
-          - contravariant
-          - effect
-          - foreign
-          - foreign-object
-          - maybe
-          - node-buffer
-          - node-net
-          - node-streams
-          - node-url
-          - nullable
-          - options
-          - prelude
-          - unsafe-coerce
-      node-net:
-        repo: https://github.com/purescript-node/purescript-node-net.git
-        version: v4.0.0
-        dependencies:
-          - effect
-          - either
-          - exceptions
-          - foreign
-          - maybe
-          - node-buffer
-          - node-fs
-          - nullable
-          - options
-          - prelude
-          - transformers
-      node-path:
-        repo: https://github.com/purescript-node/purescript-node-path.git
-        version: v5.0.0
-        dependencies:
-          - effect
-      node-process:
-        repo: https://github.com/purescript-node/purescript-node-process.git
-        version: v10.0.0
-        dependencies:
-          - effect
-          - foreign-object
-          - maybe
-          - node-streams
-          - posix-types
-          - prelude
-          - unsafe-coerce
-      node-readline:
-        repo: https://github.com/purescript-node/purescript-node-readline.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - foreign
-          - node-process
-          - node-streams
-          - options
-          - prelude
-      node-streams:
-        repo: https://github.com/purescript-node/purescript-node-streams.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - either
-          - exceptions
-          - node-buffer
-          - nullable
-          - prelude
-      node-streams-aff:
-        repo: https://github.com/jamesdbrock/purescript-node-streams-aff.git
-        version: v2.0.0
-        dependencies:
-          - aff
-          - arrays
-          - effect
-          - either
-          - exceptions
-          - maybe
-          - node-buffer
-          - node-streams
-          - prelude
-          - st
-          - tuples
-      node-url:
-        repo: https://github.com/purescript-node/purescript-node-url.git
-        version: v6.0.0
-        dependencies:
-          - nullable
-      nonempty:
-        repo: https://github.com/purescript/purescript-nonempty.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - foldable-traversable
-          - maybe
-          - prelude
-          - tuples
-          - unfoldable
-      now:
-        repo: https://github.com/purescript-contrib/purescript-now.git
-        version: v6.0.0
-        dependencies:
-          - datetime
-          - effect
-      npm-package-json:
-        repo: https://github.com/maxdeviant/purescript-npm-package-json.git
-        version: v2.0.0
-        dependencies:
-          - argonaut
-          - control
-          - either
-          - foreign-object
-          - maybe
-          - ordered-collections
-          - prelude
-      nullable:
-        repo: https://github.com/purescript-contrib/purescript-nullable.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - functions
-          - maybe
-      numbers:
-        repo: https://github.com/purescript/purescript-numbers.git
-        version: v9.0.0
-        dependencies:
-          - functions
-          - maybe
-      open-folds:
-        repo: https://github.com/purescript-open-community/purescript-open-folds.git
-        version: v6.3.0
-        dependencies:
-          - bifunctors
-          - console
-          - control
-          - distributive
-          - effect
-          - either
-          - foldable-traversable
-          - identity
-          - invariant
-          - maybe
-          - newtype
-          - ordered-collections
-          - prelude
-          - profunctor
-          - psci-support
-          - tuples
-      open-memoize:
-        repo: https://github.com/purescript-open-community/purescript-open-memoize.git
-        version: v6.1.0
-        dependencies:
-          - console
-          - effect
-          - either
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - psci-support
-          - strings
-          - tuples
-      open-pairing:
-        repo: https://github.com/purescript-open-community/purescript-open-pairing.git
-        version: v6.1.0
-        dependencies:
-          - console
-          - control
-          - effect
-          - either
-          - free
-          - functors
-          - identity
-          - newtype
-          - prelude
-          - psci-support
-          - transformers
-          - tuples
-      options:
-        repo: https://github.com/purescript-contrib/purescript-options.git
-        version: v7.0.0
-        dependencies:
-          - contravariant
-          - foreign
-          - foreign-object
-          - maybe
-          - tuples
-      optparse:
-        repo: https://github.com/f-o-a-m/purescript-optparse.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - console
-          - control
-          - effect
-          - either
-          - enums
-          - exists
-          - exitcodes
-          - foldable-traversable
-          - free
-          - gen
-          - integers
-          - lazy
-          - lists
-          - maybe
-          - newtype
-          - node-buffer
-          - node-process
-          - node-streams
-          - nonempty
-          - numbers
-          - open-memoize
-          - partial
-          - prelude
-          - quickcheck
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-      ordered-collections:
-        repo: https://github.com/purescript/purescript-ordered-collections.git
-        version: v3.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - gen
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - st
-          - tailrec
-          - tuples
-          - unfoldable
-      ordered-set:
-        repo: https://github.com/flip111/purescript-ordered-set.git
-        version: v0.4.0
-        dependencies:
-          - argonaut-codecs
-          - arrays
-          - partial
-          - prelude
-          - unfoldable
-      orders:
-        repo: https://github.com/purescript/purescript-orders.git
-        version: v6.0.0
-        dependencies:
-          - newtype
-          - prelude
-      pairs:
-        repo: https://github.com/sharkdp/purescript-pairs.git
-        version: v9.0.0
-        dependencies:
-          - console
-          - distributive
-          - foldable-traversable
-          - quickcheck
-      parallel:
-        repo: https://github.com/purescript/purescript-parallel.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - functors
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - refs
-          - transformers
-      parsing:
-        repo: https://github.com/purescript-contrib/purescript-parsing.git
-        version: v9.1.0
-        dependencies:
-          - arrays
-          - either
-          - foldable-traversable
-          - identity
-          - integers
-          - lists
-          - maybe
-          - nullable
-          - prelude
-          - strings
-          - transformers
-          - unicode
-      parsing-dataview:
-        repo: https://github.com/jamesdbrock/purescript-parsing-dataview.git
-        version: v3.1.0
-        dependencies:
-          - arraybuffer
-          - arraybuffer-types
-          - effect
-          - float32
-          - maybe
-          - parsing
-          - prelude
-          - transformers
-          - tuples
-          - uint
-      partial:
-        repo: https://github.com/purescript/purescript-partial.git
-        version: v4.0.0
-        dependencies: []
-      pathy:
-        repo: https://github.com/purescript-contrib/purescript-pathy.git
-        version: v9.0.0
-        dependencies:
-          - console
-          - exceptions
-          - lists
-          - partial
-          - profunctor
-          - strings
-          - transformers
-          - typelevel-prelude
-          - unsafe-coerce
-      pha:
-        repo: https://github.com/gbagan/purescript-pha.git
-        version: v0.9.0
-        dependencies:
-          - aff
-          - arrays
-          - bifunctors
-          - datetime
-          - effect
-          - foldable-traversable
-          - free
-          - integers
-          - maybe
-          - prelude
-          - profunctor-lenses
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-          - unsafe-coerce
-          - unsafe-reference
-          - web-dom
-          - web-events
-          - web-html
-          - web-pointerevents
-          - web-uievents
-      phaser:
-        repo: https://github.com/lfarroco/purescript-phaser.git
-        version: v0.6.0
-        dependencies:
-          - canvas
-          - console
-          - effect
-          - maybe
-          - nullable
-          - options
-          - prelude
-          - web-html
-      pipes:
-        repo: https://github.com/felixschl/purescript-pipes.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - lists
-          - mmorph
-          - prelude
-          - tailrec
-          - transformers
-          - tuples
-      point-free:
-        repo: https://github.com/ursi/purescript-point-free.git
-        version: v1.0.0
-        dependencies:
-          - prelude
-      polymorphic-vectors:
-        repo: https://github.com/artemisSystem/purescript-polymorphic-vectors.git
-        version: v4.0.0
-        dependencies:
-          - distributive
-          - foldable-traversable
-          - numbers
-          - prelude
-          - record
-          - safe-coerce
-          - type-equality
-          - typelevel-prelude
-      posix-types:
-        repo: https://github.com/purescript-node/purescript-posix-types.git
-        version: v6.0.0
-        dependencies:
-          - maybe
-          - prelude
-      precise:
-        repo: https://github.com/purescript-contrib/purescript-precise.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - exceptions
-          - gen
-          - integers
-          - lists
-          - numbers
-          - prelude
-          - strings
-      precise-datetime:
-        repo: https://github.com/awakesecurity/purescript-precise-datetime.git
-        version: v7.0.0
-        dependencies:
-          - arrays
-          - datetime
-          - decimals
-          - either
-          - enums
-          - foldable-traversable
-          - formatters
-          - integers
-          - js-date
-          - lists
-          - maybe
-          - newtype
-          - numbers
-          - prelude
-          - strings
-          - tuples
-          - unicode
-      prelude:
-        repo: https://github.com/purescript/purescript-prelude.git
-        version: v6.0.0
-        dependencies: []
-      prettier-printer:
-        repo: https://github.com/paulyoung/purescript-prettier-printer.git
-        version: v3.0.0
-        dependencies:
-          - console
-          - lists
-          - prelude
-          - strings
-          - tuples
-      profunctor:
-        repo: https://github.com/purescript/purescript-profunctor.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - distributive
-          - either
-          - exists
-          - invariant
-          - newtype
-          - prelude
-          - tuples
-      profunctor-lenses:
-        repo: https://github.com/purescript-contrib/purescript-profunctor-lenses.git
-        version: v8.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - const
-          - control
-          - distributive
-          - either
-          - foldable-traversable
-          - foreign-object
-          - functors
-          - identity
-          - lists
-          - maybe
-          - newtype
-          - ordered-collections
-          - partial
-          - prelude
-          - profunctor
-          - record
-          - transformers
-          - tuples
-      protobuf:
-        repo: https://github.com/xc-jp/purescript-protobuf.git
-        version: v4.0.0
-        dependencies:
-          - arraybuffer
-          - arraybuffer-builder
-          - arraybuffer-types
-          - arrays
-          - control
-          - effect
-          - either
-          - enums
-          - exceptions
-          - float32
-          - foldable-traversable
-          - functions
-          - int64
-          - maybe
-          - newtype
-          - parsing
-          - parsing-dataview
-          - prelude
-          - record
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-          - uint
-          - web-encoding
-      ps-cst:
-        repo: https://github.com/purescript-codegen/purescript-ps-cst.git
-        version: v1.2.0
-        dependencies:
-          - ansi
-          - console
-          - dodo-printer
-          - effect
-          - node-fs-aff
-          - node-path
-          - psci-support
-          - record
-          - strings
-      psa-utils:
-        repo: https://github.com/natefaubion/purescript-psa-utils.git
-        version: v8.0.0
-        dependencies:
-          - ansi
-          - argonaut-codecs
-          - argonaut-core
-          - arrays
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - maybe
-          - node-path
-          - ordered-collections
-          - prelude
-          - strings
-          - tuples
-          - unsafe-coerce
-      psc-ide:
-        repo: https://github.com/kRITZCREEK/purescript-psc-ide.git
-        version: v19.0.0
-        dependencies:
-          - aff
-          - argonaut
-          - arrays
-          - console
-          - maybe
-          - node-child-process
-          - node-fs
-          - parallel
-          - random
-      psci-support:
-        repo: https://github.com/purescript/purescript-psci-support.git
-        version: v6.0.0
-        dependencies:
-          - console
-          - effect
-          - prelude
-      qualified-do:
-        repo: https://github.com/artemisSystem/purescript-qualified-do.git
-        version: v2.2.0
-        dependencies:
-          - arrays
-          - control
-          - foldable-traversable
-          - parallel
-          - prelude
-          - unfoldable
-      quantities:
-        repo: https://github.com/sharkdp/purescript-quantities.git
-        version: v12.0.1
-        dependencies:
-          - decimals
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - newtype
-          - nonempty
-          - numbers
-          - pairs
-          - prelude
-          - tuples
-      quickcheck:
-        repo: https://github.com/purescript/purescript-quickcheck.git
-        version: v8.0.1
-        dependencies:
-          - arrays
-          - console
-          - control
-          - effect
-          - either
-          - enums
-          - exceptions
-          - foldable-traversable
-          - gen
-          - identity
-          - integers
-          - lazy
-          - lcg
-          - lists
-          - maybe
-          - newtype
-          - nonempty
-          - numbers
-          - partial
-          - prelude
-          - record
-          - st
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-          - unfoldable
-      quickcheck-combinators:
-        repo: https://github.com/athanclark/purescript-quickcheck-combinators.git
-        version: v0.1.3
-        dependencies:
-          - quickcheck
-          - typelevel
-      quickcheck-laws:
-        repo: https://github.com/purescript-contrib/purescript-quickcheck-laws.git
-        version: v7.0.0
-        dependencies:
-          - enums
-          - quickcheck
-      quickcheck-utf8:
-        repo: https://github.com/openchronology/purescript-quickcheck-utf8.git
-        version: v0.0.0
-        dependencies:
-          - quickcheck
-      quotient:
-        repo: https://github.com/rightfold/purescript-quotient.git
-        version: v3.0.0
-        dependencies:
-          - prelude
-          - quickcheck
-      random:
-        repo: https://github.com/purescript/purescript-random.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - integers
-      rationals:
-        repo: https://github.com/anttih/purescript-rationals.git
-        version: v5.0.0
-        dependencies:
-          - integers
-          - prelude
-      react:
-        repo: https://github.com/purescript-contrib/purescript-react.git
-        version: v10.0.1
-        dependencies:
-          - effect
-          - exceptions
-          - maybe
-          - nullable
-          - prelude
-          - typelevel-prelude
-          - unsafe-coerce
-      react-basic:
-        repo: https://github.com/lumihq/purescript-react-basic.git
-        version: v17.0.0
-        dependencies:
-          - effect
-          - prelude
-          - record
-      react-basic-dom:
-        repo: https://github.com/lumihq/purescript-react-basic-dom.git
-        version: v5.0.0
-        dependencies:
-          - effect
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - nullable
-          - prelude
-          - react-basic
-          - unsafe-coerce
-          - web-dom
-          - web-events
-          - web-file
-          - web-html
-      react-basic-hooks:
-        repo: https://github.com/megamaddu/purescript-react-basic-hooks.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - aff-promise
-          - bifunctors
-          - console
-          - control
-          - datetime
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - functions
-          - indexed-monad
-          - integers
-          - maybe
-          - newtype
-          - now
-          - nullable
-          - ordered-collections
-          - prelude
-          - react-basic
-          - refs
-          - tuples
-          - type-equality
-          - unsafe-coerce
-          - unsafe-reference
-          - web-html
-      react-dom:
-        repo: https://github.com/purescript-contrib/purescript-react-dom.git
-        version: v8.0.0
-        dependencies:
-          - effect
-          - react
-          - web-dom
-      read:
-        repo: https://github.com/truqu/purescript-read.git
-        version: v1.0.1
-        dependencies:
-          - maybe
-          - prelude
-          - strings
-      record:
-        repo: https://github.com/purescript/purescript-record.git
-        version: v4.0.0
-        dependencies:
-          - functions
-          - prelude
-          - unsafe-coerce
-      refined:
-        repo: https://github.com/danieljharvey/purescript-refined.git
-        version: v1.0.0
-        dependencies:
-          - argonaut
-          - effect
-          - prelude
-          - quickcheck
-          - typelevel
-      refs:
-        repo: https://github.com/purescript/purescript-refs.git
-        version: v6.0.0
-        dependencies:
-          - effect
-          - prelude
-      remotedata:
-        repo: https://github.com/krisajenkins/purescript-remotedata.git
-        version: v5.0.0
-        dependencies:
-          - bifunctors
-          - either
-          - profunctor-lenses
-      resource:
-        repo: https://github.com/joneshf/purescript-resource.git
-        version: v2.0.1
-        dependencies:
-          - aff
-          - console
-          - control
-          - effect
-          - newtype
-          - prelude
-          - psci-support
-          - refs
-      resourcet:
-        repo: https://github.com/robertdp/purescript-resourcet.git
-        version: v1.0.0
-        dependencies:
-          - aff
-          - effect
-          - foldable-traversable
-          - maybe
-          - ordered-collections
-          - parallel
-          - refs
-          - tailrec
-          - transformers
-          - tuples
-      result:
-        repo: https://github.com/ad-si/purescript-result.git
-        version: v1.0.3
-        dependencies:
-          - either
-          - foldable-traversable
-          - prelude
-      return:
-        repo: https://github.com/ursi/purescript-return.git
-        version: v0.2.0
-        dependencies:
-          - foldable-traversable
-          - point-free
-          - prelude
-      ring-modules:
-        repo: https://github.com/f-o-a-m/purescript-ring-modules.git
-        version: v5.0.1
-        dependencies:
-          - prelude
-      routing:
-        repo: https://github.com/purescript-contrib/purescript-routing.git
-        version: v11.0.0
-        dependencies:
-          - aff
-          - console
-          - control
-          - effect
-          - either
-          - foldable-traversable
-          - integers
-          - js-uri
-          - lists
-          - maybe
-          - numbers
-          - partial
-          - prelude
-          - semirings
-          - tuples
-          - validation
-          - web-html
-      routing-duplex:
-        repo: https://github.com/natefaubion/purescript-routing-duplex.git
-        version: v0.6.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - js-uri
-          - lazy
-          - numbers
-          - prelude
-          - profunctor
-          - record
-          - strings
-          - typelevel-prelude
-      run:
-        repo: https://github.com/natefaubion/purescript-run.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - free
-          - maybe
-          - newtype
-          - prelude
-          - profunctor
-          - tailrec
-          - tuples
-          - type-equality
-          - typelevel-prelude
-          - unsafe-coerce
-          - variant
-      safe-coerce:
-        repo: https://github.com/purescript/purescript-safe-coerce.git
-        version: v2.0.0
-        dependencies:
-          - unsafe-coerce
-      safely:
-        repo: https://github.com/paf31/purescript-safely.git
-        version: v4.0.1
-        dependencies:
-          - freet
-          - lists
-      selection-foldable:
-        repo: https://github.com/jamieyung/purescript-selection-foldable.git
-        version: v0.2.0
-        dependencies:
-          - filterable
-          - foldable-traversable
-          - maybe
-          - prelude
-      semirings:
-        repo: https://github.com/purescript/purescript-semirings.git
-        version: v7.0.0
-        dependencies:
-          - foldable-traversable
-          - lists
-          - newtype
-          - prelude
-      signal:
-        repo: https://github.com/bodil/purescript-signal.git
-        version: v13.0.0
-        dependencies:
-          - aff
-          - effect
-          - either
-          - foldable-traversable
-          - maybe
-          - prelude
-      simple-emitter:
-        repo: https://github.com/oreshinya/purescript-simple-emitter.git
-        version: v2.0.0
-        dependencies:
-          - ordered-collections
-          - refs
-      sized-matrices:
-        repo: https://github.com/csicar/purescript-sized-matrices.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - distributive
-          - foldable-traversable
-          - maybe
-          - prelude
-          - sized-vectors
-          - strings
-          - typelevel
-          - unfoldable
-          - vectorfield
-      sized-vectors:
-        repo: https://github.com/bodil/purescript-sized-vectors.git
-        version: v5.0.2
-        dependencies:
-          - argonaut
-          - arrays
-          - distributive
-          - foldable-traversable
-          - maybe
-          - prelude
-          - quickcheck
-          - typelevel
-          - unfoldable
-      slug:
-        repo: https://github.com/thomashoneyman/purescript-slug.git
-        version: v3.0.1
-        dependencies:
-          - argonaut-codecs
-          - maybe
-          - prelude
-          - strings
-          - unicode
-      soundfonts:
-        repo: https://github.com/newlandsvalley/purescript-soundfonts.git
-        version: v4.1.0
-        dependencies:
-          - aff
-          - affjax
-          - affjax-web
-          - argonaut-core
-          - arraybuffer-types
-          - arrays
-          - b64
-          - bifunctors
-          - console
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign-object
-          - http-methods
-          - integers
-          - lists
-          - maybe
-          - midi
-          - ordered-collections
-          - parallel
-          - partial
-          - prelude
-          - strings
-          - transformers
-          - tuples
-      sparse-matrices:
-        repo: https://github.com/Ebmtranceboy/purescript-sparse-matrices.git
-        version: v1.2.1
-        dependencies:
-          - console
-          - effect
-          - prelude
-          - sparse-polynomials
-      sparse-polynomials:
-        repo: https://github.com/Ebmtranceboy/purescript-sparse-polynomials.git
-        version: v1.0.5
-        dependencies:
-          - cartesian
-          - console
-          - effect
-          - ordered-collections
-          - prelude
-          - rationals
-          - tuples
-      spec:
-        repo: https://github.com/purescript-spec/purescript-spec.git
-        version: v7.0.0
-        dependencies:
-          - aff
-          - ansi
-          - avar
-          - console
-          - exceptions
-          - foldable-traversable
-          - fork
-          - now
-          - pipes
-          - prelude
-          - strings
-          - transformers
-      spec-discovery:
-        repo: https://github.com/purescript-spec/purescript-spec-discovery.git
-        version: v8.0.0
-        dependencies:
-          - aff
-          - aff-promise
-          - arrays
-          - console
-          - effect
-          - foldable-traversable
-          - node-fs
-          - prelude
-          - spec
-      spec-quickcheck:
-        repo: https://github.com/purescript-spec/purescript-spec-quickcheck.git
-        version: v5.0.0
-        dependencies:
-          - aff
-          - prelude
-          - quickcheck
-          - random
-          - spec
-      ssrs:
-        repo: https://github.com/PureFunctor/purescript-ssrs.git
-        version: v1.0.0
-        dependencies:
-          - dissect
-          - either
-          - fixed-points
-          - free
-          - lists
-          - prelude
-          - safe-coerce
-          - tailrec
-          - tuples
-          - variant
-      st:
-        repo: https://github.com/purescript/purescript-st.git
-        version: v6.0.0
-        dependencies:
-          - partial
-          - prelude
-          - tailrec
-          - unsafe-coerce
-      strictlypositiveint:
-        repo: https://github.com/jamieyung/purescript-strictlypositiveint.git
-        version: v1.0.1
-        dependencies:
-          - prelude
-      string-parsers:
-        repo: https://github.com/purescript-contrib/purescript-string-parsers.git
-        version: v8.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - lists
-          - maybe
-          - prelude
-          - strings
-          - tailrec
-      strings:
-        repo: https://github.com/purescript/purescript-strings.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - control
-          - either
-          - enums
-          - foldable-traversable
-          - gen
-          - integers
-          - maybe
-          - newtype
-          - nonempty
-          - partial
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-          - unsafe-coerce
-      strings-extra:
-        repo: https://github.com/purescript-contrib/purescript-strings-extra.git
-        version: v4.0.0
-        dependencies:
-          - arrays
-          - foldable-traversable
-          - maybe
-          - prelude
-          - strings
-          - unicode
-      stringutils:
-        repo: https://github.com/menelaos/purescript-stringutils.git
-        version: v0.0.12
-        dependencies:
-          - arrays
-          - integers
-          - maybe
-          - partial
-          - prelude
-          - strings
-      substitute:
-        repo: https://github.com/ursi/purescript-substitute.git
-        version: v0.2.3
-        dependencies:
-          - foldable-traversable
-          - foreign-object
-          - maybe
-          - prelude
-          - return
-          - strings
-      supply:
-        repo: https://github.com/ajnsit/purescript-supply.git
-        version: v0.2.0
-        dependencies:
-          - console
-          - control
-          - effect
-          - lazy
-          - prelude
-          - refs
-          - tuples
-      tailrec:
-        repo: https://github.com/purescript/purescript-tailrec.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - effect
-          - either
-          - identity
-          - maybe
-          - partial
-          - prelude
-          - refs
-      test-unit:
-        repo: https://github.com/bodil/purescript-test-unit.git
-        version: v17.0.0
-        dependencies:
-          - aff
-          - avar
-          - effect
-          - either
-          - free
-          - js-timers
-          - lists
-          - prelude
-          - quickcheck
-          - strings
-      thermite:
-        repo: https://github.com/paf31/purescript-thermite.git
-        version: v6.3.1
-        dependencies:
-          - aff
-          - coroutines
-          - freet
-          - profunctor-lenses
-          - react
-      thermite-dom:
-        repo: https://github.com/athanclark/purescript-thermite-dom.git
-        version: v0.3.1
-        dependencies:
-          - react
-          - react-dom
-          - thermite
-          - web-html
-      these:
-        repo: https://github.com/purescript-contrib/purescript-these.git
-        version: v6.0.0
-        dependencies:
-          - arrays
-          - gen
-          - lists
-          - quickcheck
-          - quickcheck-laws
-          - tuples
-      transformers:
-        repo: https://github.com/purescript/purescript-transformers.git
-        version: v6.0.0
-        dependencies:
-          - control
-          - distributive
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - identity
-          - lazy
-          - maybe
-          - newtype
-          - prelude
-          - tailrec
-          - tuples
-          - unfoldable
-      tree-rose:
-        repo: https://github.com/jordanmartinez/purescript-tree-rose.git
-        version: v4.0.2
-        dependencies:
-          - control
-          - foldable-traversable
-          - free
-          - lists
-          - maybe
-          - prelude
-          - tailrec
-      tuples:
-        repo: https://github.com/purescript/purescript-tuples.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - invariant
-          - prelude
-      two-or-more:
-        repo: https://github.com/i-am-the-slime/purescript-two-or-more.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - foldable-traversable
-          - maybe
-          - partial
-          - prelude
-          - psci-support
-          - tuples
-      type-equality:
-        repo: https://github.com/purescript/purescript-type-equality.git
-        version: v4.0.1
-        dependencies: []
-      typelevel:
-        repo: https://github.com/bodil/purescript-typelevel.git
-        version: v6.0.0
-        dependencies:
-          - partial
-          - prelude
-          - tuples
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-lists:
-        repo: https://github.com/PureFunctor/purescript-typelevel-lists.git
-        version: v2.1.0
-        dependencies:
-          - prelude
-          - tuples
-          - typelevel-peano
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-peano:
-        repo: https://github.com/csicar/purescript-typelevel-peano.git
-        version: v1.0.1
-        dependencies:
-          - arrays
-          - console
-          - effect
-          - prelude
-          - psci-support
-          - typelevel-prelude
-          - unsafe-coerce
-      typelevel-prelude:
-        repo: https://github.com/purescript/purescript-typelevel-prelude.git
-        version: v7.0.0
-        dependencies:
-          - prelude
-          - type-equality
-      typelevel-rows:
-        repo: https://github.com/jordanmartinez/purescript-typelevel-rows.git
-        version: v0.1.0
-        dependencies:
-          - prelude
-      uint:
-        repo: https://github.com/purescript-contrib/purescript-uint.git
-        version: v7.0.0
-        dependencies:
-          - effect
-          - enums
-          - gen
-          - maybe
-          - numbers
-          - prelude
-      uncurried-transformers:
-        repo: https://github.com/PureFunctor/purescript-uncurried-transformers.git
-        version: v1.1.0
-        dependencies:
-          - control
-          - effect
-          - either
-          - functions
-          - identity
-          - prelude
-          - safe-coerce
-          - tailrec
-          - transformers
-          - tuples
-      undefined-is-not-a-problem:
-        repo: https://github.com/paluh/purescript-undefined-is-not-a-problem.git
-        version: v1.0.0
-        dependencies:
-          - arrays
-          - assert
-          - effect
-          - either
-          - foreign
-          - maybe
-          - newtype
-          - prelude
-          - random
-          - tuples
-          - type-equality
-          - unsafe-coerce
-      unfoldable:
-        repo: https://github.com/purescript/purescript-unfoldable.git
-        version: v6.0.0
-        dependencies:
-          - foldable-traversable
-          - maybe
-          - partial
-          - prelude
-          - tuples
-      unicode:
-        repo: https://github.com/purescript-contrib/purescript-unicode.git
-        version: v6.0.0
-        dependencies:
-          - foldable-traversable
-          - maybe
-          - strings
-      unlift:
-        repo: https://github.com/tweag/purescript-unlift.git
-        version: v1.0.1
-        dependencies:
-          - aff
-          - effect
-          - either
-          - freet
-          - identity
-          - lists
-          - maybe
-          - monad-control
-          - prelude
-          - st
-          - transformers
-          - tuples
-      unsafe-coerce:
-        repo: https://github.com/purescript/purescript-unsafe-coerce.git
-        version: v6.0.0
-        dependencies: []
-      unsafe-reference:
-        repo: https://github.com/purescript-contrib/purescript-unsafe-reference.git
-        version: v5.0.0
-        dependencies:
-          - prelude
-      uri:
-        repo: https://github.com/purescript-contrib/purescript-uri.git
-        version: v9.0.0
-        dependencies:
-          - arrays
-          - integers
-          - js-uri
-          - numbers
-          - parsing
-          - prelude
-          - profunctor-lenses
-          - these
-          - transformers
-          - unfoldable
-      validation:
-        repo: https://github.com/purescript/purescript-validation.git
-        version: v6.0.0
-        dependencies:
-          - bifunctors
-          - control
-          - either
-          - foldable-traversable
-          - newtype
-          - prelude
-      variant:
-        repo: https://github.com/natefaubion/purescript-variant.git
-        version: v8.0.0
-        dependencies:
-          - enums
-          - lists
-          - maybe
-          - partial
-          - prelude
-          - record
-          - tuples
-          - unsafe-coerce
-      vectorfield:
-        repo: https://github.com/csicar/purescript-vectorfield.git
-        version: v1.0.1
-        dependencies:
-          - console
-          - effect
-          - group
-          - prelude
-          - psci-support
-      versions:
-        repo: https://github.com/hdgarrood/purescript-versions.git
-        version: v7.0.0
-        dependencies:
-          - control
-          - either
-          - foldable-traversable
-          - functions
-          - integers
-          - lists
-          - maybe
-          - orders
-          - parsing
-          - partial
-          - strings
-      web-clipboard:
-        repo: https://github.com/purescript-web/purescript-web-clipboard.git
-        version: v4.0.0
-        dependencies:
-          - web-html
-      web-cssom:
-        repo: https://github.com/purescript-web/purescript-web-cssom.git
-        version: v2.0.0
-        dependencies:
-          - web-dom
-          - web-html
-          - web-uievents
-      web-dom:
-        repo: https://github.com/purescript-web/purescript-web-dom.git
-        version: v6.0.0
-        dependencies:
-          - web-events
-      web-dom-parser:
-        repo: https://github.com/purescript-web/purescript-web-dom-parser.git
-        version: v8.0.0
-        dependencies:
-          - effect
-          - partial
-          - prelude
-          - web-dom
-      web-dom-xpath:
-        repo: https://github.com/purescript-web/purescript-web-dom-xpath.git
-        version: v3.0.0
-        dependencies:
-          - web-dom
-      web-encoding:
-        repo: https://github.com/purescript-web/purescript-web-encoding.git
-        version: v3.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - newtype
-          - prelude
-      web-events:
-        repo: https://github.com/purescript-web/purescript-web-events.git
-        version: v4.0.0
-        dependencies:
-          - datetime
-          - enums
-          - foreign
-          - nullable
-      web-fetch:
-        repo: https://github.com/purescript-web/purescript-web-fetch.git
-        version: v3.0.0
-        dependencies:
-          - effect
-          - foreign-object
-          - http-methods
-          - prelude
-          - record
-          - typelevel-prelude
-          - web-file
-          - web-promise
-          - web-streams
-      web-file:
-        repo: https://github.com/purescript-web/purescript-web-file.git
-        version: v4.0.0
-        dependencies:
-          - foreign
-          - media-types
-          - web-dom
-      web-html:
-        repo: https://github.com/purescript-web/purescript-web-html.git
-        version: v4.0.0
-        dependencies:
-          - js-date
-          - web-dom
-          - web-file
-          - web-storage
-      web-page-visibility:
-        repo: https://git.sr.ht/~toastal/purescript-web-page-visibility
-        version: v2.0.0
-        dependencies:
-          - effect
-          - enums
-          - exceptions
-          - maybe
-          - prelude
-          - strings
-          - web-events
-          - web-html
-      web-pointerevents:
-        repo: https://github.com/purescript-web/purescript-web-pointerevents.git
-        version: v1.0.0
-        dependencies:
-          - effect
-          - maybe
-          - prelude
-          - web-dom
-          - web-uievents
-      web-promise:
-        repo: https://github.com/purescript-web/purescript-web-promise.git
-        version: v3.0.0
-        dependencies:
-          - effect
-          - exceptions
-          - foldable-traversable
-          - functions
-          - maybe
-          - prelude
-      web-socket:
-        repo: https://github.com/purescript-web/purescript-web-socket.git
-        version: v4.0.0
-        dependencies:
-          - arraybuffer-types
-          - web-file
-      web-storage:
-        repo: https://github.com/purescript-web/purescript-web-storage.git
-        version: v5.0.0
-        dependencies:
-          - nullable
-          - web-events
-      web-streams:
-        repo: https://github.com/purescript-web/purescript-web-streams.git
-        version: v3.0.0
-        dependencies:
-          - arraybuffer-types
-          - effect
-          - exceptions
-          - nullable
-          - prelude
-          - tuples
-          - web-promise
-      web-touchevents:
-        repo: https://github.com/purescript-web/purescript-web-touchevents.git
-        version: v4.0.0
-        dependencies:
-          - web-uievents
-      web-uievents:
-        repo: https://github.com/purescript-web/purescript-web-uievents.git
-        version: v4.0.0
-        dependencies:
-          - web-html
-      web-workers:
-        repo: https://github.com/gbagan/purescript-web-workers.git
-        version: v1.1.0
-        dependencies:
-          - effect
-          - foreign
-          - maybe
-          - prelude
-          - unsafe-coerce
-          - web-events
-      web-xhr:
-        repo: https://github.com/purescript-web/purescript-web-xhr.git
-        version: v5.0.0
-        dependencies:
-          - arraybuffer-types
-          - datetime
-          - http-methods
-          - web-dom
-          - web-file
-          - web-html
-      yoga-fetch:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-fetch.git
-        version: v1.0.1
-        dependencies:
-          - aff
-          - aff-promise
-          - arraybuffer-types
-          - effect
-          - foreign
-          - foreign-object
-          - newtype
-          - prelude
-          - typelevel-prelude
-          - unsafe-coerce
-      yoga-json:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-json.git
-        version: v2.0.0
-        dependencies:
-          - arrays
-          - bifunctors
-          - control
-          - effect
-          - either
-          - exceptions
-          - foldable-traversable
-          - foreign
-          - foreign-object
-          - identity
-          - lists
-          - maybe
-          - nullable
-          - partial
-          - prelude
-          - record
-          - transformers
-          - typelevel-prelude
-          - variant
-      yoga-postgres:
-        repo: https://github.com/rowtype-yoga/purescript-yoga-postgres.git
-        version: v6.0.0
-        dependencies:
-          - aff
-          - arrays
-          - datetime
-          - effect
-          - either
-          - enums
-          - foldable-traversable
-          - foreign
-          - integers
-          - maybe
-          - nullable
-          - prelude
-          - transformers
-          - unsafe-coerce
+      abc-parser: 2.0.0
+      ace: 9.0.0
+      aff: 7.1.0
+      aff-bus: 6.0.0
+      aff-coroutines: 9.0.0
+      aff-promise: 4.0.0
+      aff-retry: 2.0.0
+      affjax: 13.0.0
+      affjax-node: 1.0.0
+      affjax-web: 1.0.0
+      ansi: 7.0.0
+      argonaut: 9.0.0
+      argonaut-aeson-generic: 0.4.1
+      argonaut-codecs: 9.1.0
+      argonaut-core: 7.0.0
+      argonaut-generic: 8.0.0
+      argonaut-traversals: 10.0.0
+      argparse-basic: 2.0.0
+      array-builder: 0.1.2
+      arraybuffer: 13.1.1
+      arraybuffer-builder: 3.1.0
+      arraybuffer-types: 3.0.2
+      arrays: 7.1.0
+      arrays-zipper: 2.0.1
+      ask: 1.0.0
+      assert: 6.0.0
+      avar: 5.0.0
+      b64: 0.0.8
+      barbies: 1.0.1
+      barlow-lens: 0.9.0
+      basic-auth: 3.0.1
+      bifunctors: 6.0.0
+      bigints: 7.0.1
+      bolson: 0.3.1
+      bower-json: 3.0.0
+      bucketchain: 1.0.1
+      bucketchain-basic-auth: 1.0.1
+      bucketchain-conditional: 1.0.1
+      bucketchain-cors: 1.0.1
+      bucketchain-csrf: 1.0.1
+      bucketchain-header-utils: 1.0.1
+      bucketchain-health: 1.0.1
+      bucketchain-history-api-fallback: 1.0.1
+      bucketchain-logger: 1.0.1
+      bucketchain-secure: 1.0.1
+      bucketchain-simple-api: 5.0.1
+      bucketchain-sslify: 1.0.1
+      bucketchain-static: 1.0.1
+      call-by-name: 4.0.1
+      canvas: 6.0.0
+      canvas-action: 9.0.0
+      cartesian: 1.0.6
+      catenable-lists: 7.0.0
+      channel: 1.0.0
+      checked-exceptions: 3.1.1
+      classless: 0.1.1
+      classless-arbitrary: 0.1.1
+      classless-decode-json: 0.1.1
+      classless-encode-json: 0.1.3
+      classnames: 2.0.0
+      codec: 6.0.0
+      codec-argonaut: 10.0.0
+      colors: 7.0.1
+      concur-core: 0.5.0
+      concur-react: 0.5.0
+      concurrent-queues: 3.0.0
+      console: 6.0.0
+      const: 6.0.0
+      contravariant: 6.0.0
+      control: 6.0.0
+      convertable-options: 1.0.0
+      coroutines: 7.0.0
+      crypto: 5.0.1
+      css: 6.0.0
+      datetime: 6.1.0
+      datetime-parsing: 0.2.0
+      debug: 6.0.2
+      decimals: 7.1.0
+      default-values: 1.0.1
+      deku: 0.9.9
+      deno: 0.0.5
+      dissect: 1.0.0
+      distributive: 6.0.0
+      dodo-printer: 2.2.1
+      dom-filereader: 7.0.0
+      dom-indexed: 11.0.0
+      dotenv: 3.0.0
+      droplet: 0.5.0
+      dynamic-buffer: 3.0.1
+      echarts-simple: 0.0.1
+      effect: 4.0.0
+      either: 6.1.0
+      elmish: 0.8.3
+      elmish-enzyme: 0.1.1
+      elmish-hooks: 0.9.1
+      elmish-html: 0.7.2
+      elmish-testing-library: 0.3.1
+      email-validate: 7.0.0
+      encoding: 0.0.8
+      enums: 6.0.1
+      error: 2.0.0
+      exceptions: 6.0.0
+      exists: 6.0.0
+      exitcodes: 4.0.0
+      expect-inferred: 3.0.0
+      fahrtwind: 2.0.0
+      fallback: 0.1.0
+      fast-vect: 1.1.0
+      fetch: 1.1.4
+      fetch-argonaut: 1.0.0
+      fetch-core: 4.0.4
+      fetch-yoga-json: 1.1.0
+      filterable: 5.0.0
+      fixed-points: 7.0.0
+      fixed-precision: 5.0.0
+      flame: 1.2.0
+      float32: 2.0.0
+      foldable-traversable: 6.0.0
+      foreign: 7.0.0
+      foreign-object: 4.1.0
+      foreign-readwrite: 3.4.0
+      fork: 6.0.0
+      form-urlencoded: 7.0.0
+      formatters: 7.0.0
+      framer-motion: 1.0.1
+      free: 7.0.0
+      freeap: 7.0.0
+      freer-free: 0.0.1
+      freet: 7.0.0
+      functions: 6.0.0
+      functor1: 3.0.0
+      functors: 5.0.0
+      fuzzy: 0.4.0
+      gen: 4.0.0
+      generate-values: 1.0.1
+      generic-router: 0.0.1
+      geometry-plane: 1.0.3
+      github-actions-toolkit: 0.5.0
+      grain: 3.0.0
+      grain-router: 3.0.0
+      grain-virtualized: 3.0.0
+      graphql-client: 9.3.2
+      graphs: 8.1.0
+      group: 4.1.1
+      halogen: 7.0.0
+      halogen-bootstrap5: 2.1.0
+      halogen-css: 10.0.0
+      halogen-echarts-simple: 0.0.4
+      halogen-formless: 4.0.2
+      halogen-hooks: 0.6.3
+      halogen-hooks-extra: 0.9.0
+      halogen-store: 0.5.4
+      halogen-storybook: 2.0.0
+      halogen-subscriptions: 2.0.0
+      halogen-svg-elems: 7.0.0
+      halogen-vdom: 8.0.0
+      halogen-vdom-string-renderer: 0.5.0
+      heckin: 2.0.1
+      heterogeneous: 0.6.0
+      homogeneous: 0.4.0
+      http-methods: 6.0.0
+      httpure: 0.16.0
+      httpurple: 3.0.1
+      httpurple-argonaut: 1.0.1
+      httpurple-yoga-json: 1.0.0
+      humdrum: 0.0.1
+      hyrule: 2.3.5
+      identity: 6.0.0
+      identy: 4.0.1
+      indexed-monad: 2.1.0
+      int64: 3.0.0
+      integers: 6.0.0
+      interpolate: 5.0.2
+      invariant: 6.0.0
+      jarilo: 1.0.1
+      jelly: 0.9.1
+      jelly-hooks: 0.3.1
+      jelly-router: 0.2.2
+      jelly-signal: 0.3.0
+      jest: 1.0.0
+      js-bigints: 1.2.0
+      js-date: 8.0.0
+      js-fileio: 3.0.0
+      js-promise: 1.0.0
+      js-promise-aff: 1.0.0
+      js-timers: 6.1.0
+      js-uri: 3.1.0
+      justifill: 0.5.0
+      jwt: 0.0.9
+      language-cst-parser: 0.12.1
+      lazy: 6.0.0
+      lazy-joe: 1.0.0
+      lcg: 4.0.0
+      leibniz: 5.0.0
+      linalg: 5.1.0
+      lists: 7.0.0
+      literals: 1.0.2
+      logging: 3.0.0
+      logging-journald: 0.4.0
+      machines: 7.0.0
+      marionette: 1.0.0
+      marionette-commander: 0.1.1
+      marionette-react-basic-hooks: 0.1.1
+      matrices: 5.0.1
+      matryoshka: 1.0.0
+      maybe: 6.0.0
+      mdast-util-from-markdown: 0.2.1
+      media-types: 6.0.0
+      midi: 4.0.0
+      milkis: 9.0.0
+      minibench: 4.0.1
+      mmorph: 7.0.0
+      monad-control: 5.0.0
+      monad-logger: 1.3.1
+      monad-loops: 0.5.0
+      monad-unlift: 1.0.1
+      monoid-extras: 0.0.1
+      monoidal: 0.16.0
+      morello: 0.4.0
+      mote: 3.0.0
+      motsunabe: 2.0.0
+      mysql: 6.0.1
+      n3: 0.1.0
+      nano-id: 1.1.0
+      naturals: 3.0.0
+      nested-functor: 0.2.1
+      newtype: 5.0.0
+      nextui: 0.1.0
+      node-buffer: 8.0.0
+      node-buffer-blob: 1.0.0
+      node-child-process: 9.0.0
+      node-fs: 8.1.1
+      node-fs-aff: 9.1.0
+      node-http: 8.0.0
+      node-net: 4.0.0
+      node-path: 5.0.0
+      node-process: 10.0.0
+      node-readline: 7.0.0
+      node-sqlite3: 8.0.0
+      node-streams: 7.0.0
+      node-streams-aff: 4.0.1
+      node-url: 6.0.0
+      nodemailer: 4.0.1
+      nonempty: 7.0.0
+      now: 6.0.0
+      npm-package-json: 2.0.0
+      nullable: 6.0.0
+      numbers: 9.0.0
+      object-maps: 0.1.1
+      ocarina: 1.5.2
+      open-folds: 6.3.0
+      open-memoize: 6.1.0
+      open-pairing: 6.1.0
+      options: 7.0.0
+      optparse: 5.0.0
+      ordered-collections: 3.0.0
+      ordered-set: 0.4.0
+      orders: 6.0.0
+      pairs: 9.0.0
+      parallel: 6.0.0
+      parsing: 10.2.0
+      parsing-dataview: 3.2.4
+      partial: 4.0.0
+      pathy: 9.0.0
+      pha: 0.9.0
+      phaser: 0.6.0
+      pipes: 8.0.0
+      pirates-charm: 0.0.1
+      point-free: 1.0.0
+      pointed-list: 0.5.1
+      polymorphic-vectors: 4.0.0
+      posix-types: 6.0.0
+      precise: 6.0.0
+      precise-datetime: 7.0.0
+      prelude: 6.0.1
+      prettier-printer: 3.0.0
+      profunctor: 6.0.0
+      profunctor-lenses: 8.0.0
+      protobuf: 4.2.0
+      ps-cst: 1.2.0
+      psa-utils: 8.0.0
+      psc-ide: 19.0.0
+      psci-support: 6.0.0
+      qualified-do: 2.2.0
+      quantities: 12.1.0
+      quickcheck: 8.0.1
+      quickcheck-combinators: 0.1.3
+      quickcheck-laws: 7.0.0
+      quickcheck-utf8: 0.0.0
+      random: 6.0.0
+      rationals: 5.0.1
+      rdf: 0.1.0
+      react: 10.0.1
+      react-aria: 0.2.0
+      react-basic: 17.0.0
+      react-basic-classic: 3.0.0
+      react-basic-dnd: 10.1.0
+      react-basic-dom: 6.0.0
+      react-basic-emotion: 7.1.0
+      react-basic-hooks: 8.1.2
+      react-basic-storybook: 2.0.0
+      react-dom: 8.0.0
+      react-halo: 3.0.0
+      react-icons: 1.0.8
+      react-testing-library: 4.0.1
+      react-virtuoso: 1.0.0
+      read: 1.0.1
+      record: 4.0.0
+      record-extra: 5.0.1
+      record-studio: 1.0.4
+      refs: 6.0.0
+      remotedata: 5.0.0
+      resource: 2.0.1
+      resourcet: 1.0.0
+      result: 1.0.3
+      return: 0.2.0
+      ring-modules: 5.0.1
+      rito: 0.3.2
+      routing: 11.0.0
+      routing-duplex: 0.7.0
+      run: 5.0.0
+      safe-coerce: 2.0.0
+      safely: 4.0.1
+      school-of-music: 1.3.0
+      selection-foldable: 0.2.0
+      semirings: 7.0.0
+      signal: 13.0.0
+      simple-emitter: 3.0.1
+      simple-i18n: 2.0.1
+      simple-json: 9.0.0
+      simple-jwt: 4.0.1
+      simple-ulid: 3.0.0
+      sized-matrices: 1.0.0
+      sized-vectors: 5.0.2
+      slug: 3.0.8
+      small-ffi: 4.0.1
+      soundfonts: 4.1.0
+      sparse-matrices: 1.2.1
+      sparse-polynomials: 1.0.5
+      spec: 7.2.0
+      spec-discovery: 8.0.1
+      spec-quickcheck: 5.0.0
+      splitmix: 2.1.0
+      ssrs: 1.0.0
+      st: 6.2.0
+      strictlypositiveint: 1.0.1
+      string-parsers: 8.0.0
+      strings: 6.0.1
+      strings-extra: 4.0.0
+      stringutils: 0.0.12
+      substitute: 0.2.3
+      sunde: 3.0.0
+      supply: 0.2.0
+      svg-parser: 3.0.0
+      systemd-journald: 0.3.0
+      tagged: 4.0.2
+      tailrec: 6.1.0
+      tecton: 0.1.6
+      tecton-halogen: 0.1.3
+      test-unit: 17.0.0
+      thermite: 6.3.1
+      thermite-dom: 0.3.1
+      these: 6.0.0
+      toppokki: 4.0.0
+      transformers: 6.0.0
+      tree-rose: 4.0.2
+      tuples: 7.0.0
+      two-or-more: 1.0.0
+      type-equality: 4.0.1
+      typelevel: 6.0.0
+      typelevel-lists: 2.1.0
+      typelevel-peano: 1.0.1
+      typelevel-prelude: 7.0.0
+      typelevel-rows: 0.1.0
+      uint: 7.0.0
+      ulid: 3.0.1
+      uncurried-transformers: 1.1.0
+      undefined: 2.0.0
+      undefined-is-not-a-problem: 1.1.0
+      unfoldable: 6.0.0
+      unicode: 6.0.0
+      unlift: 1.0.1
+      unordered-collections: 3.0.1
+      unsafe-coerce: 6.0.0
+      unsafe-reference: 5.0.0
+      untagged-to-tagged: 0.1.4
+      untagged-union: 1.0.0
+      uri: 9.0.0
+      uuid: 9.0.0
+      uuidv4: 1.0.0
+      validation: 6.0.0
+      variant: 8.0.0
+      vectorfield: 1.0.1
+      vectors: 2.1.0
+      versions: 7.0.0
+      visx: 0.0.2
+      web-clipboard: 5.0.0
+      web-cssom: 2.0.0
+      web-dom: 6.0.0
+      web-dom-parser: 8.0.0
+      web-dom-xpath: 3.0.0
+      web-encoding: 3.0.0
+      web-events: 4.0.0
+      web-fetch: 3.0.0
+      web-file: 4.0.0
+      web-html: 4.1.0
+      web-pointerevents: 1.0.0
+      web-proletarian: 1.0.0
+      web-promise: 3.1.0
+      web-resize-observer: 2.0.0
+      web-router: 1.0.0
+      web-socket: 4.0.0
+      web-storage: 5.0.0
+      web-streams: 3.0.0
+      web-touchevents: 4.0.0
+      web-uievents: 4.0.0
+      web-url: 2.0.0
+      web-workers: 1.1.0
+      web-xhr: 5.0.0
+      which: 2.0.0
+      yoga-fetch: 1.0.1
+      yoga-json: 4.0.1
+      yoga-om: 0.1.0
+      yoga-postgres: 6.0.0
+      yoga-tree: 1.0.0
   extra_packages: {}
 packages:
   aff:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-aff.git
-    rev: 2d44d9f9d0d6a416a4103fba2fb39e5160f80e36
+    type: registry
+    version: 7.1.0
+    integrity: sha256-7hOC6uQO9XBAI5FD8F33ChLjFAiZVfd4BJMqlMh7TNU=
     dependencies:
+      - arrays
+      - bifunctors
+      - control
       - datetime
       - effect
+      - either
       - exceptions
+      - foldable-traversable
       - functions
+      - maybe
+      - newtype
       - parallel
+      - prelude
+      - refs
+      - tailrec
       - transformers
       - unsafe-coerce
   affjax:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-affjax.git
-    rev: 87a8ffce89a476c1425370eb4b2b7e15408e0d1c
+    type: registry
+    version: 13.0.0
+    integrity: sha256-blYfaoW4FYIrIdvmT4sB7nN7BathFaEfZuiVLPmHJOo=
     dependencies:
       - aff
       - argonaut-core
@@ -3564,9 +574,9 @@ packages:
       - unsafe-coerce
       - web-xhr
   affjax-node:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-affjax-node.git
-    rev: e34901bab82cc741dd62511b4185b75dd7f315d3
+    type: registry
+    version: 1.0.0
+    integrity: sha256-NcmRTXJxJzgHuKoLh+36yA8UejkfouYcX3uevT+Trjc=
     dependencies:
       - aff
       - affjax
@@ -3574,9 +584,9 @@ packages:
       - maybe
       - prelude
   argonaut-core:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-argonaut-core.git
-    rev: 68da81dd80ec36d3b013eff46dc067a972c22e5d
+    type: registry
+    version: 7.0.0
+    integrity: sha256-RC82GfAjItydxrO24cdX373KHVZiLqybu19b5X8u7B4=
     dependencies:
       - arrays
       - control
@@ -3590,14 +600,14 @@ packages:
       - strings
       - tailrec
   arraybuffer-types:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-arraybuffer-types.git
-    rev: 9b0b7a0f9ee034e039f3d3a2a9c3f74eb7c9264a
+    type: registry
+    version: 3.0.2
+    integrity: sha256-mQKokysYVkooS4uXbO+yovmV/s8b138Ws3zQvOwIHRA=
     dependencies: []
   arrays:
-    type: git
-    url: https://github.com/purescript/purescript-arrays.git
-    rev: d20bae2f76db6cf29b7b75e26e82b8a54c32295e
+    type: registry
+    version: 7.1.0
+    integrity: sha256-Rvb3AVLal0ZLpmpABgOPIUeYHa4M+c5GwcUP5rQ2trA=
     dependencies:
       - bifunctors
       - control
@@ -3606,15 +616,16 @@ packages:
       - nonempty
       - partial
       - prelude
+      - safe-coerce
       - st
       - tailrec
       - tuples
       - unfoldable
       - unsafe-coerce
   avar:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-avar.git
-    rev: d00f5784d9cc8f079babd62740f5c52b87e5caa5
+    type: registry
+    version: 5.0.0
+    integrity: sha256-e7hf0x4hEpcygXP0LtvfvAQ49Bbj2aWtZT3gqM///0A=
     dependencies:
       - aff
       - effect
@@ -3623,9 +634,9 @@ packages:
       - functions
       - maybe
   bifunctors:
-    type: git
-    url: https://github.com/purescript/purescript-bifunctors.git
-    rev: 16ba2fb6dd7f05528ebd9e2f9ca3a068b325e5b3
+    type: registry
+    version: 6.0.0
+    integrity: sha256-/gZwC9YhNxZNQpnHa5BIYerCGM2jeX9ukZiEvYxm5Nw=
     dependencies:
       - const
       - either
@@ -3633,9 +644,9 @@ packages:
       - prelude
       - tuples
   catenable-lists:
-    type: git
-    url: https://github.com/purescript/purescript-catenable-lists.git
-    rev: 09abe1f4888bc00841ad2b59e56a9e7ce7ebd4ab
+    type: registry
+    version: 7.0.0
+    integrity: sha256-76vYENhwF4BWTBsjeLuErCH2jqVT4M3R1HX+4RwSftA=
     dependencies:
       - control
       - foldable-traversable
@@ -3645,24 +656,24 @@ packages:
       - tuples
       - unfoldable
   console:
-    type: git
-    url: https://github.com/purescript/purescript-console.git
-    rev: 3b83d7b792d03872afeea5e62b4f686ab0f09842
+    type: registry
+    version: 6.0.0
+    integrity: sha256-gJpJ53fCDAL8BiCiJXH0HNAJ9K3gJtLo8GDaCK6hA5U=
     dependencies:
       - effect
       - prelude
   const:
-    type: git
-    url: https://github.com/purescript/purescript-const.git
-    rev: ab9570cf2b6e67f7e441178211db1231cfd75c37
+    type: registry
+    version: 6.0.0
+    integrity: sha256-tNrxDW8D8H4jdHE2HiPzpLy08zkzJMmGHdRqt5BQuTc=
     dependencies:
       - invariant
       - newtype
       - prelude
   contravariant:
-    type: git
-    url: https://github.com/purescript/purescript-contravariant.git
-    rev: 9ad3e105b8855bcc25f4e0893c784789d05a58de
+    type: registry
+    version: 6.0.0
+    integrity: sha256-TP+ooAp3vvmdjfQsQJSichF5B4BPDHp3wAJoWchip6c=
     dependencies:
       - const
       - either
@@ -3670,16 +681,16 @@ packages:
       - prelude
       - tuples
   control:
-    type: git
-    url: https://github.com/purescript/purescript-control.git
-    rev: a6033808790879a17b2729e73747a9ed3fb2264e
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sH7Pg9E96JCPF9PIA6oQ8+BjTyO/BH1ZuE/bOcyj4Jk=
     dependencies:
       - newtype
       - prelude
   datetime:
-    type: git
-    url: https://github.com/purescript/purescript-datetime.git
-    rev: a6a0cf1b0324964ad1854bc3377ed8766ba90e6f
+    type: registry
+    version: 6.1.0
+    integrity: sha256-g/5X5BBegQWLpI9IWD+sY6mcaYpzzlW5lz5NBzaMtyI=
     dependencies:
       - bifunctors
       - control
@@ -3698,9 +709,9 @@ packages:
       - prelude
       - tuples
   distributive:
-    type: git
-    url: https://github.com/purescript/purescript-distributive.git
-    rev: 6005e513642e855ebf6f884d24a35c2803ca252a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-HTDdmEnzigMl+02SJB88j+gAXDx9VKsbvR4MJGDPbOQ=
     dependencies:
       - identity
       - newtype
@@ -3708,24 +719,24 @@ packages:
       - tuples
       - type-equality
   effect:
-    type: git
-    url: https://github.com/purescript/purescript-effect.git
-    rev: a192ddb923027d426d6ea3d8deb030c9aa7c7dda
+    type: registry
+    version: 4.0.0
+    integrity: sha256-eBtZu+HZcMa5HilvI6kaDyVX3ji8p0W9MGKy2K4T6+M=
     dependencies:
       - prelude
   either:
-    type: git
-    url: https://github.com/purescript/purescript-either.git
-    rev: af655a04ed2fd694b6688af39ee20d7907ad0763
+    type: registry
+    version: 6.1.0
+    integrity: sha256-6hgTPisnMWVwQivOu2PKYcH8uqjEOOqDyaDQVUchTpY=
     dependencies:
       - control
       - invariant
       - maybe
       - prelude
   enums:
-    type: git
-    url: https://github.com/purescript/purescript-enums.git
-    rev: bae47961d401f9acf88da38f32e87403e5f0cf2f
+    type: registry
+    version: 6.0.1
+    integrity: sha256-HWaD73JFLorc4A6trKIRUeDMdzE+GpkJaEOM1nTNkC8=
     dependencies:
       - control
       - either
@@ -3738,24 +749,24 @@ packages:
       - tuples
       - unfoldable
   exceptions:
-    type: git
-    url: https://github.com/purescript/purescript-exceptions.git
-    rev: afab3c07c820bb49b6c5be50049db46a964a6161
+    type: registry
+    version: 6.0.0
+    integrity: sha256-y/xTAEIZIARCE+50/u1di0ncebJ+CIwNOLswyOWzMTw=
     dependencies:
       - effect
       - either
       - maybe
       - prelude
   exists:
-    type: git
-    url: https://github.com/purescript/purescript-exists.git
-    rev: f765b4ace7869c27b9c05949e18c843881f9173b
+    type: registry
+    version: 6.0.0
+    integrity: sha256-A0JQHpTfo1dNOj9U5/Fd3xndlRSE0g2IQWOGor2yXn8=
     dependencies:
       - unsafe-coerce
   foldable-traversable:
-    type: git
-    url: https://github.com/purescript/purescript-foldable-traversable.git
-    rev: b3926f870532d287ea59e2d5cd3873b81ef2a93a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-fLeqRYM4jUrZD5H4WqcwUgzU7XfYkzO4zhgtNc3jcWM=
     dependencies:
       - bifunctors
       - const
@@ -3769,9 +780,9 @@ packages:
       - prelude
       - tuples
   foreign:
-    type: git
-    url: https://github.com/purescript/purescript-foreign.git
-    rev: 2dd222d1ec7363fa0a0a7adb0d8eaf81bb7006dd
+    type: registry
+    version: 7.0.0
+    integrity: sha256-1ORiqoS3HW+qfwSZAppHPWy4/6AQysxZ2t29jcdUMNA=
     dependencies:
       - either
       - functions
@@ -3783,9 +794,9 @@ packages:
       - strings
       - transformers
   foreign-object:
-    type: git
-    url: https://github.com/purescript/purescript-foreign-object.git
-    rev: 28a635827a9a6c251df73f68874070d51fe9f756
+    type: registry
+    version: 4.1.0
+    integrity: sha256-q24okj6mT+yGHYQ+ei/pYPj5ih6sTbu7eDv/WU56JVo=
     dependencies:
       - arrays
       - foldable-traversable
@@ -3800,9 +811,9 @@ packages:
       - typelevel-prelude
       - unfoldable
   form-urlencoded:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-form-urlencoded.git
-    rev: e0e3eebc76f62f2594a0e823e8d6241ca00b2459
+    type: registry
+    version: 7.0.0
+    integrity: sha256-WUzk8DTjrbPVHKZ5w7XpPBO6ci6xFhvYguHp6RvX+18=
     dependencies:
       - foldable-traversable
       - js-uri
@@ -3812,9 +823,9 @@ packages:
       - strings
       - tuples
   free:
-    type: git
-    url: https://github.com/purescript/purescript-free.git
-    rev: e2d8fa8023a864363857834e11393483bced5e38
+    type: registry
+    version: 7.0.0
+    integrity: sha256-72auTIZAG6fhz4F94rxyDwgfnHwp+/89rujZpZWrV0w=
     dependencies:
       - catenable-lists
       - control
@@ -3831,15 +842,15 @@ packages:
       - tuples
       - unsafe-coerce
   functions:
-    type: git
-    url: https://github.com/purescript/purescript-functions.git
-    rev: f626f20580483977c5b27a01aac6471e28aff367
+    type: registry
+    version: 6.0.0
+    integrity: sha256-adMyJNEnhGde2unHHAP79gPtlNjNqzgLB8arEOn9hLI=
     dependencies:
       - prelude
   functors:
-    type: git
-    url: https://github.com/purescript/purescript-functors.git
-    rev: 022ffd7a2a7ec12080314f3d217b400674a247b4
+    type: registry
+    version: 5.0.0
+    integrity: sha256-zfPWWYisbD84MqwpJSZFlvM6v86McM68ob8p9s27ywU=
     dependencies:
       - bifunctors
       - const
@@ -3855,9 +866,9 @@ packages:
       - tuples
       - unsafe-coerce
   gen:
-    type: git
-    url: https://github.com/purescript/purescript-gen.git
-    rev: 9fbcc2a1261c32e30d79c5418edef4d96fe76931
+    type: registry
+    version: 4.0.0
+    integrity: sha256-f7yzAXWwr+xnaqEOcvyO3ezKdoes8+WXWdXIHDBCAPI=
     dependencies:
       - either
       - foldable-traversable
@@ -3870,41 +881,41 @@ packages:
       - tuples
       - unfoldable
   http-methods:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-http-methods.git
-    rev: 99b48d54b978e4e6438d850015d59e57ac64824e
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Orr7rbDGcp7qoqmUMXPRMjBx+C4jqOQcFe9+gE3nMgU=
     dependencies:
       - either
       - prelude
       - strings
   identity:
-    type: git
-    url: https://github.com/purescript/purescript-identity.git
-    rev: ef6768f8a52ab0bc943a85f5761ba07c257f639f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-4wY0XZbAksjY6UAg99WkuKyJlQlWAfTi2ssadH0wVMY=
     dependencies:
       - control
       - invariant
       - newtype
       - prelude
   integers:
-    type: git
-    url: https://github.com/purescript/purescript-integers.git
-    rev: 54d712b25c594833083d15dc9ff2418eb9c52822
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sf+sK26R1hzwl3NhXR7WAu9zCDjQnfoXwcyGoseX158=
     dependencies:
       - maybe
       - numbers
       - prelude
   invariant:
-    type: git
-    url: https://github.com/purescript/purescript-invariant.git
-    rev: 1d2a196d51e90623adb88496c2cfd759c6736894
+    type: registry
+    version: 6.0.0
+    integrity: sha256-RGWWyYrz0Hs1KjPDA+87Kia67ZFBhfJ5lMGOMCEFoLo=
     dependencies:
       - control
       - prelude
   js-date:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-js-date.git
-    rev: 1ea020316946cc4b87195bca9c54d0c16abaa490
+    type: registry
+    version: 8.0.0
+    integrity: sha256-6TVF4DWg5JL+jRAsoMssYw8rgOVALMUHT1CuNZt8NRo=
     dependencies:
       - datetime
       - effect
@@ -3913,31 +924,31 @@ packages:
       - integers
       - now
   js-timers:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-js-timers.git
-    rev: 7cb728b3e6dc29f355143617e6e9ac770ecd9273
+    type: registry
+    version: 6.1.0
+    integrity: sha256-znHWLSSOYw15P5DTcsAdal2lf7nGA2yayLdOZ2t5r7o=
     dependencies:
       - effect
   js-uri:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-js-uri.git
-    rev: ac659740288de7c5e64166dbfda9d4985c5044b7
+    type: registry
+    version: 3.1.0
+    integrity: sha256-3p0ynHveCJmC2CXze+eMBdW/2l5e953Q8XMAKz+jxUo=
     dependencies:
       - functions
       - maybe
   lazy:
-    type: git
-    url: https://github.com/purescript/purescript-lazy.git
-    rev: 48347841226b27af5205a1a8ec71e27a93ce86fd
+    type: registry
+    version: 6.0.0
+    integrity: sha256-lMsfFOnlqfe4KzRRiW8ot5ge6HtcU3Eyh2XkXcP5IgU=
     dependencies:
       - control
       - foldable-traversable
       - invariant
       - prelude
   lcg:
-    type: git
-    url: https://github.com/purescript/purescript-lcg.git
-    rev: 67c6c6483a563a59ae036d9dca0f1be2835326a5
+    type: registry
+    version: 4.0.0
+    integrity: sha256-h7ME5cthLfbgJOJdsZcSfFpwXsx4rf8YmhebU+3iSYg=
     dependencies:
       - effect
       - integers
@@ -3946,9 +957,9 @@ packages:
       - prelude
       - random
   lists:
-    type: git
-    url: https://github.com/purescript/purescript-lists.git
-    rev: b113451e5b41cad87d669a3165f955c71cd863e2
+    type: registry
+    version: 7.0.0
+    integrity: sha256-EKF15qYqucuXP2lT/xPxhqy58f0FFT6KHdIB/yBOayI=
     dependencies:
       - bifunctors
       - control
@@ -3963,32 +974,32 @@ packages:
       - tuples
       - unfoldable
   maybe:
-    type: git
-    url: https://github.com/purescript/purescript-maybe.git
-    rev: c6f98ac1088766287106c5d9c8e30e7648d36786
+    type: registry
+    version: 6.0.0
+    integrity: sha256-5cCIb0wPwbat2PRkQhUeZO0jcAmf8jCt2qE0wbC3v2Q=
     dependencies:
       - control
       - invariant
       - newtype
       - prelude
   media-types:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-media-types.git
-    rev: af853de226592f319a953637069a943dd261cba3
+    type: registry
+    version: 6.0.0
+    integrity: sha256-n/4FoGBasbVSYscGVRSyBunQ6CZbL3jsYL+Lp01mc9k=
     dependencies:
       - newtype
       - prelude
   newtype:
-    type: git
-    url: https://github.com/purescript/purescript-newtype.git
-    rev: 29d8e6dd77aec2c975c948364ec3faf26e14ee7b
+    type: registry
+    version: 5.0.0
+    integrity: sha256-gdrQu8oGe9eZE6L3wOI8ql/igOg+zEGB5ITh2g+uttw=
     dependencies:
       - prelude
       - safe-coerce
   node-buffer:
-    type: git
-    url: https://github.com/purescript-node/purescript-node-buffer.git
-    rev: 7be7bd082b7d3e15de2ed5a626d43af746bdb35e
+    type: registry
+    version: 8.0.0
+    integrity: sha256-RwOTB8yTS4Jjqc55JqxRcVaMXP+cYJ5aww0XH1Z/I8A=
     dependencies:
       - arraybuffer-types
       - effect
@@ -3996,9 +1007,9 @@ packages:
       - st
       - unsafe-coerce
   node-fs:
-    type: git
-    url: https://github.com/purescript-node/purescript-node-fs.git
-    rev: 7dfc7cad919cec097d40c8fce611338715969f75
+    type: registry
+    version: 8.1.1
+    integrity: sha256-mXPDpXgWviWhkrYSQx2ERu4R8Z0CLIEikQDLzGZ7iuY=
     dependencies:
       - datetime
       - effect
@@ -4018,24 +1029,24 @@ packages:
       - strings
       - unsafe-coerce
   node-fs-aff:
-    type: git
-    url: https://github.com/purescript-node/purescript-node-fs-aff.git
-    rev: a6acd335f5b3e4b8c6df9bb0784f0e06eef0075e
+    type: registry
+    version: 9.1.0
+    integrity: sha256-YDOvcpw4Ep0vOXvPxzvpWfangki5x4lueHK380J0tYs=
     dependencies:
       - aff
       - either
       - node-fs
       - node-path
   node-path:
-    type: git
-    url: https://github.com/purescript-node/purescript-node-path.git
-    rev: d5f08cfde829b831408c4c6587cec83f2cd6a58e
+    type: registry
+    version: 5.0.0
+    integrity: sha256-pd82nQ+2l5UThzaxPdKttgDt7xlsgIDLpPG0yxDEdyE=
     dependencies:
       - effect
   node-streams:
-    type: git
-    url: https://github.com/purescript-node/purescript-node-streams.git
-    rev: 8395652f9f347101fe042f58726edc592ae5086c
+    type: registry
+    version: 7.0.0
+    integrity: sha256-EGCA+hp6chlxDlQ8UG3RIaIIL1R0OckKnqP+KPAX1y4=
     dependencies:
       - effect
       - either
@@ -4044,9 +1055,9 @@ packages:
       - nullable
       - prelude
   nonempty:
-    type: git
-    url: https://github.com/purescript/purescript-nonempty.git
-    rev: 28150ecc7419238b187abd609a92a645273348bb
+    type: registry
+    version: 7.0.0
+    integrity: sha256-54ablJZUHGvvlTJzi3oXyPCuvY6zsrWJuH/dMJ/MFLs=
     dependencies:
       - control
       - foldable-traversable
@@ -4055,31 +1066,31 @@ packages:
       - tuples
       - unfoldable
   now:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-now.git
-    rev: b5ffed2381e5fefc063f484e607e8499e79eaf32
+    type: registry
+    version: 6.0.0
+    integrity: sha256-xZ7x37ZMREfs6GCDw/h+FaKHV/3sPWmtqBZRGTxybQY=
     dependencies:
       - datetime
       - effect
   nullable:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-nullable.git
-    rev: 3202744c6c65e8d1fbba7f4256a1c482078e7fb5
+    type: registry
+    version: 6.0.0
+    integrity: sha256-yiGBVl3AD+Guy4kNWWeN+zl1gCiJK+oeIFtZtPCw4+o=
     dependencies:
       - effect
       - functions
       - maybe
   numbers:
-    type: git
-    url: https://github.com/purescript/purescript-numbers.git
-    rev: 2a53528f18f9415334bae28e7bb3cf3be86342c2
+    type: registry
+    version: 9.0.0
+    integrity: sha256-fDKXExFxMRFgy+v+kbjVbGBIOOQkWGnmm0vtnE3zWRE=
     dependencies:
       - functions
       - maybe
   ordered-collections:
-    type: git
-    url: https://github.com/purescript/purescript-ordered-collections.git
-    rev: 9826b7632d0d0a691173bde308a634195f42a419
+    type: registry
+    version: 3.0.0
+    integrity: sha256-R9WddNBRPkY37gw8XkDCLX2vJ5eI9qdaWDdCp61r2+M=
     dependencies:
       - arrays
       - foldable-traversable
@@ -4093,16 +1104,16 @@ packages:
       - tuples
       - unfoldable
   orders:
-    type: git
-    url: https://github.com/purescript/purescript-orders.git
-    rev: f86db621ec5eef1274145f8b1fd8ebbfe0ed4a2c
+    type: registry
+    version: 6.0.0
+    integrity: sha256-nBA0g3/ai0euH8q9pSbGqk53W2q6agm/dECZTHcoink=
     dependencies:
       - newtype
       - prelude
   parallel:
-    type: git
-    url: https://github.com/purescript/purescript-parallel.git
-    rev: 85290dca837771ac4870071008c933d315ef678f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-VJbkGD0rAKX+NUEeBJbYJ78bEKaZbgow+QwQEfPB6ko=
     dependencies:
       - control
       - effect
@@ -4116,19 +1127,19 @@ packages:
       - refs
       - transformers
   partial:
-    type: git
-    url: https://github.com/purescript/purescript-partial.git
-    rev: 0fa0646f5ea1ec5f0c46dcbd770c705a6c9ad3ec
+    type: registry
+    version: 4.0.0
+    integrity: sha256-fwXerld6Xw1VkReh8yeQsdtLVrjfGiVuC5bA1Wyo/J4=
     dependencies: []
   prelude:
-    type: git
-    url: https://github.com/purescript/purescript-prelude.git
-    rev: 32787f4399c92459c41602131a5858559eb868c5
+    type: registry
+    version: 6.0.1
+    integrity: sha256-o8p6SLYmVPqzXZhQFd2hGAWEwBoXl1swxLG/scpJ0V0=
     dependencies: []
   profunctor:
-    type: git
-    url: https://github.com/purescript/purescript-profunctor.git
-    rev: 0a966a14e7b0c827d44657dc1710cdc712d2e034
+    type: registry
+    version: 6.0.0
+    integrity: sha256-99NzxFgTr4CGlCSRYG1kShL+JhYbihhHtbOk1/0R5zI=
     dependencies:
       - control
       - distributive
@@ -4139,9 +1150,9 @@ packages:
       - prelude
       - tuples
   quickcheck:
-    type: git
-    url: https://github.com/purescript/purescript-quickcheck.git
-    rev: bf5029f97e6c0d7552d3a08d2ab793a19e2c5e3d
+    type: registry
+    version: 8.0.1
+    integrity: sha256-ZvpccKQCvgslTXZCNmpYW4bUsFzhZd/kQUr2WmxFTGY=
     dependencies:
       - arrays
       - console
@@ -4171,46 +1182,46 @@ packages:
       - tuples
       - unfoldable
   random:
-    type: git
-    url: https://github.com/purescript/purescript-random.git
-    rev: 9540bc965a9596da02fefd9949418bb19c92533a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-CJ611a35MPCE7XQMp0rdC6MCn76znlhisiCRgboAG+Q=
     dependencies:
       - effect
       - integers
   record:
-    type: git
-    url: https://github.com/purescript/purescript-record.git
-    rev: c89cd1ada6b636692571fc374196b1c39c4c9f70
+    type: registry
+    version: 4.0.0
+    integrity: sha256-Za5U85bTRJEfGK5Sk4hM41oXy84YQI0I8TL3WUn1Qzg=
     dependencies:
       - functions
       - prelude
       - unsafe-coerce
   refs:
-    type: git
-    url: https://github.com/purescript/purescript-refs.git
-    rev: f8e6216da4cb9309fde1f20cd6f69ac3a3b7f9e8
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Vgwne7jIbD3ZMoLNNETLT8Litw6lIYo3MfYNdtYWj9s=
     dependencies:
       - effect
       - prelude
   safe-coerce:
-    type: git
-    url: https://github.com/purescript/purescript-safe-coerce.git
-    rev: 7fa799ae80a38b8d948efcb52608e58e198b3da7
+    type: registry
+    version: 2.0.0
+    integrity: sha256-a1ibQkiUcbODbLE/WAq7Ttbbh9ex+x33VCQ7GngKudU=
     dependencies:
       - unsafe-coerce
   st:
-    type: git
-    url: https://github.com/purescript/purescript-st.git
-    rev: 2cc7ae1c3318a303378c4a9f3fa0f10ee7cc3589
+    type: registry
+    version: 6.2.0
+    integrity: sha256-z9X0WsOUlPwNx9GlCC+YccCyz8MejC8Wb0C4+9fiBRY=
     dependencies:
       - partial
       - prelude
       - tailrec
       - unsafe-coerce
   strings:
-    type: git
-    url: https://github.com/purescript/purescript-strings.git
-    rev: 4bc6954448d056f8aa7a659695a6ad60ad4fdf19
+    type: registry
+    version: 6.0.1
+    integrity: sha256-WssD3DbX4OPzxSdjvRMX0yvc9+pS7n5gyPv5I2Trb7k=
     dependencies:
       - arrays
       - control
@@ -4229,9 +1240,9 @@ packages:
       - unfoldable
       - unsafe-coerce
   tailrec:
-    type: git
-    url: https://github.com/purescript/purescript-tailrec.git
-    rev: 5e2104aa734b31a17074cc805bf087d72b65afd1
+    type: registry
+    version: 6.1.0
+    integrity: sha256-Xx19ECVDRrDWpz9D2GxQHHV89vd61dnXxQm0IcYQHGk=
     dependencies:
       - bifunctors
       - effect
@@ -4242,9 +1253,9 @@ packages:
       - prelude
       - refs
   test-unit:
-    type: git
-    url: https://github.com/bodil/purescript-test-unit.git
-    rev: 3112d7ebe06d467238058a6384dc75ffd960d335
+    type: registry
+    version: 17.0.0
+    integrity: sha256-aITJ2KngFFjASmG0JjnjybaKWl9dn7Hf2B3Wk4engNs=
     dependencies:
       - aff
       - avar
@@ -4257,9 +1268,9 @@ packages:
       - quickcheck
       - strings
   transformers:
-    type: git
-    url: https://github.com/purescript/purescript-transformers.git
-    rev: be72ab52357d9a665cbf93d73ba1c07c4b0957ee
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Pzw40HjthX77tdPAYzjx43LK3X5Bb7ZspYAp27wksFA=
     dependencies:
       - control
       - distributive
@@ -4276,29 +1287,29 @@ packages:
       - tuples
       - unfoldable
   tuples:
-    type: git
-    url: https://github.com/purescript/purescript-tuples.git
-    rev: 4f52da2729b448c8564369378f1232d8d2dc1d8b
+    type: registry
+    version: 7.0.0
+    integrity: sha256-1rXgTomes9105BjgXqIw0FL6Fz1lqqUTLWOumhWec1M=
     dependencies:
       - control
       - invariant
       - prelude
   type-equality:
-    type: git
-    url: https://github.com/purescript/purescript-type-equality.git
-    rev: 0525b7d39e0fbd81b4209518139fb8ab02695774
+    type: registry
+    version: 4.0.1
+    integrity: sha256-Hs9D6Y71zFi/b+qu5NSbuadUQXe5iv5iWx0226vOHUw=
     dependencies: []
   typelevel-prelude:
-    type: git
-    url: https://github.com/purescript/purescript-typelevel-prelude.git
-    rev: dca2fe3c8cfd5527d4fe70c4bedfda30148405bf
+    type: registry
+    version: 7.0.0
+    integrity: sha256-uFF2ph+vHcQpfPuPf2a3ukJDFmLhApmkpTMviHIWgJM=
     dependencies:
       - prelude
       - type-equality
   unfoldable:
-    type: git
-    url: https://github.com/purescript/purescript-unfoldable.git
-    rev: 493dfe04ed590e20d8f69079df2f58486882748d
+    type: registry
+    version: 6.0.0
+    integrity: sha256-JtikvJdktRap7vr/K4ITlxUX1QexpnqBq0G/InLr6eg=
     dependencies:
       - foldable-traversable
       - maybe
@@ -4306,53 +1317,53 @@ packages:
       - prelude
       - tuples
   unsafe-coerce:
-    type: git
-    url: https://github.com/purescript/purescript-unsafe-coerce.git
-    rev: ab956f82e66e633f647fb3098e8ddd3ec58d689f
+    type: registry
+    version: 6.0.0
+    integrity: sha256-IqIYW4Vkevn8sI+6aUwRGvd87tVL36BBeOr0cGAE7t0=
     dependencies: []
   web-dom:
-    type: git
-    url: https://github.com/purescript-web/purescript-web-dom.git
-    rev: 568a1ee158b29e6e739e7a9aaed3e35ca4c4305a
+    type: registry
+    version: 6.0.0
+    integrity: sha256-1kSKWFDI4LupdmpjK01b1MMxDFW7jvatEgPgVmCmSBQ=
     dependencies:
       - web-events
   web-events:
-    type: git
-    url: https://github.com/purescript-web/purescript-web-events.git
-    rev: 2124356117be7b764a2f3948032255ac4dab7051
+    type: registry
+    version: 4.0.0
+    integrity: sha256-YDt8b6u1tzGtnWyNRodne57iO8FNSGPaTCVzBUyUn4k=
     dependencies:
       - datetime
       - enums
       - foreign
       - nullable
   web-file:
-    type: git
-    url: https://github.com/purescript-web/purescript-web-file.git
-    rev: 023786ae62bbb8bf58156dd7f02011fa38221ef1
+    type: registry
+    version: 4.0.0
+    integrity: sha256-1h5jPBkvjY71jLEdwVadXCx86/2inNoMBO//Rd3eCSU=
     dependencies:
       - foreign
       - media-types
       - web-dom
   web-html:
-    type: git
-    url: https://github.com/purescript-web/purescript-web-html.git
-    rev: be189cf91b9a19cf493637423522e2fe4a0088cc
+    type: registry
+    version: 4.1.0
+    integrity: sha256-ByqS/h1/yG+hjCOnOQp7L1QpIWzQENNKB1kaHtpEhlE=
     dependencies:
       - js-date
       - web-dom
       - web-file
       - web-storage
   web-storage:
-    type: git
-    url: https://github.com/purescript-web/purescript-web-storage.git
-    rev: 6b74461e136755db70c271dc898d51776363d7e2
+    type: registry
+    version: 5.0.0
+    integrity: sha256-q+6lxcnfWxus0/nDeFVtF1V+tLehZvvXQ0cduYPLksY=
     dependencies:
       - nullable
       - web-events
   web-xhr:
-    type: git
-    url: https://github.com/purescript-web/purescript-web-xhr.git
-    rev: 476122fe3ad19031aeb69186209b480e2fc9ef25
+    type: registry
+    version: 5.0.0
+    integrity: sha256-/++2tUdplQH6BszpPmV6tIeMx+tYa1/hNLvCJh3U29U=
     dependencies:
       - arraybuffer-types
       - datetime

--- a/exercises/chapter9/spago.yaml
+++ b/exercises/chapter9/spago.yaml
@@ -1,0 +1,27 @@
+package:
+  dependencies:
+    - aff
+    - affjax
+    - affjax-node
+    - arrays
+    - bifunctors
+    - console
+    - effect
+    - either
+    - exceptions
+    - foldable-traversable
+    - functions
+    - maybe
+    - node-buffer
+    - node-fs-aff
+    - node-path
+    - ordered-collections
+    - parallel
+    - prelude
+    - strings
+    - test-unit
+  name: my-project
+workspace:
+  extraPackages: {}
+  packageSet:
+    url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json

--- a/exercises/chapter9/spago.yaml
+++ b/exercises/chapter9/spago.yaml
@@ -24,4 +24,4 @@ package:
 workspace:
   extraPackages: {}
   packageSet:
-    url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.2-20220615/packages.json
+    registry: 10.0.0


### PR DESCRIPTION
Allow people to user either spago version by adding auto-generated spago-next configs  (#458)